### PR TITLE
Massive Balance Changes.

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -103023,7 +103023,7 @@
         
     wraith.Wield(new BlackStaff());
         
-    wraith.AddGold(350);
+    wraith.AddGold(500);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103067,7 +103067,7 @@
         new CreatureBlock(3, "a paw"),
     };
         
-    wolf.AddGold(75);
+    wolf.AddGold(175);
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103106,7 +103106,7 @@
     
     skeleton.Wield(new Spear());
             
-    skeleton.AddGold(200);
+    skeleton.AddGold(270);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103145,7 +103145,7 @@
     goblin.Wield(new Crossbow());
     goblin.Equip(new LeatherArmor());
             
-    goblin.AddGold(120);
+    goblin.AddGold(220);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103185,7 +103185,7 @@
     orc.Wield(new BattleAxe());
     orc.Equip(new LeatherArmor());
             
-    orc.AddGold(100);
+    orc.AddGold(250);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103227,7 +103227,7 @@
     troll.Wield(new Greatsword());
     troll.Equip(new ChainmailArmor());
     
-    troll.AddGold(500);
+    troll.AddGold(400);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103267,7 +103267,7 @@
     goblin.Wield(new Longsword());
     goblin.Equip(new LeatherArmor());
             
-    goblin.AddGold(120);
+    goblin.AddGold(220);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103364,7 +103364,7 @@
     
     goblin.Wield(new BlackStaff());
             
-    goblin.AddGold(120);
+    goblin.AddGold(350);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103403,7 +103403,7 @@
     goblin.Wield(new BattleAxe());
     goblin.Equip(new LeatherArmor());
             
-    goblin.AddGold(200);
+    goblin.AddGold(225);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103445,7 +103445,7 @@
     troll.Wield(new Greatsword());
     troll.Equip(new ChainmailArmor());
     
-    troll.AddGold(500);
+    troll.AddGold(450);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103578,7 +103578,7 @@
     orc.Wield(new BattleAxe());
     orc.Equip(new LeatherArmor());
             
-    orc.AddGold(100);
+    orc.AddGold(180);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103718,7 +103718,7 @@
         
     wraith.Wield(new BlackStaff());
         
-    wraith.AddGold(350);
+    wraith.AddGold(550);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103766,7 +103766,7 @@
     
     goblin.Wield(new BlackStaff());
             
-    goblin.AddGold(120);
+    goblin.AddGold(400);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -103851,7 +103851,7 @@
     goblin.Wield(new Crossbow());
     goblin.Equip(new LeatherArmor());
             
-    goblin.AddGold(200);
+    goblin.AddGold(225);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
@@ -104573,7 +104573,7 @@
     
     goblin.Wield(new BlackStaff());
             
-    goblin.AddGold(250);
+    goblin.AddGold(450);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -104738,7 +104738,7 @@
     orc.Wield(new ShortSword());
     orc.Equip(new LeatherArmor());
             
-    orc.AddGold(200);
+    orc.AddGold(300);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -104919,7 +104919,7 @@
         
     wraith.Wield(new BlackStaff());
         
-    wraith.AddGold(50);
+    wraith.AddGold(650);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -105140,9 +105140,9 @@
         new CreatureSpell<LightningBoltSpell>(10),
     };
     
-    drake.AddGold(2000);
+    drake.AddGold(5000);
     drake.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    100, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(5000u),    100, gemsPriceMutator),
         new LootPackEntry(true, (from, container) => new StrongShieldRing(),    50),
         new LootPackEntry(true, (from, container) => new PermanentConstitutionPotion(),     100),
         new LootPackEntry(true, (from, container) => new LightningShield(),     10),
@@ -105646,7 +105646,7 @@
         
     shadow.Wield(new Spear());
         
-    shadow.AddGold(200);
+    shadow.AddGold(600);
     shadow.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -105705,7 +105705,7 @@
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
-    wizard.AddGold(650);
+    wizard.AddGold(700);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -105762,7 +105762,7 @@
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
-    thaum.AddGold(650);
+    thaum.AddGold(750);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -105821,7 +105821,7 @@
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
-    wizard.AddGold(600);
+    wizard.AddGold(725);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
@@ -107803,7 +107803,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new GoldNugget(700u);
+	return new GoldNugget(800u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107812,7 +107812,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutEmerald(600u);
+	return new UncutEmerald(700u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107821,7 +107821,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutDiamond(800u);
+	return new UncutDiamond(1000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107870,7 +107870,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new GoldNugget(800u);
+	return new GoldNugget(1100u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107879,7 +107879,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutEmerald(900u);
+	return new UncutEmerald(1500u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107888,7 +107888,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutDiamond(1000u);
+	return new UncutDiamond(1800u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107899,7 +107899,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PearDiamond(1500u);
+	return new PearDiamond(2000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107908,7 +107908,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new GoldNugget(1100u);
+	return new GoldNugget(1500u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -107917,7 +107917,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutDiamond(1200u);
+	return new UncutDiamond(1700u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -107962,7 +107962,7 @@
       </entry>
     </treasure>
     <treasure name="upperTreasure">
-      <entry weight="50">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -107971,7 +107971,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="50">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -107980,7 +107980,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="50">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104195,7 +104195,7 @@
     
     lizard.Spells = new CreatureSpellCollection(80.0)
     {
-        new CreatureSpell<IceStormSpell>(8), instantCast = true,
+        new CreatureSpell<IceStormSpell>(8),
     };
     
     lizard.AddGold(400);
@@ -104970,7 +104970,7 @@
     
     lizard.Spells = new CreatureSpellCollection(80.0)
     {
-        new CreatureSpell<IceStormSpell>(8), instantCast = true,
+        new CreatureSpell<IceStormSpell>(8),
     };
     
     lizard.AddGold(500);
@@ -105139,7 +105139,7 @@
         
     drake.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<LightningBoltSpell>(10), instantCast = true,
+        new CreatureSpell<LightningBoltSpell>(10),
     };
     
     drake.AddGold(5000);
@@ -105225,7 +105225,7 @@
         
     dragon.Spells = new CreatureSpellCollection(35.0)
     {
-        new CreatureSpell<DragonBreathIceSpell>(21), instantCast = true,
+        new CreatureSpell<DragonBreathIceSpell>(21), 
     };
     //todo: add griffin figurine, protection from cold amulet (replaces f/i ammy)
     dragon.AddGold(6000);
@@ -105306,7 +105306,7 @@
     
     yeti.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<DragonBreathIceSpell>(21), instantCast = true,
+        new CreatureSpell<DragonBreathIceSpell>(21),
     };
         
    yeti.AddGold(12000);

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -103002,7 +103002,7 @@
         MaxMana = 17, Mana = 17,
         BaseDodge = 12,
         
-        Experience = 900,
+        Experience = 1700,
     };
     wraith.AddStatus(new NightVisionStatus(wraith));
         
@@ -103026,7 +103026,7 @@
     wraith.AddGold(500);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -103051,14 +103051,14 @@
         MaxHealth = 50, Health = 50,
         BaseDodge = 11,
                 
-        Experience = 500,
+        Experience = 900,
     };
     
     wolf.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(5,     3, 10,   "The wolf rakes you with its claws."),  50 }, 
-        { new CreatureAttack(7,     4, 12,  "The wolf sinks its teeth into you."),  30 }, 
-        { new CreatureAttack(7,     5, 14,  "The wolf lunges at you."),             20 }, 
+        { new CreatureAttack(5,     3, 7,   "The wolf rakes you with its claws."),  50 }, 
+        { new CreatureAttack(7,     4, 8,  "The wolf sinks its teeth into you."),  30 }, 
+        { new CreatureAttack(7,     5, 10,  "The wolf lunges at you."),             20 }, 
     };
         
     wolf.Blocks = new CreatureBlockCollection
@@ -103070,7 +103070,7 @@
     wolf.AddGold(175);
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
         
@@ -103094,7 +103094,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 10,
                 
-        Experience = 500,
+        Experience = 800,
                 
         Movement = 2,
                 
@@ -103109,7 +103109,7 @@
     skeleton.AddGold(270);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -103134,7 +103134,7 @@
         MaxHealth = 36, Health = 36,
         BaseDodge = 10,
                 
-        Experience = 600,
+        Experience = 900,
         
         Attacks = new CreatureAttackCollection()
         {
@@ -103148,7 +103148,7 @@
     goblin.AddGold(220);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103172,13 +103172,13 @@
         MaxHealth = 35, Health = 35,
         BaseDodge = 10,
                 
-        Experience = 425,
+        Experience = 925,
         
         CanFlee = true,
                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(6, 5, 13)
+            new CreatureBasicAttack(6, 3, 11)
         }
     };
     
@@ -103188,7 +103188,7 @@
     orc.AddGold(250);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103209,10 +103209,10 @@
         <block><![CDATA[
     var troll = new Troll()
     {
-        MaxHealth = 60, Health = 60,
+        MaxHealth = 45, Health = 45,
         BaseDodge = 12,
                 
-        Experience = 700,
+        Experience = 1300,
                 
         Movement = 2,
                 
@@ -103220,7 +103220,7 @@
                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(6, 10, 17)
+            new CreatureBasicAttack(6, 4, 13)
         }
     };
     
@@ -103230,7 +103230,7 @@
     troll.AddGold(400);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -103255,11 +103255,11 @@
         MaxHealth = 36, Health = 36,
         BaseDodge = 10,
                 
-        Experience = 600,
+        Experience = 900,
     
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(6, 5, 12),
+            new CreatureBasicAttack(6, 3, 9),
         }
     
     };
@@ -103270,7 +103270,7 @@
     goblin.AddGold(220);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new LeatherGauntlets(), 7.5)
     ));
@@ -103317,7 +103317,7 @@
     gargoyle.AddGold(700);
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5),
         new LootPackEntry(true, (from, container) => new IronOre(), 2.6)
@@ -103344,7 +103344,7 @@
         MaxMana = 16, Mana = 16,
         BaseDodge = 9,
                 
-        Experience = 600,
+        Experience = 900,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -103367,7 +103367,7 @@
     goblin.AddGold(350);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103391,11 +103391,11 @@
         MaxHealth = 45, Health = 45,
         BaseDodge = 13,
                 
-        Experience = 700,
+        Experience = 1900,
     
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(7, 10, 14),
+            new CreatureBasicAttack(7, 8, 14),
         }
     
     };
@@ -103406,7 +103406,7 @@
     goblin.AddGold(225);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103430,7 +103430,7 @@
         MaxHealth = 70, Health = 70,
         BaseDodge = 11,
                 
-        Experience = 800,
+        Experience = 2700,
                 
         Movement = 2,
                 
@@ -103438,7 +103438,7 @@
                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(8, 15, 25)
+            new CreatureBasicAttack(8, 12, 21)
         }
     };
     
@@ -103448,7 +103448,7 @@
     troll.AddGold(450);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103477,7 +103477,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 11,
     
-        Experience = 1600,
+        Experience = 3600,
     
         BasePenetration = ShieldPenetration.Light,
             
@@ -103486,7 +103486,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9), 
+        new CreatureBasicAttack(9, 13, 21), 
     };
     
     fighter.Wield(new Longsword());
@@ -103495,7 +103495,7 @@
     fighter.AddGold(550);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -103525,7 +103525,7 @@
         MaxHealth = 100, Health = 100,
         BaseDodge = 13,
     
-        Experience = 2650,
+        Experience = 3650,
         BasePenetration = ShieldPenetration.Light,
         
         CanJumpkick = true,
@@ -103534,13 +103534,13 @@
     
     martialartist.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 20, 25), 
+        new CreatureBasicAttack(8, 20, 25), 
     };   
     
     martialartist.AddGold(550);
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -103565,7 +103565,7 @@
         MaxHealth = 50, Health = 50,
         BaseDodge = 10,
                 
-        Experience = 600,
+        Experience = 2050,
         
         CanFlee = true,
                 
@@ -103581,7 +103581,7 @@
     orc.AddGold(180);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103605,7 +103605,7 @@
         MaxHealth = 107, Health = 107,
         BaseDodge = 12,
                 
-        Experience = 2025,
+        Experience = 2625,
                 
         Movement = 2,
     };
@@ -103627,7 +103627,7 @@
     gargoyle.AddGold(700);
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
@@ -103653,7 +103653,7 @@
         MaxHealth = 55, Health = 55,
         BaseDodge = 10,
                 
-        Experience = 600,
+        Experience = 2200,
     };
     
     wolf.Attacks = new CreatureAttackCollection
@@ -103672,7 +103672,7 @@
     wolf.AddGold(300);
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
         
@@ -103697,7 +103697,7 @@
         MaxMana = 17, Mana = 17,
         BaseDodge = 11,
         
-        Experience = 1100,
+        Experience = 2600,
     };
     wraith.AddStatus(new NightVisionStatus(wraith));
         
@@ -103721,7 +103721,7 @@
     wraith.AddGold(550);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103746,7 +103746,7 @@
         MaxMana = 16, Mana = 16,
         BaseDodge = 12,
                 
-        Experience = 725,
+        Experience = 1725,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -103769,7 +103769,7 @@
     goblin.AddGold(400);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103798,7 +103798,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 12,
     
-        Experience = 1600,
+        Experience = 3600,
     
         BasePenetration = ShieldPenetration.Light,
             
@@ -103807,7 +103807,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 20, 30), 
+        new CreatureBasicAttack(9, 13, 28), 
     };
     
     fighter.Wield(new Rapier());
@@ -103816,7 +103816,7 @@
     fighter.AddGold(550);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103840,7 +103840,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 12,
                 
-        Experience = 700,
+        Experience = 1800,
         
         Attacks = new CreatureAttackCollection()
         {
@@ -103854,7 +103854,7 @@
     goblin.AddGold(225);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103878,11 +103878,11 @@
         MaxHealth = 59, Health = 59,
         BaseDodge = 13,
     
-        Experience = 750,
+        Experience = 2950,
         
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(8, 10, 18) }, 
+            { new CreatureBasicAttack(8, 9, 16) }, 
         },
     };
     
@@ -103892,7 +103892,7 @@
     hobgoblin.AddGold(300);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103916,11 +103916,13 @@
         MaxHealth = 100, Health = 100,
         BaseDodge = 14,
                 
-        Experience = 2500,
+        Experience = 4500,
         BasePenetration = ShieldPenetration.Medium,
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
                    CreatureImmunity.Projectile | CreatureImmunity.Poison | CreatureImmunity.Web,
         Weakness = CreatureWeakness.Silver,
+        FireProtection = 50,
+        IceProtection = 75,
     };
     
     wolf.AddStatus(new NightVisionStatus(wolf));
@@ -103941,7 +103943,7 @@
     wolf.AddGold(500);
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    50),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -103965,7 +103967,7 @@
         BaseDodge = 17,
         MaxHealth = 700, Health = 700,
 
-        Experience = 5500,
+        Experience = 11500,
          
         BasePenetration = ShieldPenetration.Medium,
 
@@ -104026,11 +104028,11 @@
         MaxHealth = 200, Health = 200,
         BaseDodge = 13,
     
-        Experience = 3000,
+        Experience = 5500,
         BasePenetration = ShieldPenetration.Light,
         VisibilityDistance = 1,
         
-        Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
+        Immunity = CreatureImmunity.Slashing | CreatureImmunity.Bashing |
                    CreatureImmunity.Projectile | CreatureImmunity.Poison | CreatureImmunity.Web,
         Weakness = CreatureWeakness.Silver,
             
@@ -104056,7 +104058,7 @@
     rockworm.AddGold(800);
     rockworm.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    50),
         new LootPackEntry(true, upperTreasure,   0.63)
         
         ));
@@ -104086,7 +104088,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 11,
     
-        Experience = 1600,
+        Experience = 3600,
     
         BasePenetration = ShieldPenetration.Light,
             
@@ -104104,7 +104106,7 @@
     fighter.AddGold(550);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -104129,7 +104131,7 @@
         MaxHealth = 120, Health = 120,
         BaseDodge = 13,
     
-        Experience = 2600,
+        Experience = 5200,
         BasePenetration = ShieldPenetration.Medium,
         Immunity = CreatureImmunity.Web
     };
@@ -104146,7 +104148,7 @@
     ogre.AddGold(650);
     ogre.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
@@ -104171,7 +104173,7 @@
         MaxHealth = 70, Health = 70,
         BaseDodge = 11,
         
-        Experience = 800,
+        Experience = 3800,
         
         Movement = 2,
         
@@ -104193,13 +104195,13 @@
     
     lizard.Spells = new CreatureSpellCollection(80.0)
     {
-        new CreatureSpell<IceStormSpell>(8),
+        new CreatureSpell<IceStormSpell>(8), instantCast = true,
     };
     
     lizard.AddGold(400);
     lizard.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, surfaceTreasureBottles,    20),
+        new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104332,7 +104334,7 @@
         MaxHealth = 55, Health = 55,
         BaseDodge = 11,
                 
-        Experience = 800,
+        Experience = 2800,
         BasePenetration = ShieldPenetration.Light,
         Attacks = new CreatureAttackCollection()
         {
@@ -104346,7 +104348,7 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104375,7 +104377,7 @@
         MaxHealth = 120, Health = 120,
         BaseDodge = 13,
     
-        Experience = 2000,
+        Experience = 7000,
     
         BasePenetration = ShieldPenetration.Light,
             
@@ -104393,7 +104395,7 @@
     fighter.AddGold(700);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104422,7 +104424,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
     
-        Experience = 2000,
+        Experience = 7500,
     
         BasePenetration = ShieldPenetration.Light,
             
@@ -104440,7 +104442,7 @@
     fighter.AddGold(650);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104464,7 +104466,7 @@
         MaxHealth = 175, Health = 175,
         BaseDodge = 13,
                 
-        Experience = 2525,
+        Experience = 5525,
                 
         BasePenetration = ShieldPenetration.Light,
         CanJumpkick = true,
@@ -104487,7 +104489,7 @@
     gargoyle.AddGold(700);
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63),
         
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5)
@@ -104513,7 +104515,7 @@
         MaxHealth = 65, Health = 65,
         BaseDodge = 11,
                 
-        Experience = 800,
+        Experience = 2800,
     
         Attacks = new CreatureAttackCollection()
         {
@@ -104528,7 +104530,7 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104553,7 +104555,7 @@
         MaxMana = 16, Mana = 16,
         BaseDodge = 11,
                 
-        Experience = 800,
+        Experience = 2800,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -104576,7 +104578,7 @@
     goblin.AddGold(450);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104600,7 +104602,7 @@
         MaxHealth = 72, Health = 72,
         BaseDodge = 11,
     
-        Experience = 800,
+        Experience = 3800,
         
         Attacks = new CreatureAttackCollection
         {
@@ -104614,7 +104616,7 @@
     hobgoblin.AddGold(500);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104643,7 +104645,7 @@
         MaxHealth = 160, Health = 160,
         BaseDodge = 13,
     
-        Experience = 2000,
+        Experience = 8000,
     
         BasePenetration = ShieldPenetration.Light,
         
@@ -104659,7 +104661,7 @@
     martialartist.AddGold(650);
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104683,7 +104685,7 @@
         MaxHealth = 175, Health = 175,
         BaseDodge = 15,
     
-        Experience = 3000,
+        Experience = 6000,
         BasePenetration = ShieldPenetration.Medium,
         Immunity = CreatureImmunity.Web
     };
@@ -104700,7 +104702,7 @@
     ogre.AddGold(700);
     ogre.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
@@ -104725,7 +104727,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 11,
                 
-        Experience = 700,
+        Experience = 3100,
         
         CanFlee = true,
                 
@@ -104741,7 +104743,7 @@
     orc.AddGold(300);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104770,7 +104772,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
     
-        Experience = 2000,
+        Experience = 7500,
     
         BasePenetration = ShieldPenetration.Light,
             
@@ -104788,7 +104790,7 @@
     fighter.AddGold(700);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104812,7 +104814,7 @@
         MaxHealth = 100, Health = 100,
         BaseDodge = 12,
                 
-        Experience = 1100,
+        Experience = 4200,
                 
         Movement = 2,
                 
@@ -104830,7 +104832,7 @@
     troll.AddGold(500);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104854,7 +104856,7 @@
         MaxHealth = 65, Health = 65,
         BaseDodge = 11,
                 
-        Experience = 700,
+        Experience = 3700,
     };
     
     wolf.Attacks = new CreatureAttackCollection
@@ -104873,7 +104875,7 @@
     wolf.AddGold(300);
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -104898,7 +104900,7 @@
         MaxMana = 17, Mana = 17,
         BaseDodge = 11,
         
-        Experience = 1500,
+        Experience = 4500,
     };
     wraith.AddStatus(new NightVisionStatus(wraith));
         
@@ -104922,7 +104924,7 @@
     wraith.AddGold(650);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104946,7 +104948,7 @@
         MaxHealth = 70, Health = 70,
         BaseDodge = 11,
         
-        Experience = 900,
+        Experience = 4300,
         
         Movement = 2,
         
@@ -104968,13 +104970,13 @@
     
     lizard.Spells = new CreatureSpellCollection(80.0)
     {
-        new CreatureSpell<IceStormSpell>(8),
+        new CreatureSpell<IceStormSpell>(8), instantCast = true,
     };
     
     lizard.AddGold(500);
     lizard.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104998,7 +105000,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 11,
                 
-        Experience = 2500,
+        Experience = 5500,
                 
         BasePenetration = ShieldPenetration.VeryLight,
         CanSwim = true,
@@ -105021,7 +105023,7 @@
     bear.AddGold(500);
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    50),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105045,7 +105047,7 @@
         MaxHealth = 300, Health = 300,
         BaseDodge = 13,
                 
-        Experience = 5000,
+        Experience = 9000,
                 
         BasePenetration = ShieldPenetration.Medium,
             
@@ -105069,7 +105071,7 @@
     bear.AddGold(700);
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    75),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105137,7 +105139,7 @@
         
     drake.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<LightningBoltSpell>(10),
+        new CreatureSpell<LightningBoltSpell>(10), instantCast = true,
     };
     
     drake.AddGold(5000);
@@ -105175,7 +105177,7 @@
         MaxHealth = 5000, Health = 5000,
         BaseDodge = 19,
         
-        Experience = 55000,
+        Experience = 75000,
         
         CanFly = true,
         CanCharge = true,
@@ -105223,7 +105225,7 @@
         
     dragon.Spells = new CreatureSpellCollection(35.0)
     {
-        new CreatureSpell<DragonBreathIceSpell>(21),
+        new CreatureSpell<DragonBreathIceSpell>(21), instantCast = true,
     };
     //todo: add griffin figurine, protection from cold amulet (replaces f/i ammy)
     dragon.AddGold(6000);
@@ -105258,7 +105260,7 @@
         MaxHealth = 3500, Health = 3500,
         BaseDodge = 21,
     
-        Experience = 50000,
+        Experience = 53000,
         HideDetection = 27,
         CanJumpkick = true,
         
@@ -105304,7 +105306,7 @@
     
     yeti.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<DragonBreathIceSpell>(21),
+        new CreatureSpell<DragonBreathIceSpell>(21), instantCast = true,
     };
         
    yeti.AddGold(12000);
@@ -105626,7 +105628,7 @@
         MaxMana = 5, Mana = 5,
         BaseDodge = 12,
         
-        Experience = 1200,
+        Experience = 2500,
         
         VisibilityDistance = 1,
     };
@@ -105649,7 +105651,7 @@
     shadow.AddGold(600);
     shadow.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105679,7 +105681,7 @@
         MaxMana = 16, Mana = 16,
         BaseDodge = 12,
     
-        Experience = 2000,
+        Experience = 7000,
         
         CanSwim = true,
             
@@ -105708,7 +105710,7 @@
     wizard.AddGold(700);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105765,7 +105767,7 @@
     thaum.AddGold(750);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105795,7 +105797,7 @@
         MaxMana = 16, Mana = 16,
         BaseDodge = 13,
     
-        Experience = 2000,
+        Experience = 7000,
         
         CanSwim = true,
             
@@ -105824,7 +105826,7 @@
     wizard.AddGold(725);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105997,11 +105999,9 @@
     {
         MaxHealth = 200, Health = 200,
         BaseDodge = 14,
+        MaxMana = 50, Mana = 50,
     
-        Experience = 5000,
-    
-        Movement = 3,
-        
+        Experience = 9000,
         VisibilityDistance = 1,
         
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
@@ -106027,7 +106027,7 @@
     presence.Spells = new CreatureSpellCollection(100.0)
     {
         new CreatureSpell<IceStormSpell>(
-            skillLevel: 10, cost: 0,
+            skillLevel: 10, cost: 1,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -106056,7 +106056,7 @@
         BaseDodge = 13,
         Alignment = Alignment.Evil,
                 
-        Experience = 800,
+        Experience = 3800,
         BasePenetration = ShieldPenetration.Light,
         Attacks = new CreatureAttackCollection()
         {
@@ -106095,7 +106095,7 @@
         MaxHealth = 55, Health = 55,
         BaseDodge = 13,
         Alignment = Alignment.Evil,
-        Experience = 800,
+        Experience = 3800,
         BasePenetration = ShieldPenetration.Medium,
         Attacks = new CreatureAttackCollection()
         {

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -96135,7 +96135,7 @@
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon1Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    25),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, dungeon1Treasure,   2.5)
     ));
     
@@ -96178,7 +96178,7 @@
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon1Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    25),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, dungeon1Treasure,   2.5),
         
         new LootPackEntry(true, (from, container) => new ThrowingHammer(), 16)
@@ -96305,7 +96305,7 @@
     wyvern.AddGold(80);
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon1Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    25),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, dungeon1Treasure,   2.5)
     ));
     
@@ -96996,7 +96996,7 @@
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    16),
+        new LootPackEntry(true, dungeon2Bottles,    25),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6),
         
@@ -97039,7 +97039,7 @@
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       33,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    16),
+        new LootPackEntry(true, dungeon2Bottles,    25),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6)
     ));
@@ -97082,7 +97082,7 @@
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    20),
+        new LootPackEntry(true, dungeon2Bottles,    33),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6),
         
@@ -97125,7 +97125,7 @@
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    20),
+        new LootPackEntry(true, dungeon2Bottles,    33),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6)
     ));
@@ -97166,7 +97166,7 @@
     skeleton.AddGold(80);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    16),
+        new LootPackEntry(true, dungeon2Bottles,    25),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6),
         
@@ -97258,7 +97258,7 @@
     wyvern.AddGold(110);
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    20),
+        new LootPackEntry(true, dungeon2Bottles,    33),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6)
     ));
@@ -97308,7 +97308,7 @@
     wight.AddGold(120);
     wight.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       30,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    16),
+        new LootPackEntry(true, dungeon2Bottles,    25),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6)
     ));
@@ -97360,7 +97360,7 @@
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    20),
+        new LootPackEntry(true, dungeon2Bottles,    33),
         new LootPackEntry(true, dungeon2Treasure,   0.6),
         new LootPackEntry(true, dungeon2Rings,      0.6)
     ));
@@ -97485,7 +97485,7 @@ return orc;
     troll.AddGold(500);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -97527,7 +97527,7 @@ return orc;
     hobgoblin.AddGold(470);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -97569,7 +97569,7 @@ return orc;
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -97613,7 +97613,7 @@ return orc;
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -97655,7 +97655,7 @@ return orc;
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -97697,7 +97697,7 @@ return orc;
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -97750,7 +97750,7 @@ return orc;
     orc.AddGold(100);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -97798,7 +97798,7 @@ return orc;
     gargoyle.AddGold(700);
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       50,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    23),
+        new LootPackEntry(true, dungeon3Bottles,    50),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -97850,7 +97850,7 @@ return orc;
     salamander.Spells.Add(new CreatureSpell<FirewallSpell>(6), 100, TimeSpan.FromSeconds(15.0));
     
     salamander.AddLoot(new LootPack(
-        new LootPackEntry(true, dungeon3Bottles,    20), 
+        new LootPackEntry(true, dungeon3Bottles,    33), 
         new LootPackEntry(true, dungeon3Treasure,   0.6), 
         new LootPackEntry(true, dungeon3Rings,      0.6), 
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -97900,7 +97900,7 @@ return orc;
     wraith.AddGold(270);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -97952,7 +97952,7 @@ return orc;
     wight.AddGold(120);
     wight.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -97994,7 +97994,7 @@ return orc;
     orc.AddGold(225);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98038,7 +98038,7 @@ return orc;
     orc.AddGold(255);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98093,7 +98093,7 @@ return orc;
     orc.AddGold(255);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -98133,7 +98133,7 @@ return orc;
     troll.AddGold(625);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -98173,7 +98173,7 @@ return orc;
     hobgoblin.AddGold(500);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -98219,7 +98219,7 @@ return orc;
     gargoyle.AddGold(1000);
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98271,7 +98271,7 @@ return orc;
     salamander.Spells.Add(new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
     salamander.AddGold(500);
     salamander.AddLoot(new LootPack(
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.6), 
         new LootPackEntry(true, dungeon4Rings,      0.6), 
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98324,7 +98324,7 @@ return orc;
     wraith.AddGold(550);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98378,7 +98378,7 @@ return orc;
     spectre.AddGold(550);
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98428,7 +98428,7 @@ return orc;
     ghoul.AddGold(950);
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2)
@@ -98481,7 +98481,7 @@ return orc;
     minotaur.AddGold(650);
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    50),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98532,7 +98532,7 @@ return orc;
     fighter.AddGold(750);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98583,7 +98583,7 @@ return orc;
     fighter.AddGold(550);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98646,7 +98646,7 @@ return orc;
     wizard.AddGold(650);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98711,7 +98711,7 @@ return orc;
     thaum.AddGold(650);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),
@@ -98759,7 +98759,7 @@ return orc;
     
     boar.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    20),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
@@ -98804,7 +98804,7 @@ return orc;
     wolf.AddGold(75);
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    20),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
@@ -98892,7 +98892,7 @@ return orc;
     bear.AddGold(125);
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    20),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
@@ -98936,7 +98936,7 @@ return orc;
     orc.AddGold(150);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    20),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(),         1.6),
@@ -98979,7 +98979,7 @@ return orc;
     orc.AddGold(150);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon2Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    20),
+        new LootPackEntry(true, dungeon1Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(),         1.6),
@@ -99029,7 +99029,7 @@ return orc;
     wraith.AddGold(400);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon3Bottles,    20),
+        new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(),         1.6)
@@ -99081,7 +99081,7 @@ return orc;
     wight.AddGold(180);
     wight.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       33,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon2Bottles,    20),
+        new LootPackEntry(true, dungeon2Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(),     1.6)
@@ -99120,7 +99120,7 @@ return orc;
     centaur.AddGold(200);
     centaur.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
-        new LootPackEntry(true, dungeon1Bottles,    20),
+        new LootPackEntry(true, dungeon1Bottles,    50),
         new LootPackEntry(true, surfaceTreasure,    0.6),
         
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
@@ -99400,7 +99400,7 @@ return orc;
     wraith.AddGold(500);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, dungeon4Bottles,    20),
+        new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
         new LootPackEntry(true, dungeon3Potions,    0.2),

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -97847,7 +97847,7 @@ return orc;
     };
     
     salamander.Spells = new CreatureSpellCollection(50.0);
-    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(6), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
+    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(6), 100, TimeSpan.FromSeconds(15.0));
     
     salamander.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Bottles,    33), 
@@ -98268,7 +98268,7 @@ return orc;
     };
     
     salamander.Spells = new CreatureSpellCollection(50.0);
-    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
+    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0));
     salamander.AddGold(500);
     salamander.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Bottles,    33),
@@ -99520,7 +99520,7 @@ return orc;
         
     dragon.Spells = new CreatureSpellCollection(40.0)
     {
-        new CreatureSpell<DragonBreathFireSpell>(9), instantCast = true,
+        new CreatureSpell<DragonBreathFireSpell>(9),
     };
     
     //todo: add the +4 shining silver longsword in her loot chance (the purple one from OG). Add the binding "Agate gem" assuming the agate I added isn't it

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -97991,7 +97991,7 @@ return orc;
     orc.Wield(new Longsword());
     orc.Equip(new LeatherArmor());    
     
-    orc.AddGold(125);
+    orc.AddGold(225);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    20),
@@ -98035,7 +98035,7 @@ return orc;
     orc.Wield(new Longbow());
     orc.Equip(new LeatherArmor());    
     
-    orc.AddGold(125);
+    orc.AddGold(255);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    20),
@@ -98090,7 +98090,7 @@ return orc;
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
-    orc.AddGold(125);
+    orc.AddGold(255);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    20),
@@ -98268,9 +98268,8 @@ return orc;
     };
     
     salamander.Spells = new CreatureSpellCollection(50.0);
-    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0));
-    
-    salamander.AddGold(400);
+    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
+    salamander.AddGold(500);
     salamander.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Bottles,    20),
         new LootPackEntry(true, dungeon4Treasure,   0.6), 
@@ -98322,7 +98321,7 @@ return orc;
         
     wraith.Wield(new BlackStaff());
         
-    wraith.AddGold(350);
+    wraith.AddGold(550);
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    20),
@@ -98426,7 +98425,7 @@ return orc;
         { new CreatureBlock(4, "a claw") }, 
     };
     
-    ghoul.AddGold(350);
+    ghoul.AddGold(950);
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    20),
@@ -98530,7 +98529,7 @@ return orc;
     fighter.Wield(new SteelLongsword());
     fighter.Equip(new PlatemailArmor());    
     
-    fighter.AddGold(550);
+    fighter.AddGold(750);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    20),

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -97847,7 +97847,7 @@ return orc;
     };
     
     salamander.Spells = new CreatureSpellCollection(50.0);
-    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(6), 100, TimeSpan.FromSeconds(15.0));
+    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(6), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
     
     salamander.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon3Bottles,    33), 
@@ -99520,7 +99520,7 @@ return orc;
         
     dragon.Spells = new CreatureSpellCollection(40.0)
     {
-        new CreatureSpell<DragonBreathFireSpell>(9),
+        new CreatureSpell<DragonBreathFireSpell>(9), instantCast = true,
     };
     
     //todo: add the +4 shining silver longsword in her loot chance (the purple one from OG). Add the binding "Agate gem" assuming the agate I added isn't it
@@ -99556,62 +99556,6 @@ return orc;
             quest.SetStage(player, KnightsPurposeStage.Harriette);
         }
     }
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-    </entity>
-    <entity name="dpVendor">
-      <script name="OnSpawn" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    var female = Utility.RandomBool();
-    var vendor = new Merchant<PermanentConstitutionPotion>(16, 10, byte.MaxValue)
-    {
-        Name = "Dp",
-        
-        Body = (female ? 16 : 48), IsFemale = female,
-        
-        BaseDodge = 10,
-        MaxHealth = 50, Health = 50,
-        
-        Experience = 50,
-    };
-
-    return vendor;
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnDeath" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-    </entity>
-    <entity name="robeVendor">
-      <script name="OnSpawn" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    var female = Utility.RandomBool();
-    var vendor = new Merchant<StarsRobe>(16, 10, byte.MaxValue)
-    {
-        Name = "Robe",
-        
-        Body = (female ? 16 : 48), IsFemale = female,
-        
-        BaseDodge = 10,
-        MaxHealth = 50, Health = 50,
-        
-        Experience = 50,
-    };
-
-    return vendor;
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnDeath" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -100592,46 +100536,6 @@ return orc;
       </script>
       <entry entity="enragedTroll" size="1" minimum="1" maximum="2" />
       <location x="24" y="33" region="12" />
-    </spawn>
-    <spawn type="LocationSpawner" name="kesmaiDPVendor">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>900</maximumDelay>
-      <script name="OnAfterSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <entry entity="dpVendor" size="1" minimum="1" maximum="1" />
-      <location x="33" y="8" region="1" />
-    </spawn>
-    <spawn type="LocationSpawner" name="kesmaiRobeVendor">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>900</maximumDelay>
-      <script name="OnAfterSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <entry entity="robeVendor" size="1" minimum="1" maximum="1" />
-      <location x="33" y="9" region="1" />
     </spawn>
     <spawn type="RegionSpawner" name="Kesmai -1">
       <minimumDelay>600</minimumDelay>

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -82352,8 +82352,8 @@
         </component>
       </tile>
       <tile x="15" y="23">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="DoorComponent">
           <openId>74</openId>
@@ -83756,8 +83756,8 @@
         </component>
       </tile>
       <tile x="25" y="28">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
       </tile>
       <tile x="26" y="28">
@@ -98745,8 +98745,8 @@ return orc;
     
     boar.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(5,     1, 8,   "You have been gored by the boar."),    60 }, 
-        { new CreatureAttack(6,     2, 10,  "The boar tramples you."),              40 }, 
+        { new CreatureAttack(5,     1, 5,   "You have been gored by the boar."),    60 }, 
+        { new CreatureAttack(6,     2, 6,  "The boar tramples you."),              40 }, 
     };
 
     boar.Blocks = new CreatureBlockCollection
@@ -98790,9 +98790,9 @@ return orc;
     
     wolf.Attacks = new CreatureAttackCollection
     {
-        { new CreatureAttack(5,     1, 8,   "The wolf rakes you with its claws."),  50 }, 
-        { new CreatureAttack(7,     2, 10,  "The wolf sinks its teeth into you."),  30 }, 
-        { new CreatureAttack(7,     3, 12,  "The wolf lunges at you."),             20 }, 
+        { new CreatureAttack(5,     1, 4,   "The wolf rakes you with its claws."),  50 }, 
+        { new CreatureAttack(7,     2, 5,  "The wolf sinks its teeth into you."),  30 }, 
+        { new CreatureAttack(7,     3, 6,  "The wolf lunges at you."),             20 }, 
     };
         
     wolf.Blocks = new CreatureBlockCollection
@@ -98837,7 +98837,7 @@ return orc;
     
     bee.Attacks = new CreatureAttackCollection
     {
-        new CreatureAttack(5,   1, 3,   "You have been stung by a bee.", 
+        new CreatureAttack(5,   1, 2,   "You have been stung by a bee.", 
                                             new AttackPoisonComponent(3)), 
     };
         
@@ -98927,7 +98927,7 @@ return orc;
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(5),
+        new CreatureBasicAttack(5, 1, 5),
     };
     
     orc.Wield(new Longsword());
@@ -98970,7 +98970,7 @@ return orc;
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(5),
+        new CreatureBasicAttack(3),
     };
     
     orc.Wield(new Crossbow());

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -78709,7 +78709,7 @@
       </entry>
     </treasure>
     <treasure name="MinotaurTreasures">
-      <entry weight="1">
+      <entry weight="2">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -78718,7 +78718,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="2">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75158,15 +75158,14 @@
     
     wizard.Spells = new CreatureSpellCollection
     {
-        //removed instantCast = true, here to double check if spells are by default instant now
         { new CreatureSpell<ConcussionSpell>(
-            skillLevel: 5, cost: 16, 
-            mantra: SpellHelper.GenerateMantra(),   50 },
+            skillLevel: 5, cost: 16, instantCast: false,
+            mantra: SpellHelper.GenerateMantra()),   50 },
         { new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 8, cost: 6, 
-            mantra: SpellHelper.GenerateMantra(),   25 },
+            skillLevel: 8, cost: 6, instantCast: false,
+            mantra: SpellHelper.GenerateMantra()),   25 },
         { new CreatureSpell<IceStormSpell>(
-            skillLevel: 8, cost: 6, 
+            skillLevel: 8, cost: 6, instantCast: false,
             mantra: SpellHelper.GenerateMantra()),   25 }
     };
     
@@ -75865,7 +75864,7 @@
         
     dragon.Spells = new CreatureSpellCollection(40.0)
     {
-        new CreatureSpell<DragonBreathFireSpell>(14), instantCast = true,
+        new CreatureSpell<DragonBreathFireSpell>(14),
     };
     
     dragon.AddGold(10000);
@@ -75928,7 +75927,7 @@
     
     vlad.Spells = new CreatureSpellCollection(25.0)
     {
-        new CreatureSpell<DeathSpell>(12), instantCast = true, 
+        new CreatureSpell<DeathSpell>(12) 
     };
     
     vlad.AddGold(25000);
@@ -76012,7 +76011,7 @@
         
     drake.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<LightningBoltSpell>(13), instantCast = true,
+        new CreatureSpell<LightningBoltSpell>(13)
     };
     
     drake.AddGold(2000);
@@ -76350,7 +76349,7 @@
     };
     
     salamander.Spells = new CreatureSpellCollection(50.0);
-    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(13), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
+    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(13), 100, TimeSpan.FromSeconds(15.0));
     
     salamander.AddGold(800);
     salamander.AddLoot(new LootPack(

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -74754,13 +74754,13 @@
         MaxHealth = 90, Health = 90,
         BaseDodge = 10,
 
-        Experience = 1500,
+        Experience = 3100,
 
         Movement = 2,
                 
         Attacks = new CreatureAttackCollection()
         {
-            new CreatureBasicAttack(8, 10, 18)
+            new CreatureBasicAttack(8, 6, 15)
         },
     };
     
@@ -75088,7 +75088,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 12,
         
-        Experience = 1700,
+        Experience = 3200,
     };
     wraith.AddStatus(new NightVisionStatus(wraith));
         
@@ -75141,7 +75141,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
     
-        Experience = 2000,
+        Experience = 7500,
         
         CanSwim = true,
             
@@ -75158,15 +75158,16 @@
     
     wizard.Spells = new CreatureSpellCollection
     {
+        //removed instantCast = true, here to double check if spells are by default instant now
         { new CreatureSpell<ConcussionSpell>(
             skillLevel: 5, cost: 16, 
-            mantra: SpellHelper.GenerateMantra(), instantCast: false),   50 },
+            mantra: SpellHelper.GenerateMantra(),   50 },
         { new CreatureSpell<MagicMissileSpell>(
             skillLevel: 8, cost: 6, 
-            mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 },
+            mantra: SpellHelper.GenerateMantra(),   25 },
         { new CreatureSpell<IceStormSpell>(
             skillLevel: 8, cost: 6, 
-            mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 }
+            mantra: SpellHelper.GenerateMantra()),   25 }
     };
     
     wizard.AddGold(450);
@@ -75200,7 +75201,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 13,
     
-        Experience = 2000,
+        Experience = 7000,
         
         CanSwim = true,
             
@@ -75253,7 +75254,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
     
-        Experience = 1800,
+        Experience = 6500,
     
         VisibilityDistance = 1,
     };
@@ -75303,11 +75304,11 @@
         MaxHealth = 90, Health = 90,
         BaseDodge = 11,
     
-        Experience = 1400,
+        Experience = 2300,
         BasePenetration = ShieldPenetration.VeryLight,
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(10, 13, 19) }, 
+            { new CreatureBasicAttack(10, 9, 17) }, 
         },
     };
     
@@ -75342,7 +75343,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 12,
     
-        Experience = 1700,
+        Experience = 2600,
     
     };
     hobgoblin.AddStatus(new NightVisionStatus(hobgoblin));
@@ -75398,7 +75399,7 @@
         
         Movement = 2,
     
-        Experience = 1300,
+        Experience = 4400,
             
     };
     
@@ -75440,7 +75441,7 @@
         BaseDodge = 12,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 0,
-        Experience = 500,
+        Experience = 700,
     };
     
     raven.Attacks = new CreatureAttackCollection
@@ -75529,7 +75530,7 @@
         MaxHealth = 750, Health = 750,
         BaseDodge = 15,
 
-        Experience = 6500,
+        Experience = 10500,
         BasePenetration = ShieldPenetration.Medium,
         Attacks = new CreatureAttackCollection
         {
@@ -75572,7 +75573,7 @@
         MaxHealth = 600, Health = 600,
         BaseDodge = 14,
         HideDetection = 18,
-        Experience = 7500,
+        Experience = 11500,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 1,
         
@@ -75631,7 +75632,7 @@
         MaxMana = 50, Mana = 50,
         BaseDodge = 14,
     
-        Experience = 7000,
+        Experience = 12000,
     
         VisibilityDistance = 0,
         
@@ -75691,7 +75692,7 @@
         MaxHealth = 3000, Health = 3000,
         BaseDodge = 23,
         HideDetection = 24,
-        Experience = 22000,
+        Experience = 32000,
         
         VisibilityDistance = 0,
        
@@ -75822,7 +75823,7 @@
         MaxHealth = 3000, Health = 3000,
         BaseDodge = 18,
         HideDetection = 22,
-        Experience = 20000,
+        Experience = 40000,
         
         CanFly = true,
         CanCharge = true,
@@ -75864,7 +75865,7 @@
         
     dragon.Spells = new CreatureSpellCollection(40.0)
     {
-        new CreatureSpell<DragonBreathFireSpell>(14),
+        new CreatureSpell<DragonBreathFireSpell>(14), instantCast = true,
     };
     
     dragon.AddGold(10000);
@@ -75899,7 +75900,7 @@
         MaxHealth = 7000, Health = 7000,
         BaseDodge = 20,
         BasePenetration = ShieldPenetration.VeryHeavy,
-        Experience = 55000,
+        Experience = 95000,
         HideDetection = 28,
         CanCharge = true,
         
@@ -75927,7 +75928,7 @@
     
     vlad.Spells = new CreatureSpellCollection(25.0)
     {
-        new CreatureSpell<DeathSpell>(12),
+        new CreatureSpell<DeathSpell>(12), instantCast = true, 
     };
     
     vlad.AddGold(25000);
@@ -75967,7 +75968,7 @@
         
         Alignment = Alignment.Chaotic,
         HideDetection = 27,
-        Experience = 50000,
+        Experience = 85000,
         
         CanFly = true,
         CanCharge = true,
@@ -76011,7 +76012,7 @@
         
     drake.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<LightningBoltSpell>(13),
+        new CreatureSpell<LightningBoltSpell>(13), instantCast = true,
     };
     
     drake.AddGold(2000);
@@ -76048,7 +76049,7 @@
         MaxHealth = 300, Health = 300,
         BaseDodge = 15,
                 
-        Experience = 6000,
+        Experience = 10000,
     };
     griffin.AddStatus(new NightVisionStatus(griffin));
         
@@ -76099,12 +76100,11 @@
         MaxHealth = 155, Health = 155,
         BaseDodge = 15,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 3200,
+        Experience = 7000,
+        CanSwim = true,
             
     };
-    
-    fighter.AddStatus(new NightVisionStatus(fighter));
-    
+        
     fighter.Attacks = new CreatureAttackCollection
     {
         new CreatureBasicAttack(11, 20, 28), 
@@ -76140,7 +76140,7 @@
         MaxHealth = 160, Health = 160,
         BaseDodge = 16,
     
-        Experience = 5500,
+        Experience = 9500,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
         
@@ -76185,8 +76185,8 @@
         MaxHealth = 100, Health = 100,
         MaxMana = 19, Mana = 19,
         BaseDodge = 14,
-        
-        Experience = 4500,
+        MagicProtection = 33,
+        Experience = 6500,
         VisibilityDistance = 0,
     };
     lich.AddStatus(new NightVisionStatus(lich));
@@ -76234,14 +76234,13 @@
         Name = "Nomad",
         Body = (female ? 33 : 32), IsFemale = female,
             
-        MaxHealth = 110, Health = 110,
+        MaxHealth = 120, Health = 120,
         BaseDodge = 14,
             
-        Experience = 2800,
-            
+        Experience = 6800,
+        CanSwim = true,
     };
     
-    fighter.AddStatus(new NightVisionStatus(fighter));
     
     fighter.Attacks = new CreatureAttackCollection
     {
@@ -76251,7 +76250,7 @@
     fighter.Wield(new FineCrossbow());
     fighter.Equip(new LeatherArmor());    
     
-    fighter.AddGold(370);
+    fighter.AddGold(470);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
@@ -76278,7 +76277,7 @@
         MaxHealth = 300, Health = 300,
         BaseDodge = 18,
     
-        Experience = 5500,
+        Experience = 15500,
     
         CanCharge = true,
         BasePenetration = ShieldPenetration.Medium,
@@ -76329,10 +76328,10 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 16,
         
-        Experience = 3025,
+        Experience = 9025,
         
         Movement = 2,
-        
+        MagicProtection = 33,
         FireProtection = 100,
         VisibilityDistance = 0,
     };
@@ -76351,7 +76350,7 @@
     };
     
     salamander.Spells = new CreatureSpellCollection(50.0);
-    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(13), 100, TimeSpan.FromSeconds(15.0));
+    salamander.Spells.Add(new CreatureSpell<FirewallSpell>(13), 100, TimeSpan.FromSeconds(15.0), instantCast = true);
     
     salamander.AddGold(800);
     salamander.AddLoot(new LootPack(
@@ -76379,9 +76378,10 @@
         MaxHealth = 300, Health = 300,
         BaseDodge = 15,
         BasePenetration = ShieldPenetration.Medium,
-        Experience = 5000,
+        Experience = 12000,
         VisibilityDistance = 0,
         FireProtection = 100,
+        MagicProtection = 33,
     };
     griffin.AddStatus(new NightVisionStatus(griffin));
         
@@ -76427,7 +76427,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
                             
-        Experience = 2700,
+        Experience = 3700,
     };
     
     centaur.Attacks = new CreatureAttackCollection
@@ -76465,7 +76465,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 14,
     
-        Experience = 1300,
+        Experience = 2300,
     
         VisibilityDistance = 1,
         
@@ -76513,7 +76513,7 @@
         MaxHealth = 90, Health = 90,
         BaseDodge = 11,
     
-        Experience = 1100,
+        Experience = 2100,
         
     };
     
@@ -76555,7 +76555,7 @@
         MaxHealth = 35, Health = 35,
         BaseDodge = 9,
                 
-        Experience = 105,
+        Experience = 500,
     
         BasePenetration = ShieldPenetration.VeryLight,
     };
@@ -76598,8 +76598,8 @@
             
         MaxHealth = 130, Health = 130,
         BaseDodge = 14,
-    
-        Experience = 4000,
+        MagicProtection = 33,
+        Experience = 8000,
     
         BasePenetration = ShieldPenetration.Medium,
             
@@ -76645,10 +76645,10 @@
             
         MaxHealth = 180, Health = 180,
         BaseDodge = 15,
-        
+        MagicProtection = 33,
         BasePenetration = ShieldPenetration.Medium,
     
-        Experience = 4750,
+        Experience = 8750,
             
     };
     
@@ -76692,8 +76692,8 @@
         MaxHealth = 130, Health = 130,
         MaxMana = 23, Mana = 23,
         BaseDodge = 14,
-    
-        Experience = 3050,
+        MagicProtection = 33,
+        Experience = 8050,
     
         VisibilityDistance = 0,
     };
@@ -76745,7 +76745,7 @@
         MaxHealth = 178, Health = 178,
         BaseDodge = 14,
         BasePenetration = ShieldPenetration.Medium,     
-        Experience = 4700,
+        Experience = 8700,
     };
     
     centaur.AddStatus(new NightVisionStatus(centaur));
@@ -76783,7 +76783,7 @@
         MaxHealth = 550, Health = 550,
         BaseDodge = 15,
                 
-        Experience = 10000,
+        Experience = 18000,
         BasePenetration = ShieldPenetration.Light,
         CanSwim = true,
     };
@@ -76828,7 +76828,7 @@
         CanSwim = true,
         CanJumpkick = true,
                 
-        Experience = 14000,
+        Experience = 22000,
         Alignment = Alignment.Chaotic,
     };
     
@@ -76870,7 +76870,7 @@
     {
         MaxHealth = 110, Health = 110,
         BaseDodge = 14,
-        Experience = 1700,
+        Experience = 6200,
         
         CanFlee = true,
                 
@@ -76910,7 +76910,7 @@
         MaxHealth = 105, Health = 105,
         BaseDodge = 15,
                 
-        Experience = 1300,
+        Experience = 5900,
     };
     
     wolf.Attacks = new CreatureAttackCollection
@@ -76953,7 +76953,7 @@
         MaxHealth = 125, Health = 125,
         BaseDodge = 15,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 2000,
+        Experience = 6900,
                        
         Attacks = new CreatureAttackCollection()
         {
@@ -76991,7 +76991,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 14,
                 
-        Experience = 1000,
+        Experience = 2500,
     };
     
     hyena.Attacks = new CreatureAttackCollection
@@ -77027,7 +77027,7 @@
     {
         MaxHealth = 90, Health = 90,
         BaseDodge = 14,
-        Experience = 1700,
+        Experience = 5700,
         
         CanFlee = true,
                 
@@ -77067,7 +77067,7 @@
         MaxHealth = 220, Health = 220,
         BaseDodge = 14,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 3500,
+        Experience = 11500,
             
         
     };
@@ -77116,7 +77116,7 @@
         MaxMana = 8, Mana = 8,
         BaseDodge = 12,
     
-        Experience = 725,
+        Experience = 1725,
         
         CanFlee = true,
     };

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -71548,33 +71548,12 @@
       </tile>
       <tile x="14" y="40">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <ground>179</ground>
         </component>
       </tile>
       <tile x="15" y="40">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <ground>179</ground>
         </component>
       </tile>
       <tile x="16" y="40">

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.69.0.0">
+<segment name="Oakvael" version="0.70.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -84554,7 +84554,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 15,
 
-        Experience = 1350,
+        Experience = 2350,
         
         Attacks = new CreatureAttackCollection
         {
@@ -84577,7 +84577,7 @@
     };
     griffin.AddStatus(new NightVisionStatus(griffin));    
 
-    griffin.AddGold(450);
+    griffin.AddGold(1050);
     griffin.AddLoot(new LootPack(
             new LootPackEntry(true, (from, container) => new OchreEgg(), 25.0), 
             new LootPackEntry(true, (from, container) => new ClearBalm(), 50.0), 
@@ -84604,7 +84604,7 @@
         MaxHealth = 46, Health = 46,
         BaseDodge = 12,
 
-        Experience = 425,
+        Experience = 625,
 
         Movement = 2,
 
@@ -84647,7 +84647,7 @@
         MaxHealth = 140, Health = 140,
         BaseDodge = 14,
 
-        Experience = 1200,
+        Experience = 2200,
         
         Attacks = new CreatureAttackCollection
         {
@@ -84663,7 +84663,7 @@
     };
     largeBear.AddStatus(new NightVisionStatus(largeBear));    
 
-    largeBear.AddGold(750);
+    largeBear.AddGold(1450);
     largeBear.AddLoot(
         new LootPack(
             new LootPackEntry(true, surfaceGems, 25.0, gemsPriceMutator), 
@@ -84691,13 +84691,13 @@
         MaxHealth = 32, Health = 32,
         BaseDodge = 12,
 
-        Experience = 250,
+        Experience = 350,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureAttack(6, 2, 8, "The wolf rakes you with its claws."), 50 }, 
-            { new CreatureAttack(7, 3, 10, "The wolf sinks its teeth into you."), 30 }, 
-            { new CreatureAttack(7, 4, 12, "The wolf lunges at you."), 20 }, 
+            { new CreatureAttack(6, 2, 5, "The wolf rakes you with its claws."), 50 }, 
+            { new CreatureAttack(7, 3, 6, "The wolf sinks its teeth into you."), 30 }, 
+            { new CreatureAttack(7, 4, 8, "The wolf lunges at you."), 20 }, 
         },
         Blocks = new CreatureBlockCollection
         {
@@ -84731,15 +84731,15 @@
         <block><![CDATA[
 	var boar = new Boar()
     {
-        MaxHealth = 38, Health = 38,
+        MaxHealth = 33, Health = 33,
         BaseDodge = 12,
 
-        Experience = 325,
+        Experience = 425,
         
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureAttack(5, 2, 8, "You have been gored by the boar."), 60 }, 
-            { new CreatureAttack(6, 3, 10, "The boar tramples you."), 40 }, 
+            { new CreatureAttack(5, 2, 6, "You have been gored by the boar."), 60 }, 
+            { new CreatureAttack(6, 3, 8, "The boar tramples you."), 40 }, 
         },
         Blocks = new CreatureBlockCollection
         {
@@ -84773,7 +84773,7 @@
         <block><![CDATA[
 	var beetle = new Beetle()
     {
-        MaxHealth = 40, Health = 40,
+        MaxHealth = 25, Health = 25,
         BaseDodge = 12,
 
         Experience = 250,
@@ -84782,7 +84782,7 @@
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureAttack(7, 1, 8, "You have been stung by a beetle.",
+            { new CreatureAttack(6, 1, 8, "You have been stung by a beetle.",
                 new AttackPoisonComponent(3), 
                 new AttackStunComponent(10)), 10 }, 
         },
@@ -84827,7 +84827,7 @@
     orc.Wield(new Katana());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(350);
+    orc.AddGold(250);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, surfaceGems, 25.0, gemsPriceMutator), 
@@ -84896,7 +84896,7 @@
         MaxHealth = 60, Health = 60,
         BaseDodge = 13,
 
-        Experience = 525,
+        Experience = 725,
 
         Attacks = new CreatureAttackCollection
         {
@@ -84937,7 +84937,7 @@
         MaxHealth = 90, Health = 90,
         BaseDodge = 12,
 
-        Experience = 700,
+        Experience = 1100,
 
         Movement = 2,
 
@@ -85006,7 +85006,7 @@
         Weakness = CreatureWeakness.Silver | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
     };    
 
-    wyrm.AddGold(250);
+    wyrm.AddGold(850);
     wyrm.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0), 
@@ -85141,7 +85141,7 @@
     scorpion.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon1Bottles, 20.0), 
+            new LootPackEntry(true, dungeon1Bottles, 33.0), 
             new LootPackEntry(true, dungeon1Treasure, 0.63)
         ));
 
@@ -85182,7 +85182,7 @@
     kobold.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon1Bottles, 20.0), 
+            new LootPackEntry(true, dungeon1Bottles, 33.0), 
             new LootPackEntry(true, dungeon1Treasure, 0.63)
         ));
 
@@ -85225,7 +85225,7 @@
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon1Bottles, 20.0), 
+            new LootPackEntry(true, dungeon1Bottles, 33.0), 
             new LootPackEntry(true, dungeon1Treasure, 0.63)
         ));
 
@@ -85266,7 +85266,7 @@
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon1Bottles, 20.0), 
+            new LootPackEntry(true, dungeon1Bottles, 33.0), 
             new LootPackEntry(true, dungeon1Treasure, 0.63)
         ));
 
@@ -85305,11 +85305,11 @@
     troll.Wield(new Greatsword());
     troll.Equip(new ChainmailArmor());    
 
-    troll.AddGold(200);
+    troll.AddGold(300);
     troll.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon1Bottles, 20.0), 
+            new LootPackEntry(true, dungeon1Bottles, 33.0), 
             new LootPackEntry(true, dungeon1Treasure, 0.63)
         ));
 
@@ -85355,7 +85355,7 @@
     spider.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon1Bottles, 20.0), 
+            new LootPackEntry(true, dungeon1Bottles, 33.0), 
             new LootPackEntry(true, dungeon1Treasure, 0.63)
         ));
 
@@ -85379,7 +85379,7 @@
         MaxHealth = 52, Health = 52,
         BaseDodge = 14,
 
-        Experience = 500,
+        Experience = 700,
 
         Movement = 2,
 
@@ -85392,11 +85392,11 @@
     hobgoblin.Wield(new Longsword());
     hobgoblin.Equip(new LeatherArmor());    
 
-    hobgoblin.AddGold(500);
+    hobgoblin.AddGold(350);
     hobgoblin.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85422,7 +85422,7 @@
         MaxHealth = 42, Health = 42,
         BaseDodge = 13,
 
-        Experience = 450,
+        Experience = 550,
 
         Attacks = new CreatureAttackCollection
         {
@@ -85437,7 +85437,7 @@
     goblin.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85463,7 +85463,7 @@
         MaxHealth = 42, Health = 42,
         BaseDodge = 13,
 
-        Experience = 450,
+        Experience = 550,
 
         Attacks = new CreatureAttackCollection
         {
@@ -85474,11 +85474,11 @@
     goblin.Wield(new Longbow());
     goblin.Equip(new LeatherArmor());    
 
-    goblin.AddGold(120);
+    goblin.AddGold(150);
     goblin.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85504,7 +85504,7 @@
         MaxHealth = 75, Health = 75,
         BaseDodge = 14,
 
-        Experience = 500,
+        Experience = 920,
 
         Movement = 2,
 
@@ -85524,7 +85524,7 @@
     troll.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85550,7 +85550,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 13,
 
-        Experience = 425,
+        Experience = 555,
         
         CanFlee = true,
 
@@ -85567,7 +85567,7 @@
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85593,7 +85593,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 13,
 
-        Experience = 325,
+        Experience = 555,
 
         CanFlee = true,
 
@@ -85610,7 +85610,7 @@
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85637,7 +85637,7 @@
         MaxMana = 12, Mana = 12,
         BaseDodge = 13,
 
-        Experience = 425,
+        Experience = 625,
         
         CanFlee = true,
 
@@ -85658,7 +85658,7 @@
     orc.Wield(new WoodenStaff());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(200);
+    orc.AddGold(250);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
@@ -85687,7 +85687,7 @@
         MaxMana = 17, Mana = 17,
         BaseDodge = 14,
 
-        Experience = 550,
+        Experience = 950,
 
         VisibilityDistance = 1,
 
@@ -85712,7 +85712,7 @@
     spectre.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
-            new LootPackEntry(true, dungeon2Bottles, 20.0), 
+            new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -85740,7 +85740,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 15,
 
-        Experience = 900,
+        Experience = 1200,
 
         Movement = 2,
 
@@ -85753,11 +85753,11 @@
     hobgoblin.Wield(new Longsword());
     hobgoblin.Equip(new LeatherArmor());    
 
-    hobgoblin.AddGold(700);
+    hobgoblin.AddGold(650);
     hobgoblin.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -85783,7 +85783,7 @@
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
 
-        Experience = 600,
+        Experience = 900,
         
         CanFlee = true,
 
@@ -85796,11 +85796,11 @@
     orc.Wield(new Longsword());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(150);
+    orc.AddGold(450);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -85826,7 +85826,7 @@
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
 
-        Experience = 600,
+        Experience = 900,
         
         CanFlee = true,
 
@@ -85839,11 +85839,11 @@
     orc.Wield(new Longbow());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(150);
+    orc.AddGold(450);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -85870,7 +85870,7 @@
         MaxMana = 12, Mana = 12,
         BaseDodge = 14,
 
-        Experience = 575,
+        Experience = 975,
 
         CanFlee = true,
 
@@ -85890,11 +85890,11 @@
     orc.Wield(new WoodenStaff());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(150);
+    orc.AddGold(450);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -85920,7 +85920,7 @@
         MaxHealth = 98, Health = 98,
         BaseDodge = 16,
 
-        Experience = 850,
+        Experience = 1250,
         
         Attacks = new CreatureAttackCollection
         {
@@ -85935,7 +85935,7 @@
     troll.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -85967,7 +85967,7 @@
         MaxMana = 18, Mana = 18,
         BaseDodge = 15,
 
-        Experience = 2100,
+        Experience = 3000,
         
         CanFlee = true,
         CanSwim = true,
@@ -85994,7 +85994,7 @@
     thaum.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -86026,7 +86026,7 @@
         MaxMana = 21, Mana = 21,
         BaseDodge = 15,
 
-        Experience = 2100,
+        Experience = 3000,
 
         CanFlee = true,
         CanSwim = true,
@@ -86052,7 +86052,7 @@
     wizard.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -86079,7 +86079,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 15,
 
-        Experience = 1100,
+        Experience = 2700,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
 
@@ -86107,7 +86107,7 @@
         new LootPack(
             new LootPackEntry(true, (from, container) => new SerpentRobe(), 2.5),
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -86133,7 +86133,7 @@
         MaxHealth = 125, Health = 125,
         BaseDodge = 15,
 
-        Experience = 2150,
+        Experience = 2350,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
         
@@ -86163,7 +86163,7 @@
     gargoyle.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14)
         ));
 
@@ -86187,7 +86187,7 @@
         MaxHealth = 71, Health = 71,
         BaseDodge = 15,
 
-        Experience = 725,
+        Experience = 1325,
 
         Movement = 2,
 
@@ -86204,7 +86204,7 @@
         },
         Spells = new CreatureSpellCollection(50.0)
         {
-            { new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0) }
+            { new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0), instantCast = true }
         }
     };    
 
@@ -86234,7 +86234,7 @@
         MaxHealth = 500, Health = 500,
         BaseDodge = 18,
 
-        Experience = 5000,
+        Experience = 9500,
 
         Movement = 2,
 
@@ -86269,7 +86269,7 @@
         new LootPack(
             new LootPackEntry(true, (from, container) => new PermanentConstitutionPotion(), 50.00),
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -86300,7 +86300,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 120, Health = 120,
         BaseDodge = 16,
 
-        Experience = 900,
+        Experience = 2500,
 
         CanWalk = false,
 
@@ -86317,7 +86317,7 @@ PROTECTION P_DEATH 40
     pescalanor.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0), 
-            new LootPackEntry(true, dungeon3Bottles, 20.0), 
+            new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2) 
@@ -86343,7 +86343,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 130, Health = 130,
         BaseDodge = 17,
 
-        Experience = 2200,
+        Experience = 2700,
 
         Movement = 2,
         CanFly = true,
@@ -86371,7 +86371,9 @@ PROTECTION P_DEATH 40
     gargoyle.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
+            new LootPackEntry(true, dungeon4Treasure, 0.63), 
+            new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14)
         ));
 
@@ -86395,7 +86397,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 160, Health = 160,
         BaseDodge = 17,
 
-        Experience = 2500,
+        Experience = 3200,
 
         CanFlee = true,
         BasePenetration = ShieldPenetration.Medium,
@@ -86418,11 +86420,11 @@ PROTECTION P_DEATH 40
     minotaur.Wield(new Greatsword());
     minotaur.Equip(new PlatemailArmor());    
 
-    minotaur.AddGold(950);
+    minotaur.AddGold(1250);
     minotaur.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86448,7 +86450,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 88, Health = 88,
         BaseDodge = 16,
 
-        Experience = 950,
+        Experience = 1450,
         
         Attacks = new CreatureAttackCollection
         {
@@ -86463,7 +86465,7 @@ PROTECTION P_DEATH 40
     hobgoblin.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86489,7 +86491,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 110, Health = 110,
         BaseDodge = 18,
 
-        Experience = 1800,
+        Experience = 1700,
 
         Movement = 2,
 
@@ -86508,7 +86510,7 @@ PROTECTION P_DEATH 40
     troll.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86534,7 +86536,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 71, Health = 71,
         BaseDodge = 16,
 
-        Experience = 700,
+        Experience = 1100,
 
         CanFlee = true,
 
@@ -86547,11 +86549,11 @@ PROTECTION P_DEATH 40
     orc.Wield(new Longsword());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(175);
+    orc.AddGold(675);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86577,7 +86579,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 71, Health = 71,
         BaseDodge = 16,
 
-        Experience = 700,
+        Experience = 1025,
 
         CanFlee = true,
 
@@ -86590,11 +86592,11 @@ PROTECTION P_DEATH 40
     orc.Wield(new Longbow());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(175);
+    orc.AddGold(675);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86626,7 +86628,7 @@ PROTECTION P_DEATH 40
         MaxMana = 18, Mana = 18,
         BaseDodge = 17,
 
-        Experience = 2500,
+        Experience = 3500,
 
         CanFlee = true,
         CanSwim = true,
@@ -86652,7 +86654,7 @@ PROTECTION P_DEATH 40
     thaum.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86684,7 +86686,7 @@ PROTECTION P_DEATH 40
         MaxMana = 21, Mana = 21,
         BaseDodge = 17,
 
-        Experience = 2600,
+        Experience = 3300,
 
         CanFlee = true,
         CanSwim = true,
@@ -86710,7 +86712,7 @@ PROTECTION P_DEATH 40
     wizard.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86738,7 +86740,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 80, Health = 80,
         BaseDodge = 17,
 
-        Experience = 800,
+        Experience = 1450,
 
         Movement = 2,
 
@@ -86759,7 +86761,7 @@ PROTECTION P_DEATH 40
         }
     };    
 
-    salamander.AddGold(600);
+    salamander.AddGold(900);
     salamander.AddLoot(
         new LootPack(
             new LootPackEntry(true, (from, container) => new FieryRuby(1700u), 100.0)
@@ -86802,11 +86804,11 @@ PROTECTION P_DEATH 40
     drizilu.Wield(new Crossbow());
     drizilu.Equip(new PlatemailArmor());    
 
-    drizilu.AddGold(600);
+    drizilu.AddGold(900);
     drizilu.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86849,11 +86851,11 @@ PROTECTION P_DEATH 40
     glamuzu.Wield(new Crossbow());
     glamuzu.Equip(new PlatemailArmor());    
 
-    glamuzu.AddGold(600);
+    glamuzu.AddGold(900);
     glamuzu.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0), 
-            new LootPackEntry(true, dungeon4Bottles, 20.0), 
+            new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.2)
@@ -86880,11 +86882,11 @@ PROTECTION P_DEATH 40
         MaxMana = 5, Mana = 5,
         BaseDodge = 18,
 
-        Experience = 2875,
+        Experience = 3475,
         
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(14) },
+            { new CreatureBasicAttack(14, 11, 25) },
         },
         Spells = new CreatureSpellCollection()
         {
@@ -86895,10 +86897,10 @@ PROTECTION P_DEATH 40
 
     banshee.Wield(new Spear());    
 
-    banshee.AddGold(700);
+    banshee.AddGold(900);
     banshee.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -86934,17 +86936,17 @@ PROTECTION P_DEATH 40
         },
         Spells = new CreatureSpellCollection()
         {
-            { new CreatureSpell<CurseSpell>(1.5, cost: 3), 100 }
+            { new CreatureSpell<CurseSpell>(9.5, cost: 3), 100 }
         }
     };
     banshee.AddStatus(new NightVisionStatus(banshee));
 
     banshee.Wield(new Spear());    
 
-    banshee.AddGold(700);
+    banshee.AddGold(850);
     banshee.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -86976,7 +86978,7 @@ PROTECTION P_DEATH 40
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(14) },
+            { new CreatureBasicAttack(14, 15, 20) },
         },
         Spells = new CreatureSpellCollection()
         {
@@ -86990,10 +86992,10 @@ PROTECTION P_DEATH 40
 
     wraith.Wield(new BlackStaff());    
 
-    wraith.AddGold(810);
+    wraith.AddGold(910);
     wraith.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -87026,7 +87028,7 @@ PROTECTION P_DEATH 40
         MaxMana = 25, Mana = 25,
         BaseDodge = 19,
 
-        Experience = 3000,
+        Experience = 3800,
 
         CanFlee = true,
         CanSwim = true,
@@ -87049,10 +87051,10 @@ PROTECTION P_DEATH 40
     wizard.Wield(new SteelShield());
     wizard.Equip(new LeatherArmor());    
 
-    wizard.AddGold(800);
+    wizard.AddGold(900);
     wizard.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5SpellOrbs, 5.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
@@ -87086,7 +87088,7 @@ PROTECTION P_DEATH 40
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
 
-        Experience = 3050,
+        Experience = 3850,
 
         CanSwim = true,
 
@@ -87107,10 +87109,10 @@ PROTECTION P_DEATH 40
     thaum.Wield(new SteelShield());
     thaum.Equip(new LeatherArmor());    
 
-    thaum.AddGold(800);
+    thaum.AddGold(950);
     thaum.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5SpellOrbs, 5.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
@@ -87156,10 +87158,10 @@ PROTECTION P_DEATH 40
         },
     };    
 
-    ghoul.AddGold(650);
+    ghoul.AddGold(1250);
     ghoul.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -87210,7 +87212,7 @@ PROTECTION P_DEATH 40
     spectre.AddGold(830);
     spectre.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -87239,13 +87241,13 @@ PROTECTION P_DEATH 40
         MaxMana = 10, Mana = 10,
         BaseDodge = 18,
 
-        Experience = 2500,
+        Experience = 2800,
 
         CanFlee = true,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(14) },
+            { new CreatureBasicAttack(14, 20, 25) },
         },
         Spells = new CreatureSpellCollection()
         {
@@ -87257,10 +87259,10 @@ PROTECTION P_DEATH 40
 
     wight.Wield(new WoodenStaff());    
 
-    wight.AddGold(620);
+    wight.AddGold(920);
     wight.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -87315,10 +87317,10 @@ PROTECTION P_DEATH 40
 
     lich.Wield(new WoodenStaff());    
 
-    lich.AddGold(930);
+    lich.AddGold(1430);
     lich.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -87359,10 +87361,10 @@ PROTECTION P_DEATH 40
 
     stalker.Wield(new Spear());    
 
-    stalker.AddGold(630);
+    stalker.AddGold(1230);
     stalker.AddLoot(
         new LootPack(
-            new LootPackEntry(true, dungeon5Bottles, 20.0), 
+            new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
@@ -87686,6 +87688,313 @@ PROTECTION P_DEATH 40
     };
     
     return dragon;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveNaiad">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var pescalanor = new Humanoid()
+    {
+        Name = "Naiad",
+        MaxHealth = 200, Health = 200,
+        BaseDodge = 16,
+        MagicProtection = 50,
+        Experience = 6500,
+        HideDetection = 35,
+        CanWalk = false,
+        Attacks = new CreatureAttackCollection
+        {
+            { new CreatureBasicAttack(19) }, 
+        },
+    };
+
+    pescalanor.Wield(new FineCrossbow());
+    pescalanor.Equip(new DragonScaleArmor());    
+
+    return pescalanor;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveDefender">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var centaur = new Centaur()
+    {
+        Name = "Grove.Defender",
+        MaxHealth = 350, Health = 350,
+        BaseDodge = 16,
+        BasePenetration = ShieldPenetration.Medium,     
+        Experience = 7500,
+        HideDetection = 30,
+        MagicProtection = 25,
+    };
+    
+    centaur.AddStatus(new NightVisionStatus(centaur));
+    centaur.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(17, 30, 45),
+    };
+        
+    centaur.Wield(new WarHammer());
+    
+    centaur.AddGold(2500);
+    centaur.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, dungeon5Bottles, 60.0), 
+            new LootPackEntry(true, groveGems, 25.0),
+            new LootPackEntry(true, groveTreasure, 0.63)
+        ));
+    
+    return centaur;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveDryad">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var centaur = new Centaur()
+    {
+        Name = "Dryad",
+        MaxHealth = 230, Health = 230,
+        MaxMana = 31, Mana = 31,
+        BaseDodge = 18,
+        BasePenetration = ShieldPenetration.Medium,     
+        Experience = 6300,
+        MagicProtection = 40,
+    };
+    
+    centaur.AddStatus(new NightVisionStatus(centaur));
+    centaur.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(16, 25, 35),
+    };
+    Spells = new CreatureSpellCollection()
+    {
+        //not sure CreateSnake will work on chaotic monster but would be interesting - I feel a natural defender monster might do it thematically
+        { new CreatureSpell<CreateSnakeSpell>(16, mantra: SpellHelper.GenerateMantra(),
+            cost: 16, instantCast: false) },
+        { new CreatureSpell<CurseSpell>(14, mantra: SpellHelper.GenerateMantra(),
+            cost: 7, instantCast: false) }
+    }
+    centaur.Wield(new IronRod());
+    
+    centaur.AddGold(1500);
+    centaur.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, dungeon5Bottles, 60.0), 
+            new LootPackEntry(true, groveGems, 25.0),
+            new LootPackEntry(true, groveTreasure, 0.63)
+        ));
+    
+    return centaur;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveBear">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var bear = new Bear()
+    {
+        Name = "Bear.Spirit",
+        MaxHealth = 2000, Health = 2000,
+        BaseDodge = 25,
+                
+        Experience = 25500,
+        HideDetection = 31,
+        BasePenetration = ShieldPenetration.Heavy,
+        CanSwim = true,
+        CanJumpkick = true,
+        MagicProtection = 50,
+    };
+    bear.AddStatus(new NightVisionStatus(bear));
+        
+    bear.Attacks = new CreatureAttackCollection
+    {
+        { new CreatureAttack(16,     50, 65,  "The bear spirit slashes you with spectral claws."),        50 },
+        { new CreatureAttack(18,     60, 80,  "The bear spirits attack passes through your defenses."),             40 },
+        { new CreatureAttack(20,     70, 90, "The spirit batters you with impossible force."),    10 }
+    };
+        
+    bear.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(6, "your weapon passing through the incorporeal beast"),
+        new CreatureBlock(4, "a spectral paw"),
+    };
+        
+    bear.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, dungeon5Bottles, 100.0), 
+            new LootPackEntry(true, groveGems, 100.0),
+            new LootPackEntry(true, groveGems, 100.0),
+            new LootPackEntry(true, groveTreasure, 3.0)
+        ));
+        
+    return bear;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveWolf">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var wolf = new Wolf()
+    {
+        Name = "Spectral.Wolf",
+        MaxHealth = 1000, Health = 1000,
+        BaseDodge = 30,
+        BasePenetration = ShieldPenetration.Heavy,
+        Experience = 22500,
+        HideDetection = 33,
+        MagicProtection = 50,
+    };
+    wolf.AddStatus(new NightVisionStatus(wolf));
+    wolf.attacks = new CreatureAttackCollection
+    {
+            { new CreatureAttack(15, 20, 35, "The spirit rakes you with its claws."), 50 }, 
+            { new CreatureAttack(17, 30, 45, "The spirit sinks its teeth into you."), 30 }, 
+            { new CreatureAttack(18, 45, 65, "The wolf lunges at you, passing through you."), 20 }, 
+    },
+    wolf.blocks = new CreatureBlockCollection
+    {
+            new CreatureBlock(6, "your weapon passing through the incorporeal beast"),
+            new CreatureBlock(4, "a spectral paw"),
+    };
+
+    wolf.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, dungeon5Bottles, 100.0), 
+            new LootPackEntry(true, groveGems, 100.0),
+            new LootPackEntry(true, groveTreasure, 2.0)
+        ));
+
+    return wolf;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveBoar">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var boar = new Boar()
+    {
+        Name = "Spectral.Boar",
+        MaxHealth = 1500, Health = 1500,
+        BaseDodge = 26,
+        BasePenetration = ShieldPenetration.Medium,
+        Experience = 23250,
+        CanCharge = true,
+        HideDetection = 28,
+        Attacks = new CreatureAttackCollection
+        {
+            { new CreatureAttack(16, 25, 40, "A spectral tusk impales you."), 60 }, 
+            { new CreatureAttack(18, 35, 50, "The boar charges through you."), 40 }, 
+        },
+        MagicProtection = 50,
+    };
+    boar.AddStatus(new NightVisionStatus(boar));
+    boar.blocks = new CreatureBlockCollection
+    {
+            new CreatureBlock(6, "your weapon passing through the incorporeal beast"),
+            new CreatureBlock(4, "a spectral tusk"),
+    };
+
+    boar.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, dungeon5Bottles, 100.0), 
+            new LootPackEntry(true, groveGems, 100.0),
+            new LootPackEntry(true, groveTreasure, 2.0)
+        ));
+
+    return boar;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="groveSnake">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var viper = new Snake()
+    {
+        Name = "Spectral.Viper",
+        
+        MaxHealth = 500, Health = 500,
+        BaseDodge = 28,
+        MagicProtection = 50,
+        CanCharge = true,
+        Experience = 10025,
+        VisibilityDistance = 1,
+        Attacks = new CreatureAttackCollection()
+        {
+            { new CreatureAttack(18,     10, 30,      "The viper sinks its spectral fangs into your flesh.", 
+                                                new AttackPoisonComponent(40)) }, 
+        };  
+        Blocks = new CreatureBlockCollection
+        {
+            { new CreatureBlock(1, "your weapon passing through the viper.") }, 
+        },
+    };    
+
+    viper.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, dungeon5Bottles, 100.0), 
+            new LootPackEntry(true, groveGems, 33.0),
+            new LootPackEntry(true, groveTreasure, 1.0)
+        ));
+    return viper;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -88339,6 +88648,69 @@ PROTECTION P_DEATH 40
       <entry entity="oakvaelDragon" size="1" minimum="1" maximum="1" />
       <location x="9" y="9" region="225" />
     </spawn>
+    <spawn type="LocationSpawner" name="groveBear">
+      <minimumDelay>1200</minimumDelay>
+      <maximumDelay>1500</maximumDelay>
+      <maximum>1</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="groveBear" size="1" minimum="1" maximum="1" />
+      <location x="37" y="0" region="236" />
+    </spawn>
+    <spawn type="LocationSpawner" name="groveWold">
+      <minimumDelay>1200</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>1</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="groveWolf" size="1" minimum="1" maximum="1" />
+      <location x="12" y="-3" region="236" />
+    </spawn>
+    <spawn type="LocationSpawner" name="groveBoar">
+      <minimumDelay>1500</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>1</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="groveBoar" size="1" minimum="1" maximum="1" />
+      <location x="1" y="7" region="236" />
+    </spawn>
     <spawn type="RegionSpawner" name="portalPeacemakers">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
@@ -88640,6 +89012,84 @@ PROTECTION P_DEATH 40
       <entry entity="dungeon4Glamuzu" size="1" minimum="1" maximum="1" />
       <bounds region="232">
         <inclusion left="0" top="3" right="25" bottom="25" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="groveNaiads">
+      <minimumDelay>960</minimumDelay>
+      <maximumDelay>1320</maximumDelay>
+      <maximum>3</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="groveNaiad" size="1" minimum="3" maximum="3" />
+      <bounds region="236">
+        <inclusion left="18" top="4" right="26" bottom="7" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="groveDefenders">
+      <minimumDelay>1140</minimumDelay>
+      <maximumDelay>1560</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="groveDefender" size="2" minimum="6" maximum="5" />
+      <entry entity="groveDryad" size="1" minimum="3" maximum="3" />
+      <bounds region="236">
+        <inclusion left="1" top="1" right="11" bottom="7" />
+        <inclusion left="12" top="-3" right="12" bottom="-2" />
+        <inclusion left="4" top="8" right="16" bottom="13" />
+        <inclusion left="12" top="5" right="16" bottom="8" />
+        <inclusion left="17" top="9" right="34" bottom="13" />
+        <inclusion left="28" top="-3" right="34" bottom="8" />
+        <inclusion left="35" top="-3" right="38" bottom="-2" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="groveVipers">
+      <minimumDelay>1200</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>1</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="groveSnake" size="3" minimum="1" maximum="1" />
+      <bounds region="236">
+        <inclusion left="24" top="13" right="34" bottom="13" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -89265,7 +89715,7 @@ PROTECTION P_DEATH 40
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new Diamond(2000u);
+	return new Diamond(1800u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -89274,7 +89724,7 @@ PROTECTION P_DEATH 40
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new BloodRuby(2000u);
+	return new BloodRuby(2500u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -89387,6 +89837,15 @@ PROTECTION P_DEATH 40
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new YouthPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="8">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -89518,7 +89977,7 @@ PROTECTION P_DEATH 40
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new BloodRuby(2000u);
+	return new BloodRuby(2700u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -89565,7 +90024,25 @@ PROTECTION P_DEATH 40
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new ShieldBracelet();
+	return new StrongShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWillpowerPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -89651,6 +90128,82 @@ PROTECTION P_DEATH 40
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new WebOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="groveTreasure">
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireIceProtectionRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BlindFearProtectionBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ScorpionBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="groveGems">
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BloodRuby(4000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new LargeEmerald(6000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SmallTopaz(40000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -84604,7 +84604,7 @@
         MaxHealth = 46, Health = 46,
         BaseDodge = 12,
 
-        Experience = 625,
+        Experience = 525,
 
         Movement = 2,
 
@@ -84691,7 +84691,7 @@
         MaxHealth = 32, Health = 32,
         BaseDodge = 12,
 
-        Experience = 350,
+        Experience = 450,
 
         Attacks = new CreatureAttackCollection
         {
@@ -84776,7 +84776,7 @@
         MaxHealth = 25, Health = 25,
         BaseDodge = 12,
 
-        Experience = 250,
+        Experience = 750,
         
         BasePenetration = ShieldPenetration.VeryLight,
 
@@ -85032,10 +85032,10 @@
         <block><![CDATA[
 	var rat = new BlackRat()
     {
-        MaxHealth = 13, Health = 13,
+        MaxHealth = 33, Health = 33,
         BaseDodge = 12,
 
-        Experience = 175,
+        Experience = 575,
 
         VisibilityDistance = 1,
         Movement = 2,
@@ -85044,9 +85044,9 @@
         
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureAttack(6, 1, 4, "The rat rakes you with its claws"), 50 }, 
-            { new CreatureAttack(6, 1, 6, "The rat bites you"), 30 }, 
-            { new CreatureAttack(6, 1, 8, "The rat whips you with its tail"), 20 }, 
+            { new CreatureAttack(6, 1, 5, "The rat rakes you with its claws"), 50 }, 
+            { new CreatureAttack(6, 1, 8, "The rat bites you"), 30 }, 
+            { new CreatureAttack(6, 1, 10, "The rat whips you with its tail"), 20 }, 
         },
         Blocks = new CreatureBlockCollection
         {
@@ -85080,7 +85080,7 @@
         MaxHealth = 18, Health = 18,
         BaseDodge = 12,
 
-        Experience = 225,
+        Experience = 850,
 
         Movement = 2,
 
@@ -85118,14 +85118,14 @@
         MaxHealth = 42, Health = 42,
         BaseDodge = 12,
 
-        Experience = 450,
+        Experience = 900,
 
         Movement = 2,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureAttack(7, 2, 6, "The scorpion crushes you with its claws."), 60 }, 
-            { new CreatureAttack(7, 3, 10, "The scorpion stings you with its tail.",
+            { new CreatureAttack(7, 3, 8, "The scorpion crushes you with its claws."), 60 }, 
+            { new CreatureAttack(7, 4, 8, "The scorpion stings you with its tail.",
                 new AttackPoisonComponent(7, 20),
                 new AttackStunComponent(10)), 40 }, 
         },
@@ -85162,12 +85162,12 @@
         <block><![CDATA[
 	var kobold = new Kobold()
     {
-        MaxHealth = 16, Health = 16,
-        BaseDodge = 12,
+        MaxHealth = 35, Health = 35,
+        BaseDodge = 13,
 
-        Experience = 275,
+        Experience = 1500,
 
-        Movement = 1,
+        Movement = 2,
 
         Attacks = new CreatureAttackCollection
         {
@@ -85178,7 +85178,7 @@
     kobold.Wield(new SteelMace());
     kobold.Equip(new LeatherArmor());    
 
-    kobold.AddGold(100);
+    kobold.AddGold(300);
     kobold.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
@@ -85203,10 +85203,10 @@
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 21, Health = 21,
+        MaxHealth = 44, Health = 44,
         BaseDodge = 11,
 
-        Experience = 300,
+        Experience = 1250,
 
         Movement = 2,
 
@@ -85214,14 +85214,14 @@
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(6) }, 
+            { new CreatureBasicAttack(7) }, 
         },
     };
 
     orc.Wield(new Longsword());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(150);
+    orc.AddGold(250);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
@@ -85246,23 +85246,23 @@
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 21, Health = 21,
-        BaseDodge = 11,
+        MaxHealth = 44, Health = 44,
+        BaseDodge = 13,
 
-        Experience = 300,
+        Experience = 1250,
 
         CanFlee = true,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(6) }, 
+            { new CreatureBasicAttack(8) }, 
         },
     };
 
     orc.Wield(new Crossbow());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(150);
+    orc.AddGold(350);
     orc.AddLoot(
         new LootPack(
             new LootPackEntry(true, dungeon1Gems, 25.0, gemsPriceMutator), 
@@ -85287,10 +85287,10 @@
         <block><![CDATA[
 	var troll = new Troll()
     {
-        MaxHealth = 35, Health = 35,
-        BaseDodge = 11,
+        MaxHealth = 55, Health = 55,
+        BaseDodge = 14,
 
-        Experience = 425,
+        Experience = 1325,
 
         Movement = 2,
 
@@ -85298,7 +85298,7 @@
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureAttack(6, 4, 15) }, 
+            { new CreatureAttack(6, 5, 15) }, 
         },
     };
 
@@ -85330,10 +85330,10 @@
         <block><![CDATA[
 	var spider = new Spider()
     {
-        MaxHealth = 42, Health = 42,
-        BaseDodge = 12,
+        MaxHealth = 48, Health = 48,
+        BaseDodge = 13,
 
-        Experience = 425,
+        Experience = 1950,
 
         Movement = 0,
         
@@ -85376,16 +85376,16 @@
         <block><![CDATA[
 	var hobgoblin = new Hobgoblin()
     {
-        MaxHealth = 52, Health = 52,
+        MaxHealth = 60, Health = 60,
         BaseDodge = 14,
 
-        Experience = 700,
+        Experience = 2500,
 
         Movement = 2,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(8) }, 
+            { new CreatureBasicAttack(9) }, 
         },
     };
 
@@ -85419,14 +85419,14 @@
         <block><![CDATA[
 	var goblin = new Goblin()
     {
-        MaxHealth = 42, Health = 42,
+        MaxHealth = 46, Health = 46,
         BaseDodge = 13,
 
-        Experience = 550,
+        Experience = 1900,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(7) }, 
+            { new CreatureBasicAttack(9) }, 
         },
     };
 
@@ -85463,7 +85463,7 @@
         MaxHealth = 42, Health = 42,
         BaseDodge = 13,
 
-        Experience = 550,
+        Experience = 1900,
 
         Attacks = new CreatureAttackCollection
         {
@@ -85504,7 +85504,7 @@
         MaxHealth = 75, Health = 75,
         BaseDodge = 14,
 
-        Experience = 920,
+        Experience = 2220,
 
         Movement = 2,
 
@@ -85547,16 +85547,16 @@
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 40, Health = 40,
+        MaxHealth = 48, Health = 48,
         BaseDodge = 13,
 
-        Experience = 555,
+        Experience = 1900,
         
         CanFlee = true,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(7) }, 
+            { new CreatureBasicAttack(8) }, 
         },
     };
 
@@ -85593,7 +85593,7 @@
         MaxHealth = 40, Health = 40,
         BaseDodge = 13,
 
-        Experience = 555,
+        Experience = 1955,
 
         CanFlee = true,
 
@@ -85637,7 +85637,7 @@
         MaxMana = 12, Mana = 12,
         BaseDodge = 13,
 
-        Experience = 625,
+        Experience = 1925,
         
         CanFlee = true,
 
@@ -85687,7 +85687,7 @@
         MaxMana = 17, Mana = 17,
         BaseDodge = 14,
 
-        Experience = 950,
+        Experience = 2750,
 
         VisibilityDistance = 1,
 
@@ -85740,7 +85740,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 15,
 
-        Experience = 1200,
+        Experience = 2500,
 
         Movement = 2,
 
@@ -85783,7 +85783,7 @@
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
 
-        Experience = 900,
+        Experience = 2250,
         
         CanFlee = true,
 
@@ -85826,7 +85826,7 @@
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
 
-        Experience = 900,
+        Experience = 2300,
         
         CanFlee = true,
 
@@ -85870,7 +85870,7 @@
         MaxMana = 12, Mana = 12,
         BaseDodge = 14,
 
-        Experience = 975,
+        Experience = 2275,
 
         CanFlee = true,
 
@@ -85920,7 +85920,7 @@
         MaxHealth = 98, Health = 98,
         BaseDodge = 16,
 
-        Experience = 1250,
+        Experience = 3250,
         
         Attacks = new CreatureAttackCollection
         {
@@ -85967,7 +85967,7 @@
         MaxMana = 18, Mana = 18,
         BaseDodge = 15,
 
-        Experience = 3000,
+        Experience = 5000,
         
         CanFlee = true,
         CanSwim = true,
@@ -86026,7 +86026,7 @@
         MaxMana = 21, Mana = 21,
         BaseDodge = 15,
 
-        Experience = 3000,
+        Experience = 5100,
 
         CanFlee = true,
         CanSwim = true,
@@ -86079,7 +86079,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 15,
 
-        Experience = 2700,
+        Experience = 5500,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
 
@@ -86133,7 +86133,7 @@
         MaxHealth = 125, Health = 125,
         BaseDodge = 15,
 
-        Experience = 2350,
+        Experience = 2450,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
         
@@ -86234,7 +86234,7 @@
         MaxHealth = 500, Health = 500,
         BaseDodge = 18,
 
-        Experience = 9500,
+        Experience = 15000,
 
         Movement = 2,
 
@@ -86300,13 +86300,13 @@ PROTECTION P_DEATH 40
         MaxHealth = 120, Health = 120,
         BaseDodge = 16,
 
-        Experience = 2500,
+        Experience = 6000,
 
         CanWalk = false,
 
         Attacks = new CreatureAttackCollection
         {
-            { new CreatureBasicAttack(10) }, 
+            { new CreatureBasicAttack(11) }, 
         },
     };
 
@@ -86343,7 +86343,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 130, Health = 130,
         BaseDodge = 17,
 
-        Experience = 2700,
+        Experience = 3500,
 
         Movement = 2,
         CanFly = true,
@@ -86397,7 +86397,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 160, Health = 160,
         BaseDodge = 17,
 
-        Experience = 3200,
+        Experience = 6600,
 
         CanFlee = true,
         BasePenetration = ShieldPenetration.Medium,
@@ -86450,7 +86450,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 88, Health = 88,
         BaseDodge = 16,
 
-        Experience = 1450,
+        Experience = 4450,
         
         Attacks = new CreatureAttackCollection
         {
@@ -86491,7 +86491,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 110, Health = 110,
         BaseDodge = 18,
 
-        Experience = 1700,
+        Experience = 4400,
 
         Movement = 2,
 
@@ -86536,7 +86536,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 71, Health = 71,
         BaseDodge = 16,
 
-        Experience = 1100,
+        Experience = 4100,
 
         CanFlee = true,
 
@@ -86579,7 +86579,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 71, Health = 71,
         BaseDodge = 16,
 
-        Experience = 1025,
+        Experience = 4025,
 
         CanFlee = true,
 
@@ -86628,7 +86628,7 @@ PROTECTION P_DEATH 40
         MaxMana = 18, Mana = 18,
         BaseDodge = 17,
 
-        Experience = 3500,
+        Experience = 6500,
 
         CanFlee = true,
         CanSwim = true,
@@ -86686,7 +86686,7 @@ PROTECTION P_DEATH 40
         MaxMana = 21, Mana = 21,
         BaseDodge = 17,
 
-        Experience = 3300,
+        Experience = 6500,
 
         CanFlee = true,
         CanSwim = true,
@@ -86740,7 +86740,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 80, Health = 80,
         BaseDodge = 17,
 
-        Experience = 1450,
+        Experience = 4450,
 
         Movement = 2,
 
@@ -86790,7 +86790,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
         BasePenetration = ShieldPenetration.Medium,
-        Experience = 5000,
+        Experience = 10000,
         
         CanFlee = true,
         CanSwim = true,
@@ -86837,7 +86837,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
         BasePenetration = ShieldPenetration.Medium,
-        Experience = 5000,
+        Experience = 10000,
 
         CanFlee = true,
         CanSwim = true,
@@ -86882,7 +86882,7 @@ PROTECTION P_DEATH 40
         MaxMana = 5, Mana = 5,
         BaseDodge = 18,
 
-        Experience = 3475,
+        Experience = 5075,
         
         Attacks = new CreatureAttackCollection
         {
@@ -86928,7 +86928,7 @@ PROTECTION P_DEATH 40
         MaxMana = 11, Mana = 11,
         BaseDodge = 18,
 
-        Experience = 3875,
+        Experience = 5475,
 
         Attacks = new CreatureAttackCollection
         {
@@ -86936,7 +86936,7 @@ PROTECTION P_DEATH 40
         },
         Spells = new CreatureSpellCollection()
         {
-            { new CreatureSpell<CurseSpell>(9.5, cost: 3), 100 }
+            { new CreatureSpell<CurseSpell>(8.5, cost: 3), 100 }
         }
     };
     banshee.AddStatus(new NightVisionStatus(banshee));
@@ -86974,7 +86974,7 @@ PROTECTION P_DEATH 40
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
 
-        Experience = 3100,
+        Experience = 6300,
 
         Attacks = new CreatureAttackCollection
         {
@@ -87028,7 +87028,7 @@ PROTECTION P_DEATH 40
         MaxMana = 25, Mana = 25,
         BaseDodge = 19,
 
-        Experience = 3800,
+        Experience = 6500,
 
         CanFlee = true,
         CanSwim = true,
@@ -87088,7 +87088,7 @@ PROTECTION P_DEATH 40
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
 
-        Experience = 3850,
+        Experience = 6850,
 
         CanSwim = true,
 
@@ -87140,7 +87140,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 180, Health = 180,
         BaseDodge = 19,
 
-        Experience = 4500,
+        Experience = 6200,
 
         Movement = 2,
         VisibilityDistance = 1,
@@ -87189,7 +87189,7 @@ PROTECTION P_DEATH 40
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
 
-        Experience = 3000,
+        Experience = 8300,
 
         VisibilityDistance = 1,
 
@@ -87241,7 +87241,7 @@ PROTECTION P_DEATH 40
         MaxMana = 10, Mana = 10,
         BaseDodge = 18,
 
-        Experience = 2800,
+        Experience = 5500,
 
         CanFlee = true,
 
@@ -87290,7 +87290,7 @@ PROTECTION P_DEATH 40
         MaxMana = 21, Mana = 21,
         BaseDodge = 19,
 
-        Experience = 5575,
+        Experience = 9575,
 
         VisibilityDistance = 1,
 
@@ -87348,7 +87348,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
 
-        Experience = 3200,
+        Experience = 6700,
 
         VisibilityDistance = 1,
 
@@ -87394,7 +87394,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 600, Health = 600, /* Based on 4 Death casts to kill at level 16 magic. */
         BaseDodge = 20,
         
-        Experience = 10000,
+        Experience = 25000,
         
         BasePenetration = ShieldPenetration.Heavy,
         
@@ -87451,7 +87451,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 600, Health = 600,
         BaseDodge = 20,
         
-        Experience = 10000,
+        Experience = 25000,
         
         BasePenetration = ShieldPenetration.Heavy,
         
@@ -87508,7 +87508,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 500, Health = 500,
         BaseDodge = 20,
 
-        Experience = 6000,
+        Experience = 10000,
 
         Attacks = new CreatureAttackCollection
         {
@@ -87549,13 +87549,13 @@ PROTECTION P_DEATH 40
         MaxHealth = 50, Health = 50,
         BaseDodge = 14,
 
-        Experience = 800,
+        Experience = 1800,
 
         CanFlee = true,
 
         Attacks = new CreatureAttackCollection
         {
-            new CreatureBasicAttack(8), 
+            new CreatureBasicAttack(9), 
         },
         
         HideDetection = 14,
@@ -87587,7 +87587,7 @@ PROTECTION P_DEATH 40
         MaxMana = 24, Mana = 24,
         BaseDodge = 16,
 
-        Experience = 3000,
+        Experience = 6000,
 
         VisibilityDistance = 0,
         
@@ -87741,7 +87741,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 350, Health = 350,
         BaseDodge = 16,
         BasePenetration = ShieldPenetration.Medium,     
-        Experience = 7500,
+        Experience = 18500,
         HideDetection = 30,
         MagicProtection = 25,
     };
@@ -87784,7 +87784,7 @@ PROTECTION P_DEATH 40
         MaxMana = 31, Mana = 31,
         BaseDodge = 18,
         BasePenetration = ShieldPenetration.Medium,     
-        Experience = 6300,
+        Experience = 17300,
         MagicProtection = 40,
     };
     
@@ -87832,7 +87832,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 2000, Health = 2000,
         BaseDodge = 25,
                 
-        Experience = 25500,
+        Experience = 45500,
         HideDetection = 31,
         BasePenetration = ShieldPenetration.Heavy,
         CanSwim = true,
@@ -87883,7 +87883,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 1000, Health = 1000,
         BaseDodge = 30,
         BasePenetration = ShieldPenetration.Heavy,
-        Experience = 22500,
+        Experience = 42500,
         HideDetection = 33,
         MagicProtection = 50,
     };
@@ -87928,7 +87928,7 @@ PROTECTION P_DEATH 40
         MaxHealth = 1500, Health = 1500,
         BaseDodge = 26,
         BasePenetration = ShieldPenetration.Medium,
-        Experience = 23250,
+        Experience = 43250,
         CanCharge = true,
         HideDetection = 28,
         Attacks = new CreatureAttackCollection
@@ -87975,7 +87975,7 @@ PROTECTION P_DEATH 40
         BaseDodge = 28,
         MagicProtection = 50,
         CanCharge = true,
-        Experience = 10025,
+        Experience = 25025,
         VisibilityDistance = 1,
         Attacks = new CreatureAttackCollection()
         {

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -86757,7 +86757,7 @@ PROTECTION P_DEATH 40
         },
         Spells = new CreatureSpellCollection(50.0)
         {
-            { new CreatureSpell<FirewallSpell>(9), 100, TimeSpan.FromSeconds(15.0) }
+            { new CreatureSpell<FirewallSpell>(9), 100, TimeSpan.FromSeconds(15.0), instantCast = true }
         }
     };    
 
@@ -87684,7 +87684,7 @@ PROTECTION P_DEATH 40
     dragon.Spells = new CreatureSpellCollection()
     {
         /* Expected output of damage is 60 per turn based on replay from Indi..DOOM. */
-        { new CreatureSpell<WhirlwindSpell>(15, cost: 20) },
+        { new CreatureSpell<WhirlwindSpell>(15, cost: 20), instantCast = true },
     };
     
     return dragon;

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -86204,7 +86204,7 @@
         },
         Spells = new CreatureSpellCollection(50.0)
         {
-            { new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0), instantCast = true }
+            { new CreatureSpell<FirewallSpell>(8), 100, TimeSpan.FromSeconds(15.0) }
         }
     };    
 
@@ -86757,7 +86757,7 @@ PROTECTION P_DEATH 40
         },
         Spells = new CreatureSpellCollection(50.0)
         {
-            { new CreatureSpell<FirewallSpell>(9), 100, TimeSpan.FromSeconds(15.0), instantCast = true }
+            { new CreatureSpell<FirewallSpell>(9), 100, TimeSpan.FromSeconds(15.0) }
         }
     };    
 
@@ -87684,7 +87684,7 @@ PROTECTION P_DEATH 40
     dragon.Spells = new CreatureSpellCollection()
     {
         /* Expected output of damage is 60 per turn based on replay from Indi..DOOM. */
-        { new CreatureSpell<WhirlwindSpell>(15, cost: 20), instantCast = true },
+        { new CreatureSpell<WhirlwindSpell>(15, cost: 20) },
     };
     
     return dragon;
@@ -87793,14 +87793,14 @@ PROTECTION P_DEATH 40
     {
         new CreatureBasicAttack(16, 25, 35),
     };
-    Spells = new CreatureSpellCollection()
+    centaur.Spells = new CreatureSpellCollection()
     {
         //not sure CreateSnake will work on chaotic monster but would be interesting - I feel a natural defender monster might do it thematically
         { new CreatureSpell<CreateSnakeSpell>(16, mantra: SpellHelper.GenerateMantra(),
             cost: 16, instantCast: false) },
         { new CreatureSpell<CurseSpell>(14, mantra: SpellHelper.GenerateMantra(),
             cost: 7, instantCast: false) }
-    }
+    };
     centaur.Wield(new IronRod());
     
     centaur.AddGold(1500);
@@ -87888,13 +87888,13 @@ PROTECTION P_DEATH 40
         MagicProtection = 50,
     };
     wolf.AddStatus(new NightVisionStatus(wolf));
-    wolf.attacks = new CreatureAttackCollection
+    wolf.Attacks = new CreatureAttackCollection
     {
             { new CreatureAttack(15, 20, 35, "The spirit rakes you with its claws."), 50 }, 
             { new CreatureAttack(17, 30, 45, "The spirit sinks its teeth into you."), 30 }, 
             { new CreatureAttack(18, 45, 65, "The wolf lunges at you, passing through you."), 20 }, 
-    },
-    wolf.blocks = new CreatureBlockCollection
+    };
+    wolf.Blocks = new CreatureBlockCollection
     {
             new CreatureBlock(6, "your weapon passing through the incorporeal beast"),
             new CreatureBlock(4, "a spectral paw"),
@@ -87931,15 +87931,16 @@ PROTECTION P_DEATH 40
         Experience = 43250,
         CanCharge = true,
         HideDetection = 28,
-        Attacks = new CreatureAttackCollection
-        {
-            { new CreatureAttack(16, 25, 40, "A spectral tusk impales you."), 60 }, 
-            { new CreatureAttack(18, 35, 50, "The boar charges through you."), 40 }, 
-        },
+        
         MagicProtection = 50,
     };
     boar.AddStatus(new NightVisionStatus(boar));
-    boar.blocks = new CreatureBlockCollection
+    boar.Attacks = new CreatureAttackCollection
+    {
+        { new CreatureAttack(16, 25, 40, "A spectral tusk impales you."), 60 }, 
+        { new CreatureAttack(18, 35, 50, "The boar charges through you."), 40 }, 
+    };
+    boar.Blocks = new CreatureBlockCollection
     {
             new CreatureBlock(6, "your weapon passing through the incorporeal beast"),
             new CreatureBlock(4, "a spectral tusk"),
@@ -87977,16 +87978,17 @@ PROTECTION P_DEATH 40
         CanCharge = true,
         Experience = 25025,
         VisibilityDistance = 1,
-        Attacks = new CreatureAttackCollection()
-        {
-            { new CreatureAttack(18,     10, 30,      "The viper sinks its spectral fangs into your flesh.", 
-                                                new AttackPoisonComponent(40)) }, 
-        };  
-        Blocks = new CreatureBlockCollection
-        {
-            { new CreatureBlock(1, "your weapon passing through the viper.") }, 
-        },
+        
     };    
+    viper.Attacks = new CreatureAttackCollection()
+    {
+        { new CreatureAttack(18,     10, 30,      "The viper sinks its spectral fangs into your flesh.", 
+                                            new AttackPoisonComponent(40)) }, 
+    };  
+    viper.Blocks = new CreatureBlockCollection
+    {
+        { new CreatureBlock(1, "your weapon passing through the viper.") }, 
+    };
 
     viper.AddLoot(
         new LootPack(

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Underkingdom" version="0.69.0.0">
+<segment name="Underkingdom" version="0.70.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -96201,7 +96201,7 @@
     var wyvern = new Wyvern()
     {
         Body = 176,
-        MaxHealth = 110, Health = 110,
+        MaxHealth = 70, Health = 70,
         BaseDodge = 12,
         BasePenetration = ShieldPenetration.Light,
         Experience = 2500,
@@ -96250,7 +96250,7 @@
     var wyvern = new Wyvern()
     {
         Body = 177,
-        MaxHealth = 110, Health = 110,
+        MaxHealth = 70, Health = 70,
         BaseDodge = 12,
                 
         Experience = 2500,
@@ -96299,7 +96299,7 @@
     var wyvern = new Wyvern()
     {
         Body = 178,
-        MaxHealth = 110, Health = 110,
+        MaxHealth = 70, Health = 70,
         BaseDodge = 12,
                 
         Experience = 2500,
@@ -96348,7 +96348,7 @@
     var wyvern = new Wyvern()
     {
         Body = 65,
-        MaxHealth = 110, Health = 110,
+        MaxHealth = 70, Health = 70,
         BaseDodge = 12,
                 
         Experience = 2500,
@@ -96446,7 +96446,7 @@
         
     drake.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<LightningBoltSpell>(9),
+        new CreatureSpell<LightningBoltSpell>(9), instantCast = true,
     };
     
     drake.AddGold(2000);
@@ -96500,7 +96500,7 @@
     
     carfel.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(15),
+        new CreatureBasicAttack(15, 25, 55),
     };
     
     //todo determine if I can force it to dual wield? Not sure of context
@@ -96538,7 +96538,7 @@
         MaxHealth = 800, Health = 800,
         BaseDodge = 15,
     
-        Experience = 14000,
+        Experience = 18000,
         BasePenetration = ShieldPenetration.Medium,
         
         VisibilityDistance = 0,
@@ -96587,12 +96587,13 @@
         
         Alignment = Alignment.Chaotic,
         HideDetection = 28,
-        Experience = 42000,
+        Experience = 56000,
         
         Immunity = CreatureImmunity.Magic,
         Weakness = CreatureWeakness.IceSpearSpell,
         
         CanCharge = true,
+        HideDetection = 30,
         
         BasePenetration = ShieldPenetration.VeryHeavy,
     
@@ -96639,7 +96640,7 @@
         BasePenetration = ShieldPenetration.Heavy,
         Alignment = Alignment.Chaotic,
         HideDetection = 24,
-        Experience = 22000,
+        Experience = 27000,
             
         VisibilityDistance = 0,
     };
@@ -96686,7 +96687,7 @@
         MaxHealth = 2500, Health = 2500,
         BaseDodge = 21,
         HideDetection = 25,
-        Experience = 35000,
+        Experience = 39000,
        
         CanCharge = true,
                 
@@ -96738,7 +96739,7 @@
         MaxHealth = 5000, Health = 5000,
         BaseDodge = 15,
     
-        Experience = 45000,
+        Experience = 69000,
         
         BasePenetration = ShieldPenetration.VeryHeavy,
         
@@ -96772,13 +96773,11 @@
     
     overlord.Spells = new CreatureSpellCollection(35.0)
     {
-        new CreatureSpell<IceSpearSpell>(10),
+        new CreatureSpell<IceSpearSpell>(10), instantCast = true,
     };
     
     overlord.AddGold(3000);
     overlord.AddLoot(new LootPack(
-        //new LootPackEntry(true, dungeon1Bottles,    20),
-        //todo: new LootPackEntry(true, ydnacTreasure,      100),
         
         new LootPackEntry(true, (from, container) => new ClearBalm(),           50),
         new LootPackEntry(true, (from, container) => new Diamond(1500u),        100,    gemsPriceMutator),
@@ -96806,7 +96805,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 12,
                 
-        Experience = 3800,
+        Experience = 5200,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
                 
@@ -96822,7 +96821,7 @@
     orc.AddGold(400);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return orc;
@@ -96845,7 +96844,7 @@
         MaxHealth = 200, Health = 200,
         BaseDodge = 16,
     
-        Experience = 5500,
+        Experience = 10500,
     
         CanCharge = true,
         BasePenetration = ShieldPenetration.Medium,
@@ -96872,7 +96871,7 @@
     minotaur.AddGold(1000);
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return minotaur;
@@ -96895,7 +96894,7 @@
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
                 
-        Experience = 9000,
+        Experience = 12000,
         BasePenetration = ShieldPenetration.Medium,
     
     };
@@ -96919,7 +96918,7 @@
     goblin.AddGold(800);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return goblin;
@@ -96943,7 +96942,7 @@
         MaxHealth = 145, Health = 145,
         BaseDodge = 13,
                 
-        Experience = 3400,
+        Experience = 6400,
                 
         Movement = 3,
         BasePenetration = ShieldPenetration.Light,
@@ -96959,7 +96958,7 @@
     troll.AddGold(500);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return troll;
@@ -96982,7 +96981,7 @@
         MaxHealth = 100, Health = 100,
         BaseDodge = 12,
                 
-        Experience = 2600,
+        Experience = 5600,
         
         CanFlee = true,
         BasePenetration = ShieldPenetration.Light,
@@ -96998,7 +96997,7 @@
     orc.AddGold(300);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return orc;
@@ -97022,7 +97021,7 @@
         MaxMana = 13, Mana = 13,
         BaseDodge = 14,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 4700,
+        Experience = 6700,
     
     };
     hobgoblin.AddStatus(new NightVisionStatus(hobgoblin));
@@ -97044,7 +97043,7 @@
     hobgoblin.AddGold(550);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return hobgoblin;
@@ -97064,10 +97063,10 @@
         <block><![CDATA[
     var hobgoblin = new Hobgoblin()
     {
-        MaxHealth = 150, Health = 120,
+        MaxHealth = 150, Health = 150,
         BaseDodge = 14,
     
-        Experience = 4600,
+        Experience = 6600,
         BasePenetration = ShieldPenetration.Medium,
         Attacks = new CreatureAttackCollection()
         {
@@ -97081,7 +97080,7 @@
     hobgoblin.AddGold(500);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return hobgoblin;
@@ -97107,14 +97106,13 @@
         MaxHealth = 135, Health = 135,
         BaseDodge = 13,
                 
-        Experience = 4200,
+        Experience = 6400,
         BasePenetration = ShieldPenetration.Medium,
         Movement = 3,
                                 
         Attacks = new CreatureAttackCollection()
         {
-            { new CreatureBasicAttack(11, 25, 30,
-                new AttackProneComponent(100.0), new AttackStunComponent(100.0)) },
+            { new CreatureBasicAttack(11, 25, 30) },
         },
     };
     
@@ -97126,7 +97124,7 @@
     troll.AddGold(500);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return troll;
@@ -97149,7 +97147,7 @@
         MaxHealth = 175, Health = 175,
         BaseDodge = 14,
                 
-        Experience = 4800,
+        Experience = 6800,
                 
         Movement = 3,
         BasePenetration = ShieldPenetration.Medium,
@@ -97167,7 +97165,7 @@
     troll.AddGold(450);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return troll;
@@ -97191,11 +97189,9 @@
         MaxHealth = 300, Health = 300,
         BaseDodge = 15,
             
-        Experience = 8000,
+        Experience = 11000,
         
-        FireProtection = 50,
-        IceProtection = 50,
-        
+        MagicProtection = 33,
         CanCharge = true,
         
         BasePenetration = ShieldPenetration.Heavy,
@@ -97214,7 +97210,7 @@
     trollguard.AddGold(1000);
     trollguard.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    33)
         ));
     
     return trollguard;
@@ -97238,7 +97234,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
     
-        Experience = 5500,
+        Experience = 7500,
         BasePenetration = ShieldPenetration.Medium,
         Attacks = new CreatureAttackCollection
         {
@@ -97252,7 +97248,7 @@
     hobgoblin.AddGold(500);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, speedygems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return hobgoblin;
@@ -97276,7 +97272,7 @@
         MaxMana = 13, Mana = 13,
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.VeryLight,
-        Experience = 2300,
+        Experience = 5300,
     
     };
     
@@ -97297,7 +97293,7 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return orc;
@@ -97320,7 +97316,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.VeryLight,
-        Experience = 1900,
+        Experience = 5500,
         
         MaxMana = 21, Mana = 21,
             
@@ -97344,7 +97340,7 @@
     troll.AddGold(250);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return troll;
@@ -97367,7 +97363,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 12,
     
-        Experience = 4800,
+        Experience = 6800,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 31, Mana = 31,
             
@@ -97391,7 +97387,7 @@
     troll.AddGold(380);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return troll;
@@ -97415,7 +97411,7 @@
         MaxMana = 21, Mana = 21,
         BaseDodge = 11,
     
-        Experience = 1900,
+        Experience = 4900,
         BasePenetration = ShieldPenetration.VeryLight,
     };
     
@@ -97439,7 +97435,7 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    25)
     ));
     
     return orc;
@@ -97463,7 +97459,7 @@
         MaxMana = 16, Mana = 16,
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.VeryLight,        
-        Experience = 2800,
+        Experience = 5800,
         FireProtection = 100,
     };
     
@@ -97487,7 +97483,7 @@
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return goblin;
@@ -97510,11 +97506,11 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 13,
     
-        Experience = 5800,
+        Experience = 6800,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 21, Mana = 21,
         DeathResistance = 100,
-            
+        MagicProtection = 33,
     };
         
     banshee.Attacks = new CreatureAttackCollection()
@@ -97557,7 +97553,7 @@
         MaxHealth = 220, Health = 220,
         BaseDodge = 14,
     
-        Experience = 8000,
+        Experience = 9000,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 0,
             
@@ -97584,7 +97580,7 @@
     ghoul.AddGold(1000);
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    15)
+        new LootPackEntry(true, undeadBottles,    50)
     ));
     
     return ghoul;
@@ -97607,7 +97603,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
 
-        Experience = 5500,
+        Experience = 6800,
         BasePenetration = ShieldPenetration.Light,
         Movement = 3,
         DeathResistance = 100,
@@ -97625,7 +97621,7 @@
     
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    20)
+        new LootPackEntry(true, undeadBottles,    33)
     ));
     
     return skeleton;
@@ -97649,7 +97645,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
     
-        Experience = 6500,
+        Experience = 8500,
         BasePenetration = ShieldPenetration.Light,
         VisibilityDistance = 1,
         DeathResistance = 100,
@@ -97676,7 +97672,7 @@
     spectre.AddGold(650);
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    20)
+        new LootPackEntry(true, undeadBottles,    33)
     ));
     
     return spectre;
@@ -97700,7 +97696,7 @@
         MaxHealth = 350, Health = 350,
         BaseDodge = 15,
         HideDetection = 26,
-        Experience = 9000,
+        Experience = 19000,
     
         BasePenetration = ShieldPenetration.Heavy,
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Bashing |
@@ -97726,7 +97722,7 @@
     mummy.AddGold(1000);
     mummy.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    20)
+        new LootPackEntry(true, undeadBottles,    50)
     ));
     
     return mummy;
@@ -97749,7 +97745,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 12,
     
-        Experience = 1725,
+        Experience = 2725,
         
     };
     wraith.AddStatus(new NightVisionStatus(wraith));
@@ -97790,7 +97786,7 @@
         MaxHealth = 230, Health = 230,
         BaseDodge = 14,
                 
-        Experience = 7500,
+        Experience = 10500,
         BasePenetration = ShieldPenetration.Medium,
                                 
         Attacks = new CreatureAttackCollection()
@@ -97807,7 +97803,7 @@
     knight.AddGold(600);
     knight.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    20)
+        new LootPackEntry(true, yasnakiBottles,    33)
     ));
     
     return knight;
@@ -97831,8 +97827,9 @@
         MaxMana = 19, Mana = 19,
         BaseDodge = 14,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 8000,
+        Experience = 12000,
         VisibilityDistance = 0,
+        MagicProtection = 33,
     };
     lich.AddStatus(new NightVisionStatus(lich));
         
@@ -97853,7 +97850,7 @@
     lich.AddGold(700);
     lich.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    15)
+        new LootPackEntry(true, undeadBottles,    50)
     ));
     
     return lich;
@@ -97880,7 +97877,7 @@
         BasePenetration = ShieldPenetration.Medium,
         CanSwim = true,
         
-        Experience = 3000,
+        Experience = 7000,
             
         VisibilityDistance = 0,
     };
@@ -97929,7 +97926,7 @@
         MaxHealth = 260, Health = 260,
         BaseDodge = 16,
     
-        Experience = 8550,
+        Experience = 10550,
         BasePenetration = ShieldPenetration.Heavy,
         CanJumpkick = true,
     };
@@ -97942,7 +97939,7 @@
     martialartist.AddGold(650);
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    20)
+        new LootPackEntry(true, yasnakiBottles,    33)
     ));
     
     return martialartist;
@@ -97969,7 +97966,7 @@
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 7050,
+        Experience = 9550,
                     
         IceProtection = 100,
     };
@@ -97998,7 +97995,7 @@
     wizard.AddGold(650);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    20)
+        new LootPackEntry(true, yasnakiBottles,    33)
     ));
     
     return wizard;
@@ -98019,11 +98016,12 @@
     //todo add all yasnaki models
     var thaum = new Humanoid()
     {
+        Name = "Dark.Thaum",
         Body = 48,
         MaxHealth = 130, Health = 130,
         BaseDodge = 11,
     
-        Experience = 6000,
+        Experience = 9500,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 31, Mana = 31,
             
@@ -98038,7 +98036,7 @@
     thaum.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 7, cost: 10, 
+            skillLevel: 8, cost: 10, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
@@ -98049,7 +98047,7 @@
     thaum.AddGold(750);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    20)
+        new LootPackEntry(true, yasnakiBottles,    33)
     ));
     
     return thaum;
@@ -98087,7 +98085,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 12,
                 
-        Experience = 2700,
+        Experience = 5700,
         BasePenetration = ShieldPenetration.Light,
         Attacks = new CreatureAttackCollection()
         {
@@ -98102,7 +98100,7 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    33)
     ));
     
     return goblin;
@@ -98125,7 +98123,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 10,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 1800,
+        Experience = 4800,
     
         Attacks = new CreatureAttackCollection()
         {
@@ -98140,7 +98138,7 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    25)
     ));
     
     return goblin;
@@ -98163,7 +98161,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 1800,
+        Experience = 4800,
         
         CanFlee = true,
                 
@@ -98179,7 +98177,7 @@
     orc.AddGold(250);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    25)
     ));
     
     return orc;
@@ -98202,7 +98200,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 12,
                 
-        Experience = 2600,
+        Experience = 5600,
         BasePenetration = ShieldPenetration.Light,         
         Attacks = new CreatureAttackCollection()
         {
@@ -98216,7 +98214,7 @@
     troll.AddGold(370);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    25)
     ));
     
     return troll;
@@ -98239,7 +98237,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 11,
                 
-        Experience = 1900,
+        Experience = 4900,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
                 
@@ -98252,13 +98250,11 @@
     orc.Wield(new Longsword());
     orc.Equip(new LeatherArmor());
             
-    orc.AddGold(300);
-    /*
+    orc.AddGold(350);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, Testgems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, Testbottles,    20)
+        new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    25)
     ));
-    */
     return orc;
 ]]></block>
         <block><![CDATA[]]></block>
@@ -98279,7 +98275,7 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 10,
         BasePenetration = ShieldPenetration.Light,       
-        Experience = 1400,
+        Experience = 4400,
         
         Attacks = new CreatureAttackCollection()
         {
@@ -98293,7 +98289,7 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       10,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    20)
+        new LootPackEntry(true, GenericBottles,    25)
     ));
     
     return goblin;
@@ -98366,7 +98362,7 @@
     {
         new CreatureSpell<WhirlwindSpell>(
             skillLevel: 11,
-            mantra: SpellHelper.GenerateMantra(), instantCast: true)
+            mantra: SpellHelper.GenerateMantra(), instantCast = true)
     };
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new HummingbirdSword(),     100)
@@ -100009,7 +100005,7 @@
   </spawns>
   <treasures>
     <treasure name="GenericBottles">
-      <entry weight="20">
+      <entry weight="150">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -100018,7 +100014,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -100027,7 +100023,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="20">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -100036,7 +100032,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -100315,7 +100311,7 @@
       </entry>
     </treasure>
     <treasure name="yasnakiBottles">
-      <entry weight="20">
+      <entry weight="70">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -100324,7 +100320,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -96446,7 +96446,7 @@
         
     drake.Spells = new CreatureSpellCollection(20.0)
     {
-        new CreatureSpell<LightningBoltSpell>(9), instantCast = true,
+        new CreatureSpell<LightningBoltSpell>(9),
     };
     
     drake.AddGold(2000);
@@ -96586,14 +96586,13 @@
         BaseDodge = 19,
         
         Alignment = Alignment.Chaotic,
-        HideDetection = 28,
+        HideDetection = 30,
         Experience = 56000,
         
         Immunity = CreatureImmunity.Magic,
         Weakness = CreatureWeakness.IceSpearSpell,
         
         CanCharge = true,
-        HideDetection = 30,
         
         BasePenetration = ShieldPenetration.VeryHeavy,
     
@@ -96773,7 +96772,7 @@
     
     overlord.Spells = new CreatureSpellCollection(35.0)
     {
-        new CreatureSpell<IceSpearSpell>(10), instantCast = true,
+        new CreatureSpell<IceSpearSpell>(10),
     };
     
     overlord.AddGold(3000);
@@ -98362,7 +98361,7 @@
     {
         new CreatureSpell<WhirlwindSpell>(
             skillLevel: 11,
-            mantra: SpellHelper.GenerateMantra(), instantCast = true)
+            mantra: SpellHelper.GenerateMantra())
     };
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new HummingbirdSword(),     100)


### PR DESCRIPTION
Kesmai surface difficulty nerf - much needed to keep new players safer. It's also more in line with OG stats.

Balm drop % increase globally- should be helpful to new players, minimal bonus to old players.

Various balances to mob hit points / damage. Not a big priority just minor changes.

Massive XP overhaul to every zone except Kesmai - Normal monsters have been brought to "OG Values" except in 2 zones where difficulty had been increased (Leng Waterfall level and Gryphon Cliffs - XP is above OG levels here but should be balanced in regards to difficulty. Thought is it will add another 16+ hunting zone that people will optimize aside from TT/UK).

Several minor tile changes for static component / LOS issues.

instantCast = true, has been added to the majority of mob spells. Context from Lux will need to be looked at. Removed instantCast = false from Mausoleum Conc Wizards to test if they will by default cast with mantra.

Robe and DP vendor have been removed from Kesmai as drops are working properly now and server optimization has reduced lag to nill.

**Oakvael "Grove" segment has been spawned** - Felt right to me thematically. Check to see if snake summoning spell works on the "groveDryad" model. Monsters have some HideDetection.