### PR TITLE
Leng Maus - Fix female wizard NPC sounds and add random names for wizard NPCs

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75141,8 +75141,8 @@
                 
     var wizard = new Humanoid()
     {
-        Name = "Thrall",
-        Body = 37,
+        Name = _names.Random(),
+        Body = (female ? 37 : 38), IsFemale = female
             
         MaxHealth = 110, Health = 110,
         MaxMana = 31, Mana = 31,
@@ -75206,7 +75206,7 @@
         <block><![CDATA[
     var wizard = new Humanoid()
     {
-        Name = "Thrall",
+        Name = _names.Random(),
         Body = 38,
             
         MaxHealth = 110, Health = 110,


### PR DESCRIPTION
This PR includes a minor change to the Leng segment. In Leng Maus the female wizard NPCs were using a male chant/death sound. This is a potential fix for that issue. I have also updated Leng Maus NPC names to be randomized similar to the Kesmai segment.

- Fixed female wizard NPC in Leng Maus to use the correct sounds
- Changed wizard NPC names to be randomized similar to Kesmai segment