### PR TITLE
Fix MovementCost for all sand terrain components in Kesmai

### DIFF
--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Kesmai" version="0.63.0.0">
+<segment name="Kesmai" version="0.64.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -4114,11 +4114,13 @@
       <tile x="11" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="12" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="13" y="5">
@@ -4753,26 +4755,31 @@
       <tile x="99" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="100" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="101" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="102" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="103" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="104" y="5">
@@ -4806,11 +4813,13 @@
       <tile x="108" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="109" y="5">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="110" y="5">
@@ -5160,11 +5169,13 @@
       <tile x="12" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="13" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="6">
@@ -5457,6 +5468,7 @@
       <tile x="48" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="49" y="6">
@@ -5706,11 +5718,13 @@
       <tile x="86" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="87" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="88" y="6">
@@ -5834,26 +5848,31 @@
       <tile x="104" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="105" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="106" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="107" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="108" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="109" y="6">
@@ -5868,16 +5887,19 @@
       <tile x="110" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="111" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="112" y="6">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="113" y="6">
@@ -6178,6 +6200,7 @@
       <tile x="13" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="7">
@@ -6488,11 +6511,13 @@
       <tile x="49" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="50" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="51" y="7">
@@ -6751,11 +6776,13 @@
       <tile x="86" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="87" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="88" y="7">
@@ -6958,16 +6985,19 @@
       <tile x="113" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="114" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="115" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="116" y="7">
@@ -7083,21 +7113,25 @@
       <tile x="131" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="132" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="133" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="134" y="7">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="135" y="7">
@@ -7530,21 +7564,25 @@
       <tile x="50" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="51" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="52" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="53" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="54" y="8">
@@ -7670,6 +7708,7 @@
       <tile x="74" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="75" y="8">
@@ -7754,6 +7793,7 @@
       <tile x="84" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="85" y="8">
@@ -7764,21 +7804,25 @@
       <tile x="86" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="87" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="88" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="89" y="8">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="90" y="8">
@@ -8595,11 +8639,13 @@
       <tile x="52" y="9">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="53" y="9">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="54" y="9">
@@ -8727,6 +8773,7 @@
       <tile x="74" y="9">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="75" y="9">
@@ -9032,11 +9079,13 @@
       <tile x="114" y="9">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="115" y="9">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="116" y="9">
@@ -9208,6 +9257,7 @@
       <tile x="140" y="9">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="141" y="9">
@@ -9336,6 +9386,7 @@
       <tile x="15" y="10">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="16" y="10">
@@ -9602,16 +9653,19 @@
       <tile x="53" y="10">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="54" y="10">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="55" y="10">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="56" y="10">
@@ -10052,6 +10106,7 @@
       <tile x="116" y="10">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="117" y="10">
@@ -10343,6 +10398,7 @@
       <tile x="15" y="11">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="16" y="11">
@@ -10721,11 +10777,13 @@
       <tile x="54" y="11">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="55" y="11">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="56" y="11">
@@ -11211,11 +11269,13 @@
       <tile x="115" y="11">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="116" y="11">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="117" y="11">
@@ -12245,6 +12305,7 @@
       <tile x="114" y="12">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="115" y="12">
@@ -12991,6 +13052,7 @@
       <tile x="67" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="68" y="13">
@@ -13334,6 +13396,7 @@
       <tile x="116" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="117" y="13">
@@ -13408,6 +13471,7 @@
       <tile x="128" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -13417,6 +13481,7 @@
       <tile x="129" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -13426,6 +13491,7 @@
       <tile x="130" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -13435,6 +13501,7 @@
       <tile x="131" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -13444,6 +13511,7 @@
       <tile x="132" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -13453,6 +13521,7 @@
       <tile x="133" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -13462,6 +13531,7 @@
       <tile x="134" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -13471,6 +13541,7 @@
       <tile x="135" y="13">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -14023,16 +14094,19 @@
       <tile x="66" y="14">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="67" y="14">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="68" y="14">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="69" y="14">
@@ -14474,6 +14548,7 @@
       <tile x="134" y="14">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -14483,6 +14558,7 @@
       <tile x="135" y="14">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -14492,6 +14568,7 @@
       <tile x="136" y="14">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -14643,6 +14720,7 @@
       <tile x="15" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="16" y="15">
@@ -15020,41 +15098,49 @@
       <tile x="60" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="61" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="62" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="63" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="64" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="65" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="66" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="67" y="15">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="68" y="15">
@@ -15629,11 +15715,13 @@
       <tile x="13" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="15" y="16">
@@ -15974,31 +16062,37 @@
       <tile x="59" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="60" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="61" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="62" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="63" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="64" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="65" y="16">
@@ -16056,6 +16150,7 @@
       <tile x="73" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -16065,6 +16160,7 @@
       <tile x="74" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -16081,6 +16177,7 @@
       <tile x="76" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -16090,6 +16187,7 @@
       <tile x="77" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -16343,6 +16441,7 @@
       <tile x="117" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="118" y="16">
@@ -16386,6 +16485,7 @@
       <tile x="124" y="16">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -16584,11 +16684,13 @@
       <tile x="13" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="15" y="17">
@@ -17060,6 +17162,7 @@
       <tile x="74" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -17069,6 +17172,7 @@
       <tile x="75" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -17078,6 +17182,7 @@
       <tile x="76" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -17087,6 +17192,7 @@
       <tile x="77" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -17367,6 +17473,7 @@
       <tile x="118" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="119" y="17">
@@ -17410,6 +17517,7 @@
       <tile x="125" y="17">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -17603,6 +17711,7 @@
       <tile x="13" y="18">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="18">
@@ -18296,11 +18405,13 @@
       <tile x="116" y="18">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="117" y="18">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="118" y="18">
@@ -19356,6 +19467,7 @@
       <tile x="116" y="19">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="117" y="19">
@@ -19459,6 +19571,7 @@
       <tile x="133" y="19">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -19468,6 +19581,7 @@
       <tile x="134" y="19">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -19477,6 +19591,7 @@
       <tile x="135" y="19">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -20177,16 +20292,19 @@
       <tile x="85" y="20">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="86" y="20">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="87" y="20">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="88" y="20">
@@ -20542,6 +20660,7 @@
       <tile x="134" y="20">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -20551,6 +20670,7 @@
       <tile x="135" y="20">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -20687,11 +20807,13 @@
       <tile x="10" y="21">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="11" y="21">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="12" y="21">
@@ -20718,6 +20840,7 @@
       <tile x="15" y="21">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="16" y="21">
@@ -21309,6 +21432,7 @@
       <tile x="88" y="21">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="89" y="21">
@@ -21803,16 +21927,19 @@
       <tile x="7" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="8" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="9" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="10" y="22">
@@ -21828,21 +21955,25 @@
       <tile x="12" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="13" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="15" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="16" y="22">
@@ -22512,6 +22643,7 @@
       <tile x="94" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -22521,21 +22653,25 @@
       <tile x="95" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="96" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="97" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="22">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -23669,6 +23805,7 @@
       <tile x="94" y="23">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -23678,16 +23815,19 @@
       <tile x="95" y="23">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="96" y="23">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="97" y="23">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="23">
@@ -24131,6 +24271,7 @@
       <tile x="7" y="24">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="8" y="24">
@@ -24882,16 +25023,19 @@
       <tile x="94" y="24">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="95" y="24">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="96" y="24">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="97" y="24">
@@ -25194,11 +25338,13 @@
       <tile x="134" y="24">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="135" y="24">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="136" y="24">
@@ -25313,6 +25459,7 @@
       <tile x="7" y="25">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="8" y="25">
@@ -25947,21 +26094,25 @@
       <tile x="95" y="25">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="96" y="25">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="97" y="25">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="25">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="99" y="25">
@@ -26260,6 +26411,7 @@
       <tile x="136" y="25">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="137" y="25">
@@ -26338,21 +26490,25 @@
       <tile x="5" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="6" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="7" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="8" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="9" y="26">
@@ -27080,21 +27236,25 @@
       <tile x="96" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="97" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="99" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -27389,6 +27549,7 @@
       <tile x="137" y="26">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="138" y="26">
@@ -27467,6 +27628,7 @@
       <tile x="6" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="7" y="27">
@@ -28190,6 +28352,7 @@
       <tile x="96" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -28199,6 +28362,7 @@
       <tile x="97" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -28208,11 +28372,13 @@
       <tile x="98" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="99" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="100" y="27">
@@ -28463,6 +28629,7 @@
       <tile x="129" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="EgressComponent">
           <egress>315</egress>
@@ -28526,6 +28693,7 @@
       <tile x="138" y="27">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="139" y="27">
@@ -28598,6 +28766,7 @@
       <tile x="6" y="28">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="7" y="28">
@@ -29075,6 +29244,7 @@
       <tile x="64" y="28">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="65" y="28">
@@ -29329,16 +29499,19 @@
       <tile x="98" y="28">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="99" y="28">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="100" y="28">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="101" y="28">
@@ -29586,6 +29759,7 @@
       <tile x="137" y="28">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="138" y="28">
@@ -29662,6 +29836,7 @@
       <tile x="6" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="7" y="29">
@@ -30414,6 +30589,7 @@
       <tile x="99" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="100" y="29">
@@ -30577,21 +30753,25 @@
       <tile x="120" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="121" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="122" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="123" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="124" y="29">
@@ -30684,6 +30864,7 @@
       <tile x="137" y="29">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="138" y="29">
@@ -30762,6 +30943,7 @@
       <tile x="6" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="7" y="30">
@@ -31462,16 +31644,19 @@
       <tile x="97" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="99" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="100" y="30">
@@ -31669,16 +31854,19 @@
       <tile x="123" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="124" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="125" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="126" y="30">
@@ -31729,16 +31917,19 @@
       <tile x="134" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="135" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="136" y="30">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="137" y="30">
@@ -31816,11 +32007,13 @@
       <tile x="5" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="6" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="7" y="31">
@@ -32477,16 +32670,19 @@
       <tile x="96" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="97" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -32496,6 +32692,7 @@
       <tile x="99" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>99</tree>
@@ -32682,21 +32879,25 @@
       <tile x="126" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="127" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="128" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="129" y="31">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="130" y="31">
@@ -33540,21 +33741,25 @@
       <tile x="97" y="32">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="98" y="32">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="99" y="32">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="100" y="32">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="101" y="32">
@@ -34572,6 +34777,7 @@
       <tile x="100" y="33">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="101" y="33">
@@ -34908,11 +35114,13 @@
       <tile x="10" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="11" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="12" y="34">
@@ -34933,11 +35141,13 @@
       <tile x="15" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="16" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="17" y="34">
@@ -34956,11 +35166,13 @@
       <tile x="19" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="20" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="21" y="34">
@@ -35697,16 +35909,19 @@
       <tile x="126" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="127" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="128" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="129" y="34">
@@ -35726,21 +35941,25 @@
       <tile x="131" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="132" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="133" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="134" y="34">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="135" y="34">
@@ -35874,6 +36093,7 @@
       <tile x="10" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="11" y="35">
@@ -35886,6 +36106,7 @@
       <tile x="12" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="TreeComponent">
           <tree>98</tree>
@@ -35895,11 +36116,13 @@
       <tile x="13" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="15" y="35">
@@ -35912,6 +36135,7 @@
       <tile x="16" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="17" y="35">
@@ -36715,51 +36939,61 @@
       <tile x="127" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="128" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="129" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="130" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="131" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="132" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="133" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="134" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="135" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="136" y="35">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="137" y="35">
@@ -36913,11 +37147,13 @@
       <tile x="13" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="14" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="15" y="36">
@@ -37311,6 +37547,7 @@
       <tile x="70" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="71" y="36">
@@ -37687,46 +37924,55 @@
       <tile x="126" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="127" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="128" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="129" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="130" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="131" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="132" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="133" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="134" y="36">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="135" y="36">
@@ -38256,6 +38502,7 @@
       <tile x="70" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="71" y="37">
@@ -38638,31 +38885,37 @@
       <tile x="125" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="126" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="127" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="128" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="129" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="130" y="37">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="131" y="37">
@@ -39198,6 +39451,7 @@
       <tile x="70" y="38">
         <component type="FloorComponent">
           <ground>18</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="71" y="38">


### PR DESCRIPTION
All sand components (id = 18), did not have a movement cost assigned. May have been lost at some point, or possibly not generated?

Resolves #452
Resolves #234