### PR TITLE
Balance/mechanic fixes

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Axe Glacier" version="0.66.0.0">
+<segment name="Axe Glacier" version="0.67.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -103223,7 +103223,7 @@
                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(7)
+            new CreatureBasicAttack(8)
         }
     };
     
@@ -103271,10 +103271,10 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(8), 
+        new CreatureBasicAttack(9), 
     };
     
-    fighter.Wield(new SteelLongsword());
+    fighter.Wield(new Longsword());
     fighter.Equip(new PlatemailArmor());    
     
     fighter.AddGold(550);
@@ -103319,7 +103319,7 @@
     
     martialartist.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(8), 
+        new CreatureBasicAttack(9), 
     };   
     
     martialartist.AddGold(550);
@@ -103355,7 +103355,7 @@
                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(6)
+            new CreatureBasicAttack(7)
         }
     };
     
@@ -103397,8 +103397,8 @@
             
     gargoyle.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(6,     4, 8,   "The gargoyle strikes you with its claws."),    60 },
-        { new CreatureAttack(7,     6, 12,  "The gargoyle batters you with its wings."),    40 },
+        { new CreatureAttack(8,     4, 8,   "The gargoyle strikes you with its claws."),    60 },
+        { new CreatureAttack(9,     6, 12,  "The gargoyle batters you with its wings."),    40 },
     };
     
     gargoyle.Blocks = new CreatureBlockCollection
@@ -103590,7 +103590,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(8), 
+        new CreatureBasicAttack(9), 
     };
     
     fighter.Wield(new Rapier());
@@ -103706,11 +103706,13 @@
         Weakness = CreatureWeakness.Silver,
     };
     
+    wolf.AddStatus(new NightVisionStatus(wolf));
+    
     wolf.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(6,     5, 20,   "The wolf rakes you with its claws."),  50 }, 
-        { new CreatureAttack(8,     6, 23,  "The wolf sinks its teeth into you."),  30 }, 
-        { new CreatureAttack(8,     7, 26,  "The wolf lunges at you."),             20 }, 
+        { new CreatureAttack(8,     5, 20,   "The wolf rakes you with its claws."),  50 }, 
+        { new CreatureAttack(9,     6, 23,  "The wolf sinks its teeth into you."),  30 }, 
+        { new CreatureAttack(9,     7, 26,  "The wolf lunges at you."),             20 }, 
     };
         
     wolf.Blocks = new CreatureBlockCollection
@@ -103743,8 +103745,8 @@
         <block><![CDATA[
     var wolf = new Wolf()
     {
-        MaxHealth = 400, Health = 400,
-        BaseDodge = 18,
+        MaxHealth = 700, Health = 700,
+        BaseDodge = 17,
                 
         Experience = 5500,
         
@@ -103796,7 +103798,7 @@
         <block><![CDATA[
     var rockworm = new Rockwyrm()
     {
-        MaxHealth = 150, Health = 150,
+        MaxHealth = 200, Health = 200,
         BaseDodge = 14,
     
         Experience = 1500,
@@ -103808,6 +103810,7 @@
         Weakness = CreatureWeakness.Silver,
             
         IceProtection = 100,
+        FireProtection = 50,
     };
     rockworm.AddStatus(new NightVisionStatus(rockworm));
     
@@ -104190,7 +104193,7 @@
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 150, Health = 150,
         BaseDodge = 15,
     
         Experience = 3000,
@@ -104202,10 +104205,10 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9), 
+        new CreatureBasicAttack(11), 
     };
     
-    fighter.Wield(new SteelLongsword());
+    fighter.Wield(new Longsword());
     fighter.Equip(new PlatemailArmor());    
     
     fighter.AddGold(650);
@@ -104232,7 +104235,7 @@
         <block><![CDATA[
     var gargoyle = new Gargoyle()
     {
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 175, Health = 175,
         BaseDodge = 13,
                 
         Experience = 2525,
@@ -104244,8 +104247,8 @@
             
     gargoyle.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(7,     5, 10,   "The gargoyle strikes you with its claws."),    60 },
-        { new CreatureAttack(8,     12, 20,  "The gargoyle batters you with its wings."),    40 },
+        { new CreatureAttack(9,     5, 10,   "The gargoyle strikes you with its claws."),    60 },
+        { new CreatureAttack(10,     12, 20,  "The gargoyle batters you with its wings."),    40 },
     };
     
     gargoyle.Blocks = new CreatureBlockCollection
@@ -104281,7 +104284,7 @@
         <block><![CDATA[
     var goblin = new Goblin()
     {
-        MaxHealth = 55, Health = 55,
+        MaxHealth = 65, Health = 65,
         BaseDodge = 13,
                 
         Experience = 800,
@@ -104411,7 +104414,7 @@
         Name = _names.Random(),
         Body = (female ? 35 : 49), IsFemale = female,
             
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 160, Health = 160,
         BaseDodge = 13,
     
         Experience = 3050,
@@ -104424,7 +104427,7 @@
     
     martialartist.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9), 
+        new CreatureBasicAttack(11), 
     };   
     
     martialartist.AddGold(650);
@@ -104451,7 +104454,7 @@
         <block><![CDATA[
     var ogre = new Ogre()
     {
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 175, Health = 175,
         BaseDodge = 15,
     
         Experience = 3000,
@@ -104461,7 +104464,7 @@
     
     ogre.Attacks = new CreatureAttackCollection
     {
-        { new CreatureBasicAttack(9) }, 
+        { new CreatureBasicAttack(11) }, 
     };
     
     ogre.AddStatus(new NightVisionStatus(ogre));
@@ -104493,7 +104496,7 @@
         <block><![CDATA[
     var orc = new Orc()
     {
-        MaxHealth = 60, Health = 60,
+        MaxHealth = 80, Health = 80,
         BaseDodge = 13,
                 
         Experience = 700,
@@ -104538,7 +104541,7 @@
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 150, Health = 150,
         BaseDodge = 16,
     
         Experience = 3050,
@@ -104580,7 +104583,7 @@
         <block><![CDATA[
     var troll = new Troll()
     {
-        MaxHealth = 80, Health = 80,
+        MaxHealth = 100, Health = 100,
         BaseDodge = 13,
                 
         Experience = 1100,
@@ -104766,7 +104769,7 @@
         <block><![CDATA[
     var bear = new Bear()
     {
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 150, Health = 150,
         BaseDodge = 13,
                 
         Experience = 2500,
@@ -104779,9 +104782,9 @@
         
     bear.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(7,     10, 18,  "The bear slashes you with its claws."),        50 },
-        { new CreatureAttack(7,     12, 20,  "You've been mauled by the bear."),             40 },
-        { new CreatureAttack(8,     18, 30, "The bear crushes you within its embrace."),    10 }
+        { new CreatureAttack(8,     10, 18,  "The bear slashes you with its claws."),        50 },
+        { new CreatureAttack(8,     12, 20,  "You've been mauled by the bear."),             40 },
+        { new CreatureAttack(9,     18, 30, "The bear crushes you within its embrace."),    10 }
     };
         
     bear.Blocks = new CreatureBlockCollection
@@ -104814,7 +104817,7 @@
         <block><![CDATA[
     var bear = new Bear()
     {
-        MaxHealth = 250, Health = 250,
+        MaxHealth = 300, Health = 300,
         BaseDodge = 13,
                 
         Experience = 5000,
@@ -104827,9 +104830,9 @@
         
     bear.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(8,     15, 20,  "The bear slashes you with its claws."),        50 },
-        { new CreatureAttack(8,     15, 30,  "You've been mauled by the bear."),             40 },
-        { new CreatureAttack(9,     30, 40, "The bear crushes you within its embrace."),    10 }
+        { new CreatureAttack(9,     15, 20,  "The bear slashes you with its claws."),        50 },
+        { new CreatureAttack(9,     15, 30,  "You've been mauled by the bear."),             40 },
+        { new CreatureAttack(10,     30, 40, "The bear crushes you within its embrace."),    10 }
     };
         
     bear.Blocks = new CreatureBlockCollection
@@ -104862,7 +104865,7 @@
         <block><![CDATA[
 	var drake = new Drake()
     {
-        MaxHealth = 2000, Health = 2000,
+        MaxHealth = 3000, Health = 3000,
         BaseDodge = 18,
     
         Experience = 15000,
@@ -104875,24 +104878,26 @@
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
                    CreatureImmunity.Projectile | CreatureImmunity.Magic,
         Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.DeathSpell | CreatureWeakness.IceSpearSpell,
-    
+            
     };
     drake.AddStatus(new NightVisionStatus(drake));
+    
+    drake.CombatantChangeInterval = TimeSpan.FromSeconds(10.0),
     
     drake.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(15,      45, 60,      "The drake slashes you with its claws.",
+            new CreatureAttack(13,      45, 60,      "The drake slashes you with its claws.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(16,      50, 65,     "The drake smashes you with its tail.",
+            new CreatureAttack(14,      50, 65,     "The drake smashes you with its tail.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(27,      60, 80,     "The drake buffets you with its wings.",
+            new CreatureAttack(15,      60, 80,     "The drake buffets you with its wings.",
                                                         new AttackProneComponent(35), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -104905,7 +104910,7 @@
         new CreatureBlock(3, "a wing"),
     };
         
-    drake.Spells = new CreatureSpellCollection(25.0)
+    drake.Spells = new CreatureSpellCollection(20.0)
     {
         new CreatureSpell<LightningBoltSpell>(10),
     };
@@ -104942,8 +104947,8 @@
     //todo add Ice Dragon model / corpse.
     var dragon = new Dragon()
     {
-        MaxHealth = 3700, Health = 3700,
-        BaseDodge = 22,
+        MaxHealth = 5000, Health = 5000,
+        BaseDodge = 19,
     
         Experience = 25000,
         
@@ -104961,20 +104966,22 @@
     };
     dragon.AddStatus(new NightVisionStatus(dragon));
     
+    dragon.CombatantChangeInterval = TimeSpan.FromSeconds(15.0)
+    
     dragon.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(21,      40, 110,      "The Ice Dragon slashes you with a claw.",
+            new CreatureAttack(21,      40, 65,      "The Ice Dragon slashes you with a claw.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(18,      50, 110,     "The Ice Dragon smashes you against the ice with its tail.",
+            new CreatureAttack(17,      50, 75,     "The Ice Dragon smashes you against the ice with its tail.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(18,      90, 115,     "The Ice Dragon buffets you with its wings.",
+            new CreatureAttack(17,      75, 100,     "The Ice Dragon buffets you with its wings.",
                                                         new AttackProneComponent(35), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -104989,7 +104996,7 @@
         
     dragon.Spells = new CreatureSpellCollection(35.0)
     {
-        new CreatureSpell<DragonBreathIceSpell>(19),
+        new CreatureSpell<DragonBreathIceSpell>(21),
     };
     //todo: add griffin figurine, protection from cold amulet (replaces f/i ammy)
     dragon.AddGold(6000);
@@ -105021,8 +105028,8 @@
         <block><![CDATA[
     var yeti = new Yeti()
     {
-        MaxHealth = 2500, Health = 2500,
-        BaseDodge = 23,
+        MaxHealth = 3500, Health = 3500,
+        BaseDodge = 21,
     
         Experience = 17000,
        
@@ -105040,20 +105047,22 @@
     };
     yeti.AddStatus(new NightVisionStatus(yeti));
     
+    yeti.CombatantChangeInterval = TimeSpan.FromSeconds(5.0)
+    
     yeti.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(15,      50, 70,      "The yeti smashes you with his fist.",
+            new CreatureAttack(13,      50, 70,      "The yeti smashes you with his fist.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(15,      60, 80,     "The yeti stomps on you.",
+            new CreatureAttack(13,      60, 80,     "The yeti stomps on you.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(16,      70, 90,     "The giant slams you across the room.",
+            new CreatureAttack(14,      70, 90,     "The giant slams you across the room.",
                                                         new AttackProneComponent(100), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -105386,6 +105395,8 @@
         BaseDodge = 13,
         
         Experience = 1200,
+        
+        VisibilityDistance = 1,
     };
     shadow.AddStatus(new NightVisionStatus(shadow));
         
@@ -105397,7 +105408,7 @@
     shadow.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<DarknessSpell>(
-            skillLevel: 8, cost: 4, 
+            skillLevel: 8, cost: 4, intensity: 2,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
     };
         
@@ -105455,10 +105466,10 @@
     wizard.Spells = new CreatureSpellCollection
     {
         new CreatureSpell<FireballSpell>(
-            skillLevel: 6, cost: 6, 
+            skillLevel: 10, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 3, 
+            skillLevel: 7, cost: 3, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -105574,7 +105585,7 @@
             skillLevel: 6, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 5, cost: 3, 
+            skillLevel: 7, cost: 3, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -105752,18 +105763,22 @@
         <block><![CDATA[
     var presence = new Presence()
     {
-        MaxHealth = 120, Health = 120,
+        MaxHealth = 200, Health = 200,
         BaseDodge = 14,
     
         Experience = 5000,
     
         Movement = 3,
         
+        VisibilityDistance = 1,
+        
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
             CreatureImmunity.Projectile | CreatureImmunity.Magic,
         Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.IceSpearSpell,
     };
     presence.AddStatus(new NightVisionStatus(presence));
+    
+    presence.CombatantChangeInterval = TimeSpan.FromSeconds(20.0)
     
     presence.Attacks = new CreatureAttackCollection
     {
@@ -105777,9 +105792,11 @@
         new CreatureBlock(1, "a fearful aura")
     };
     
-    presence.Spells = new CreatureSpellCollection(20.0)
+    presence.Spells = new CreatureSpellCollection(100.0)
     {
-        new CreatureSpell<IceStormSpell>(10),
+        new CreatureSpell<IceStormSpell>(
+            skillLevel: 10, cost: 0,
+            mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
     presence.AddLoot(new LootPack(
@@ -106525,7 +106542,7 @@
     <spawn type="RegionSpawner" name="Surface Dungeon">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>35</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106558,7 +106575,7 @@
     <spawn type="RegionSpawner" name="Surface Ice">
       <minimumDelay>420</minimumDelay>
       <maximumDelay>600</maximumDelay>
-      <maximum>10</maximum>
+      <maximum>2</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106583,7 +106600,7 @@
     <spawn type="RegionSpawner" name="Griff Cliffs Outside">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>40</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106619,7 +106636,7 @@
     <spawn type="RegionSpawner" name="Griff Cliff Dungeon">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>20</maximum>
+      <maximum>15</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106650,7 +106667,7 @@
     <spawn type="RegionSpawner" name="Lower Glacier Dungeon">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>600</maximumDelay>
-      <maximum>35</maximum>
+      <maximum>20</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106687,7 +106704,7 @@
     <spawn type="RegionSpawner" name="Outside Giant Castle">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>600</maximumDelay>
-      <maximum>50</maximum>
+      <maximum>30</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106719,13 +106736,16 @@
         <inclusion left="5" top="13" right="7" bottom="21" />
         <inclusion left="13" top="14" right="31" bottom="28" />
         <inclusion left="10" top="3" right="25" bottom="12" />
-        <exclusion left="0" top="0" right="0" bottom="0" />
+        <exclusion left="8" top="16" right="21" bottom="21" />
+        <exclusion left="13" top="13" right="14" bottom="14" />
+        <exclusion left="16" top="22" right="19" bottom="24" />
+        <exclusion left="16" top="15" right="17" bottom="15" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Inside Giants Castle">
       <minimumDelay>1200</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>11</maximum>
+      <maximum>9</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106807,7 +106827,7 @@
     <spawn type="RegionSpawner" name="BehindGiant">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>10</maximum>
+      <maximum>8</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106828,13 +106848,13 @@
       <entry entity="lightningMesaRapier" size="1" minimum="2" maximum="4" />
       <bounds region="8">
         <inclusion left="23" top="5" right="32" bottom="18" />
-        <exclusion left="0" top="0" right="0" bottom="0" />
+        <exclusion left="29" top="7" right="30" bottom="7" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Ogre Cave West">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>60</maximum>
+      <maximum>35</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106872,7 +106892,7 @@
     <spawn type="RegionSpawner" name="Ogre Caves Ice">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>600</maximumDelay>
-      <maximum>10</maximum>
+      <maximum>7</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106900,7 +106920,7 @@
     <spawn type="RegionSpawner" name="Ogre Caves East">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>30</maximum>
+      <maximum>20</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106935,7 +106955,7 @@
     <spawn type="RegionSpawner" name="Dungeons of Doom">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>60</maximum>
+      <maximum>40</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106971,7 +106991,7 @@
     <spawn type="RegionSpawner" name="Upper Glacier Left Trees">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>7</maximum>
+      <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107022,7 +107042,7 @@
     <spawn type="RegionSpawner" name="Upper Glacier Lower Right Trees">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>6</maximum>
+      <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107049,7 +107069,7 @@
     <spawn type="RegionSpawner" name="Upper Glacier Upper Trees">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>12</maximum>
+      <maximum>9</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107081,7 +107101,7 @@
     <spawn type="RegionSpawner" name="Yeti Den Outside">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>10</maximum>
+      <maximum>7</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107098,7 +107118,7 @@
       </script>
       <entry entity="upperLizard" size="1" minimum="2" maximum="4" />
       <entry entity="upperWolf" size="3" minimum="2" maximum="3" />
-      <entry entity="hardBear" size="1" minimum="1" maximum="1" />
+      <entry entity="hardBear" size="1" minimum="1" maximum="2" />
       <bounds region="45">
         <inclusion left="1" top="5" right="10" bottom="20" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -107133,7 +107153,7 @@
     <spawn type="RegionSpawner" name="Chaos Temple Bottom">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>6</maximum>
+      <maximum>3</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107158,7 +107178,7 @@
     <spawn type="RegionSpawner" name="ChaosTempleMiddle">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>6</maximum>
+      <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107184,7 +107204,7 @@
     <spawn type="RegionSpawner" name="Chaos Temple Upper">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>5</maximum>
+      <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107237,7 +107257,7 @@
     <spawn type="RegionSpawner" name="Chaos Town West">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>14</maximum>
+      <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107266,7 +107286,7 @@
     <spawn type="RegionSpawner" name="Chaos Town Main">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>25</maximum>
+      <maximum>20</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107345,6 +107365,7 @@
     <spawn type="RegionSpawner" name="Presence">
       <minimumDelay>2700</minimumDelay>
       <maximumDelay>3600</maximumDelay>
+      <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107362,6 +107383,34 @@
       <entry entity="axePresence" size="1" minimum="1" maximum="1" />
       <bounds region="36">
         <inclusion left="0" top="0" right="7" bottom="7" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="Lower Glacier East">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
+      <maximum>10</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="lightningMesaGargoyle" size="1" minimum="2" maximum="2" />
+      <entry entity="surfaceGoblin" size="3" minimum="2" maximum="2" />
+      <entry entity="lightningMesaWraith" size="1" minimum="2" maximum="2" />
+      <entry entity="lightningMesaWolf" size="3" minimum="2" maximum="2" />
+      <entry entity="lightningmesaGoblin" size="3" minimum="2" maximum="2" />
+      <bounds region="6">
+        <inclusion left="33" top="11" right="54" bottom="39" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -106767,7 +106767,7 @@
       <bounds region="6">
         <inclusion left="12" top="12" right="15" bottom="21" />
         <inclusion left="16" top="14" right="18" bottom="24" />
-        <inclusion left="19" top="17" right="20" bottom="22" />
+        <inclusion left="19" top="21" right="20" bottom="22" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75241,7 +75241,7 @@
         
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(11) }, 
+            { new CreatureBasicAttack(10) }, 
         },
     };
     
@@ -75272,7 +75272,7 @@
         <block><![CDATA[
     var hobgoblin = new Hobgoblin()
     {
-        MaxHealth = 100, Health = 100,
+        MaxHealth = 80, Health = 80,
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
     
@@ -75283,7 +75283,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(10),
+        new CreatureBasicAttack(9),
     };
     
     hobgoblin.Spells = new CreatureSpellCollection()
@@ -75327,7 +75327,7 @@
         Name = "Wretch",
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 170, Health = 170,
+        MaxHealth = 145, Health = 145,
         BaseDodge = 13,
         
         Movement = 2,
@@ -75338,7 +75338,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11), 
+        new CreatureBasicAttack(10), 
     };
     
     fighter.Wield(new Longsword());
@@ -75369,6 +75369,7 @@
     //todo add raven model
 	var raven = new Goose()
 	{
+	    Name = "Raven",
         MaxHealth = 45, Health = 45,
         BaseDodge = 12,
                 
@@ -75517,6 +75518,8 @@
     };
     sandwyrm.AddStatus(new NightVisionStatus(sandwyrm));
     
+    sandwyrm.CombatantChangeInterval = TimeSpan.FromSeconds(15.0),
+    
     sandwyrm.Attacks = new CreatureAttackCollection
     {
         { new CreatureAttack(9,     12, 25,     "The sandwyrm rolls over you"),      70 }, 
@@ -75632,6 +75635,8 @@
     };
     shidosha.AddStatus(new NightVisionStatus(shidosha));
     
+    shidosha.CombatantChangeInterval = TimeSpan.FromSeconds(4.0),
+    
     shidosha.Attacks = new CreatureAttackCollection
     {
         {
@@ -75700,17 +75705,17 @@
     ninja.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(20,      10, 30,      "The ninja hits you with a flurry of fists.",
+            new CreatureAttack(14,      10, 30,      "The ninja hits you with a flurry of fists.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(20,      30, 60,     "The ninja slams his fist into your chest.",
+            new CreatureAttack(15,      30, 60,     "The ninja slams his fist into your chest.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(5)),               40
         },
         {
-            new CreatureAttack(20,      40, 60,     "The ninja knocks you back with a forceful kick.",
+            new CreatureAttack(16,      40, 60,     "The ninja knocks you back with a forceful kick.",
                                                         new AttackProneComponent(100), 
                                                         new AttackStunComponent(5)),               20
         },
@@ -75762,20 +75767,22 @@
     };
     dragon.AddStatus(new NightVisionStatus(dragon));
     
+    dragon.CombatantChangeInterval = TimeSpan.FromSeconds(20.0),
+    
     dragon.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(17,      30, 55,      "The dragon slashes you with its claws.",
+            new CreatureAttack(13,      30, 55,      "The dragon slashes you with its claws.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                45
         },
         {
-            new CreatureAttack(17,      45, 60,     "The dragon smashes you with its tail.",
+            new CreatureAttack(14,      45, 60,     "The dragon smashes you with its tail.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               45
         },
         {
-            new CreatureAttack(17,      60, 80,     "The dragon buffets you with its wings.",
+            new CreatureAttack(15,      60, 80,     "The dragon buffets you with its wings.",
                                                         new AttackProneComponent(100), 
                                                         new AttackStunComponent(15)),               10
         },
@@ -75839,10 +75846,12 @@
         VisibilityDistance = 0,
     };
     
+    vlad.CombatantChangeInterval = TimeSpan.FromSeconds(4.0),
+    
     vlad.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(20,     40, 70,      "Vlad rends your flesh with his claws"),  70 }, 
-        { new CreatureAttack(20,     60, 80,     "Vlad appears behind you, sinking his teeth into your neck",
+        { new CreatureAttack(17,     40, 70,      "Vlad rends your flesh with his claws"),  70 }, 
+        { new CreatureAttack(18,     60, 80,     "Vlad appears behind you, sinking his teeth into your neck",
                                                     new AttackStunComponent(50)),          30 },
     };
     
@@ -75905,6 +75914,8 @@
     
     };
     drake.AddStatus(new NightVisionStatus(drake));
+    
+    drake.CombatantChangeInterval = TimeSpan.FromSeconds(10.0),
     
     drake.Attacks = new CreatureAttackCollection
     {
@@ -76019,7 +76030,7 @@
         Name = "Nomad",
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 200, Health = 200,
+        MaxHealth = 165, Health = 165,
         BaseDodge = 15,
             
         Experience = 3550,
@@ -76030,7 +76041,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12), 
+        new CreatureBasicAttack(11), 
     };
     
     fighter.Wield(new Longsword());
@@ -76060,7 +76071,7 @@
         <block><![CDATA[
     var scorpion = new Scorpion()
     {
-        MaxHealth = 220, Health = 220,
+        MaxHealth = 180, Health = 180,
         BaseDodge = 16,
     
         Experience = 5500,
@@ -76168,7 +76179,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12), 
+        new CreatureBasicAttack(11), 
     };
     
     fighter.Wield(new FineCrossbow());
@@ -76211,10 +76222,10 @@
     
     minotaur.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(15,     25, 35,      "The minotaur hits with a wicked axe"),          60 }, 
-        { new CreatureAttack(15,     30, 40,     "You've been gored by the minotaur",
+        { new CreatureAttack(13,     25, 35,      "The minotaur hits with a wicked axe"),          60 }, 
+        { new CreatureAttack(13,     30, 40,     "You've been gored by the minotaur",
                                                     new AttackStunComponent(10.0)),         30 }, 
-        { new CreatureAttack(15,     35, 60,     "You've been trampled by the minotaur"),    10 }, 
+        { new CreatureAttack(14,     35, 60,     "You've been trampled by the minotaur"),    10 }, 
     };
     
     minotaur.Blocks = new CreatureBlockCollection
@@ -76385,7 +76396,7 @@
     //todo add portal gem loot chance - replace red berries heh
     var sandwyrm = new Sandwyrm()
     {
-        MaxHealth = 160, Health = 160,
+        MaxHealth = 130, Health = 130,
         BaseDodge = 14,
     
         Experience = 3500,
@@ -76399,8 +76410,8 @@
     
     sandwyrm.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(9,     10, 20,     "The sandwyrm rolls over you"),      70 }, 
-        { new CreatureAttack(10,    15, 25,     "You've been bitten by the sandwyrm",
+        { new CreatureAttack(8,     10, 20,     "The sandwyrm rolls over you"),      70 }, 
+        { new CreatureAttack(9,    15, 25,     "You've been bitten by the sandwyrm",
                                                     new AttackPoisonComponent(4)),             30 },
                                                     // TODO: Attack poison chance. 50%
     };
@@ -76446,9 +76457,9 @@
     
     manticora.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(9,     10, 15,      "The manticora bites you with its teeth."),    40 },
-        { new CreatureAttack(9,     12, 18,      "The manticora slashes you with its claws."),    30 },
-        { new CreatureAttack(10,     15, 20,     "The manticora stings you with his tail.", 
+        { new CreatureAttack(8,     10, 15,      "The manticora bites you with its teeth."),    40 },
+        { new CreatureAttack(8,     12, 18,      "The manticora slashes you with its claws."),    30 },
+        { new CreatureAttack(9,     15, 20,     "The manticora stings you with his tail.", 
                                                     new AttackPoisonComponent(8)),                 30 }
     };
     
@@ -76522,7 +76533,7 @@
         Name = "Familiar",
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 200, Health = 200,
+        MaxHealth = 130, Health = 130,
         BaseDodge = 14,
     
         Experience = 4000,
@@ -76569,7 +76580,7 @@
         Name = "Familiar",
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 270, Health = 270,
+        MaxHealth = 180, Health = 180,
         BaseDodge = 15,
         
         Movement = 3,
@@ -76644,13 +76655,12 @@
     };
         
     thaum.AddGold(650);
-    /* TODO; These don't exist?
     thaum.AddLoot(new LootPack(
-        new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
-        new LootPackEntry(true, upperTreasure,   0.63)
+        new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
+        new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, MausTreasure,  0.63)
     ));
-    */
+    
     return thaum;
 ]]></block>
         <block><![CDATA[]]></block>
@@ -76668,7 +76678,7 @@
         <block><![CDATA[
     var centaur = new Centaur()
     {
-        MaxHealth = 350, Health = 350,
+        MaxHealth = 250, Health = 250,
         BaseDodge = 14,
                             
         Experience = 4700,
@@ -76676,7 +76686,7 @@
     
     centaur.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12),
+        new CreatureBasicAttack(11),
     };
         
     centaur.Wield(new FineCrossbow());
@@ -76756,11 +76766,13 @@
         Experience = 9000,
     };
     
+    duck.CombatantChangeInterval = TimeSpan.FromSeconds(10.0),
+    
     duck.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(15,     40, 50,   "The duck buffets you with his wings."),  50 }, 
-        { new CreatureAttack(16,     45, 60,  "The duck viciously attacks your shins."),  30 }, 
-        { new CreatureAttack(17,     50, 65,  "The duck pecks at your eyes attempting to blind you."),             20 }, 
+        { new CreatureAttack(13,     40, 50,   "The duck buffets you with his wings."),  50 }, 
+        { new CreatureAttack(14,     45, 60,  "The duck viciously attacks your shins."),  30 }, 
+        { new CreatureAttack(15,     50, 65,  "The duck pecks at your eyes attempting to blind you."),             20 }, 
     };
         
     duck.Blocks = new CreatureBlockCollection
@@ -76770,7 +76782,7 @@
     };
     duck.AddGold(500);
     duck.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new OchreEgg(),    100, gemsPriceMutator) /* Eggs are not gems, so they have a default price, do we need to make it configured? */
+        new LootPackEntry(true, (from, container) => new OchreEgg(), 100.0),  /* TODO: add another piece of minor loot just added egg because it made sense*/
     ));
         
     return duck;
@@ -76790,7 +76802,7 @@
         <block><![CDATA[
     var orc = new Orc()
     {
-        MaxHealth = 160, Health = 160,
+        MaxHealth = 150, Health = 150,
         BaseDodge = 14,
                 
         Experience = 2400,
@@ -76830,7 +76842,7 @@
         <block><![CDATA[
     var wolf = new Wolf()
     {
-        MaxHealth = 150, Health = 150,
+        MaxHealth = 125, Health = 125,
         BaseDodge = 15,
                 
         Experience = 2200,
@@ -76839,8 +76851,8 @@
     wolf.Attacks = new CreatureAttackCollection
     {
         { new CreatureAttack(9,     5, 13,   "The wolf rakes you with its claws."),  50 }, 
-        { new CreatureAttack(11,     6, 15,  "The wolf sinks its teeth into you."),  30 }, 
-        { new CreatureAttack(12,     8, 17,  "The wolf lunges at you."),             20 }, 
+        { new CreatureAttack(10,     6, 15,  "The wolf sinks its teeth into you."),  30 }, 
+        { new CreatureAttack(11,     8, 17,  "The wolf lunges at you."),             20 }, 
     };
         
     wolf.Blocks = new CreatureBlockCollection
@@ -76873,7 +76885,7 @@
         <block><![CDATA[
     var troll = new Troll()
     {
-        MaxHealth = 200, Health = 200,
+        MaxHealth = 175, Health = 175,
         BaseDodge = 15,
                 
         Experience = 2700,
@@ -76882,7 +76894,7 @@
                                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(12)
+            new CreatureBasicAttack(11)
         }
     };
     
@@ -76922,8 +76934,8 @@
     hyena.Attacks = new CreatureAttackCollection
     {
         { new CreatureAttack(8,     5, 12,   "The hyena rakes you with its claws."),  50 }, 
-        { new CreatureAttack(10,     6, 13,  "The hyena sinks its teeth into you."),  30 }, 
-        { new CreatureAttack(11,     8, 15,  "The hyena lunges at you."),             20 }, 
+        { new CreatureAttack(9,     6, 13,  "The hyena sinks its teeth into you."),  30 }, 
+        { new CreatureAttack(10,     8, 15,  "The hyena lunges at you."),             20 }, 
     };
         
     hyena.Blocks = new CreatureBlockCollection
@@ -76950,7 +76962,7 @@
         <block><![CDATA[
     var orc = new Orc()
     {
-        MaxHealth = 160, Health = 160,
+        MaxHealth = 100, Health = 100,
         BaseDodge = 14,
                 
         Experience = 2400,
@@ -77063,15 +77075,12 @@
     wight.Wield(new WoodenStaff());
         
     wight.AddGold(120);
-    /* TODO
+    
     wight.AddLoot(new LootPack(
-        new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.6),
-        new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
+        new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, MausTreasure,  0.63)
     ));
-    */
     return wight;
 ]]></block>
         <block><![CDATA[]]></block>
@@ -77564,7 +77573,7 @@
     <spawn type="RegionSpawner" name="westMausoleum">
       <minimumDelay>720</minimumDelay>
       <maximumDelay>1020</maximumDelay>
-      <maximum>25</maximum>
+      <maximum>16</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77579,11 +77588,11 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="MausSkeleton" size="3" minimum="3" maximum="8" />
+      <entry entity="MausSkeleton" size="3" minimum="2" maximum="8" />
       <entry entity="mausWraith" size="1" minimum="2" maximum="3" />
-      <entry entity="mausWretch" size="3" minimum="3" maximum="8" />
-      <entry entity="raven" size="1" minimum="4" maximum="7" />
-      <entry entity="mausHobgoblin" size="1" minimum="6" maximum="10" />
+      <entry entity="mausWretch" size="3" minimum="2" maximum="8" />
+      <entry entity="raven" size="1" minimum="2" maximum="7" />
+      <entry entity="mausHobgoblin" size="1" minimum="4" maximum="10" />
       <entry entity="mausHobgobMage" size="1" minimum="2" maximum="3" />
       <bounds region="10">
         <inclusion left="7" top="6" right="11" bottom="33" />
@@ -77593,6 +77602,35 @@
     <spawn type="RegionSpawner" name="insideMausoleum">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
+      <maximum>15</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="mausConcWiz" size="1" minimum="3" maximum="7" />
+      <entry entity="mausFireWiz" size="1" minimum="4" maximum="8" />
+      <entry entity="mausWraith" size="1" minimum="2" maximum="5" />
+      <entry entity="mausWretch" size="3" minimum="4" maximum="9" />
+      <entry entity="mausSpectre" size="1" minimum="2" maximum="3" />
+      <bounds region="10">
+        <inclusion left="13" top="8" right="31" bottom="29" />
+        <inclusion left="32" top="13" right="33" bottom="29" />
+        <exclusion left="20" top="22" right="24" bottom="26" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="southofMausoleum">
+      <minimumDelay>720</minimumDelay>
+      <maximumDelay>1020</maximumDelay>
       <maximum>20</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -77608,41 +77646,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="mausConcWiz" size="1" minimum="4" maximum="7" />
-      <entry entity="mausFireWiz" size="1" minimum="5" maximum="8" />
-      <entry entity="mausWraith" size="1" minimum="3" maximum="5" />
-      <entry entity="mausWretch" size="3" minimum="6" maximum="9" />
-      <entry entity="mausSpectre" size="1" minimum="2" maximum="3" />
-      <bounds region="10">
-        <inclusion left="13" top="8" right="31" bottom="29" />
-        <inclusion left="32" top="13" right="33" bottom="29" />
-        <exclusion left="20" top="22" right="24" bottom="26" />
-      </bounds>
-    </spawn>
-    <spawn type="RegionSpawner" name="southofMausoleum">
-      <minimumDelay>720</minimumDelay>
-      <maximumDelay>1020</maximumDelay>
-      <maximum>30</maximum>
-      <script name="OnAfterSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
       <entry entity="raven" size="3" minimum="2" maximum="4" />
-      <entry entity="mausWretch" size="3" minimum="5" maximum="12" />
+      <entry entity="mausWretch" size="3" minimum="4" maximum="12" />
       <entry entity="mausHobgoblin" size="3" minimum="4" maximum="12" />
-      <entry entity="mausHobgobMage" size="1" minimum="3" maximum="5" />
-      <entry entity="MausSkeleton" size="3" minimum="6" maximum="12" />
-      <entry entity="mausWraith" size="1" minimum="3" maximum="5" />
+      <entry entity="mausHobgobMage" size="1" minimum="2" maximum="5" />
+      <entry entity="MausSkeleton" size="3" minimum="4" maximum="12" />
+      <entry entity="mausWraith" size="1" minimum="2" maximum="5" />
       <bounds region="10">
         <inclusion left="10" top="31" right="49" bottom="40" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -77666,6 +77675,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <entry entity="presence" size="1" minimum="1" maximum="1" />
       <bounds region="10">
         <inclusion left="33" top="9" right="39" bottom="11" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -77703,7 +77713,7 @@
     <spawn type="RegionSpawner" name="gryphCliffsOutdoors">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>23</maximum>
+      <maximum>18</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77722,7 +77732,7 @@
       <entry entity="nomad" size="3" minimum="5" maximum="10" />
       <entry entity="cliffCentaur" size="1" minimum="2" maximum="3" />
       <entry entity="scorpion" size="1" minimum="3" maximum="5" />
-      <entry entity="surfacebee" size="3" minimum="3" maximum="3" />
+      <entry entity="surfacebee" size="3" minimum="1" maximum="3" />
       <entry entity="raven" size="1" minimum="2" maximum="2" />
       <bounds region="20">
         <inclusion left="9" top="3" right="37" bottom="9" />
@@ -77784,7 +77794,7 @@
     <spawn type="RegionSpawner" name="gryphcliffdungeon">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>10</maximum>
+      <maximum>8</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -78254,6 +78264,7 @@
     <spawn type="RegionSpawner" name="westofDrake">
       <minimumDelay>1200</minimumDelay>
       <maximumDelay>1500</maximumDelay>
+      <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -78296,7 +78307,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="powerTroll" size="1" minimum="1" maximum="1" />
-      <bounds region="237">
+      <bounds region="236">
         <inclusion left="3" top="6" right="6" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>


### PR DESCRIPTION
Fixed a lot of visibility issues.

Changed a lot of hit point / attack values. Left experience same. (Balance issues can come later but spawns in Leng were massively overtuned, several Axe spawns like Ogre were undertuned).

Fixed a few Leng copy paste errors in loot tables. (doomDuck egg was a placeholder, don't need a gems price mutator for eggs that I can think of). 

Added some exclusive zones, fixed several areas.

Decreased spawns by 33-50% overall. My eyes were bigger than my stomach. Should be closer to OG

Big item to check:

Added random target swaps to all bosses. Check context (based on reply to issue thread)

Axe Presence: Not sure if the spell context will be proper. I want him to run from drake, be invisible, and harass him from afar as happened in the OG.