### PR TITLE
Fix to Worldforge not removing Region Spawner

### DIFF
--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
@@ -83,7 +83,7 @@ namespace Kesmai.WorldForge.UI.Documents
 			AddRegionSpawnerCommand = new RelayCommand(AddRegionSpawner);
 			RemoveRegionSpawnerCommand = new RelayCommand<RegionSpawner>(RemoveRegionSpawner,
 				(spawner) => SelectedRegionSpawner != null);
-			RemoveLocationSpawnerCommand.DependsOn(() => SelectedRegionSpawner);
+			RemoveRegionSpawnerCommand.DependsOn(() => SelectedRegionSpawner);
 		}
 		
 		public void AddLocationSpawner()


### PR DESCRIPTION
Quick Fix to Worldforge to fix remove region spawner button.