### PR TITLE
Potion change to kes4, Exp change to oak 2-4

### DIFF
--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -97997,7 +97997,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
 
         new LootPackEntry(true, (from, container) => new ThrowingHammer(), 16.67)
     ));
@@ -98041,7 +98041,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
 
         new LootPackEntry(true, (from, container) => new Shuriken(), 11.11)
     ));
@@ -98096,7 +98096,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon4Potions,    1.0)
     ));
     
     return orc;
@@ -98136,7 +98136,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon4Potions,    1.0)
     ));
     
     return troll;
@@ -98176,7 +98176,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon4Potions,    1.0)
     ));
     
     return hobgoblin;
@@ -98222,7 +98222,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14)
     ));
@@ -98275,7 +98275,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.6), 
         new LootPackEntry(true, dungeon4Rings,      0.6), 
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         
         new LootPackEntry(true, (from, container) => new FieryRuby(1200u), 100.0)
     ));
@@ -98328,7 +98328,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6)
     ));
     
@@ -98382,7 +98382,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6)
     ));
     
@@ -98432,7 +98432,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon4Potions,    1.0)
     ));
     
     return ghoul;
@@ -98485,7 +98485,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
@@ -98536,7 +98536,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u), 10.0)
     ));
@@ -98587,7 +98587,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u), 10.0)
     ));
@@ -98650,7 +98650,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u),    10.0),
         new LootPackEntry(true, (from, container) => new RedRunesRobe(),        10.0)
@@ -98715,7 +98715,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u),    10.0),
         new LootPackEntry(true, (from, container) => new RedRunesRobe(),        10.0)
@@ -99348,7 +99348,7 @@ return orc;
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       50.0,   gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    50.0),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new ReturningHammer(),     33.33)
     ));
@@ -99404,7 +99404,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon4Potions,    1.0),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6)
     ));
     
@@ -101764,6 +101764,62 @@ return orc;
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new FireProtectionAmulet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="dungeon4Potions">
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentStrengthPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentDexterityPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWillpowerPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentIntelligencePotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentConstitutionPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.69.0.0">
+<segment name="Oakvael" version="0.70.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -85379,7 +85379,7 @@
         MaxHealth = 52, Health = 52,
         BaseDodge = 14,
 
-        Experience = 500,
+        Experience = 700,
 
         Movement = 2,
 
@@ -85422,7 +85422,7 @@
         MaxHealth = 42, Health = 42,
         BaseDodge = 13,
 
-        Experience = 450,
+        Experience = 600,
 
         Attacks = new CreatureAttackCollection
         {
@@ -85463,7 +85463,7 @@
         MaxHealth = 42, Health = 42,
         BaseDodge = 13,
 
-        Experience = 450,
+        Experience = 600,
 
         Attacks = new CreatureAttackCollection
         {
@@ -85504,7 +85504,7 @@
         MaxHealth = 75, Health = 75,
         BaseDodge = 14,
 
-        Experience = 500,
+        Experience = 800,
 
         Movement = 2,
 
@@ -85550,7 +85550,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 13,
 
-        Experience = 425,
+        Experience = 475,
         
         CanFlee = true,
 
@@ -85593,7 +85593,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 13,
 
-        Experience = 325,
+        Experience = 500,
 
         CanFlee = true,
 
@@ -85637,7 +85637,7 @@
         MaxMana = 12, Mana = 12,
         BaseDodge = 13,
 
-        Experience = 425,
+        Experience = 500,
         
         CanFlee = true,
 
@@ -85687,7 +85687,7 @@
         MaxMana = 17, Mana = 17,
         BaseDodge = 14,
 
-        Experience = 550,
+        Experience = 1800,
 
         VisibilityDistance = 1,
 
@@ -85740,7 +85740,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 15,
 
-        Experience = 900,
+        Experience = 1050,
 
         Movement = 2,
 
@@ -85783,7 +85783,7 @@
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
 
-        Experience = 600,
+        Experience = 700,
         
         CanFlee = true,
 
@@ -85826,7 +85826,7 @@
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
 
-        Experience = 600,
+        Experience = 700,
         
         CanFlee = true,
 
@@ -85870,7 +85870,7 @@
         MaxMana = 12, Mana = 12,
         BaseDodge = 14,
 
-        Experience = 575,
+        Experience = 700,
 
         CanFlee = true,
 
@@ -85920,7 +85920,7 @@
         MaxHealth = 98, Health = 98,
         BaseDodge = 16,
 
-        Experience = 850,
+        Experience = 1250,
         
         Attacks = new CreatureAttackCollection
         {
@@ -85967,7 +85967,7 @@
         MaxMana = 18, Mana = 18,
         BaseDodge = 15,
 
-        Experience = 2100,
+        Experience = 3000,
         
         CanFlee = true,
         CanSwim = true,
@@ -86026,7 +86026,7 @@
         MaxMana = 21, Mana = 21,
         BaseDodge = 15,
 
-        Experience = 2100,
+        Experience = 3000,
 
         CanFlee = true,
         CanSwim = true,
@@ -86079,7 +86079,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 15,
 
-        Experience = 1100,
+        Experience = 2500,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
 
@@ -86133,7 +86133,7 @@
         MaxHealth = 125, Health = 125,
         BaseDodge = 15,
 
-        Experience = 2150,
+        Experience = 2350,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
         
@@ -86187,7 +86187,7 @@
         MaxHealth = 71, Health = 71,
         BaseDodge = 15,
 
-        Experience = 725,
+        Experience = 1300,
 
         Movement = 2,
 
@@ -86234,7 +86234,7 @@
         MaxHealth = 500, Health = 500,
         BaseDodge = 18,
 
-        Experience = 5000,
+        Experience = 10000,
 
         Movement = 2,
 
@@ -86300,7 +86300,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 120, Health = 120,
         BaseDodge = 16,
 
-        Experience = 900,
+        Experience = 1800,
 
         CanWalk = false,
 
@@ -86343,7 +86343,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 130, Health = 130,
         BaseDodge = 17,
 
-        Experience = 2200,
+        Experience = 2600,
 
         Movement = 2,
         CanFly = true,
@@ -86395,7 +86395,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 160, Health = 160,
         BaseDodge = 17,
 
-        Experience = 2500,
+        Experience = 2850,
 
         CanFlee = true,
         BasePenetration = ShieldPenetration.Medium,
@@ -86448,7 +86448,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 88, Health = 88,
         BaseDodge = 16,
 
-        Experience = 950,
+        Experience = 1150,
         
         Attacks = new CreatureAttackCollection
         {
@@ -86534,7 +86534,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 71, Health = 71,
         BaseDodge = 16,
 
-        Experience = 700,
+        Experience = 850,
 
         CanFlee = true,
 


### PR DESCRIPTION
Kesmai Loot Changes
created dungeon4potions with str:dex:will:int:wis:con ratio of 20:20:20:10:10:1 and drop rate in kes -4 of 1% (from dungeon3potions 20:20:20:10:10:40 .2%)

Oak Exp Changes
Increased EXP in Oak 2-3 to scale more like Kesmai (Oak was harder and gave less exp than Kes)