### PR TITLE
Hummer Guardian, Targeted Loot Changes

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Axe Glacier" version="0.72.0.0">
+<segment name="Axe Glacier" version="0.73.1.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -103131,6 +103131,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103139,6 +103140,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103180,6 +103187,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
         
@@ -103188,6 +103196,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103220,6 +103234,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103228,6 +103243,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103258,6 +103279,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103266,6 +103288,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103298,6 +103326,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103306,6 +103335,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103341,6 +103376,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103349,6 +103385,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103379,6 +103421,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new LeatherGauntlets(), 7.5)
     ));
@@ -103388,6 +103431,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103432,6 +103481,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.05), 
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5),
         new LootPackEntry(true, (from, container) => new IronOre(), 2.6)
     ));
@@ -103441,6 +103491,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103481,6 +103537,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.05),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103494,8 +103551,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="lightningmesaGoblin">
+    <entity name="lightningMesaGoblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -103519,6 +103582,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103527,6 +103591,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103561,6 +103631,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103569,6 +103640,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103609,6 +103686,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103622,8 +103700,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="lightningmesaMA">
+    <entity name="lightningMesaMA">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -103654,6 +103738,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103662,6 +103747,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103694,6 +103785,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103702,6 +103794,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103746,6 +103844,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -103755,6 +103854,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103796,6 +103901,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
         
@@ -103804,6 +103910,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103844,6 +103956,7 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103852,6 +103965,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103892,6 +104011,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103900,6 +104020,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103939,6 +104065,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103947,6 +104074,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -103977,6 +104110,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103985,6 +104119,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104015,6 +104155,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104028,8 +104169,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="lightningmesapwolf">
+    <entity name="lightningMesaPwolf">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -104072,6 +104219,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    50),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -104085,8 +104233,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperkWolf">
+    <entity name="upperBossKingWolf">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -104152,8 +104306,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperrockWorm">
+    <entity name="upperRockWorm">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -104195,6 +104355,7 @@
     rockworm.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    50),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
         
         ));
@@ -104204,6 +104365,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104244,6 +104411,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -104252,6 +104420,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104286,6 +104460,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
     
@@ -104299,8 +104474,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="lightningmesalowerLizard">
+    <entity name="lightningMesalowerLizard">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -104343,6 +104524,7 @@
     lizard.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104356,15 +104538,21 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="lightningmesagiant">
+    <entity name="lightningMesaBossGiant">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[    
     var giant = new Giant()
     {
         MaxHealth = 1000, Health = 1000,
-        BaseDodge = 23,
+        BaseDodge = 21,
     
         Experience = 19000,
         
@@ -104381,6 +104569,9 @@
     };
     
     giant.AddStatus(new NightVisionStatus(giant));
+    
+    giant.Equip(new GrizzlyJacket());
+    giant.Equip(new DragonScaleArmor());
     
     giant.Attacks = new CreatureAttackCollection
     {
@@ -104412,8 +104603,6 @@
     giant.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new PearDiamond(5000u),    100, gemsPriceMutator),
         new LootPackEntry(true, (from, container) => new ReturningHammer(),        100),
-        new LootPackEntry(true, (from, container) => new GrizzlyJacket(),        100),
-        new LootPackEntry(true, (from, container) => new DragonScaleArmor(),        100),
         new LootPackEntry(true, (from, container) => new PermanentIntelligencePotion(),        50)
     ));
        
@@ -104427,8 +104616,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="lightningmesagoose">
+    <entity name="lightningMesagoose">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -104474,6 +104669,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
     <entity name="upperGoblinSentry">
       <script name="OnSpawn" enabled="true">
@@ -104500,6 +104701,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104508,6 +104710,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104547,6 +104755,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104555,6 +104764,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104594,6 +104809,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104602,6 +104818,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104647,7 +104869,7 @@
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63),
-        
+        new LootPackEntry(true, AxePotions,     0.2),        
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5)
     ));
 
@@ -104656,6 +104878,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104686,6 +104914,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104694,6 +104923,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104734,6 +104969,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104742,6 +104978,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104772,6 +105014,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104780,6 +105023,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104817,6 +105066,7 @@
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104825,6 +105075,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104859,6 +105115,7 @@
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
     
@@ -104867,6 +105124,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104899,6 +105162,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104907,6 +105171,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104946,6 +105216,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104954,6 +105225,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -104988,6 +105265,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -104996,6 +105274,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -105037,6 +105321,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105045,6 +105330,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -105085,6 +105376,7 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105093,6 +105385,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -105131,17 +105429,17 @@
         new CreatureBlock(3, "a claw"),
         new CreatureBlock(1, "a tail")
     };
-    
-    lizard.Spells = new CreatureSpellCollection(80.0)
+    lizard.Spells = new CreatureSpellCollection(100)
     {
-        new CreatureSpell<IceStormSpell>(
-        skillLevel: 8, intensity: 2)
+       { new CreatureSpell<IceStormSpell>(
+            skillLevel: 9.5, intensity: 2), 100, TimeSpan.FromSeconds(5.0) }
     };
     
     lizard.AddGold(500);
     lizard.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105155,8 +105453,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="uppereasyBear">
+    <entity name="upperEasyBear">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105194,6 +105498,7 @@
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    50),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105207,8 +105512,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperhardBear">
+    <entity name="upperHardBear">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105249,6 +105560,7 @@
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, minibossTreasureGems,       50,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    75),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105262,8 +105574,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperdrake">
+    <entity name="upperBossDrake">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105307,7 +105625,7 @@
         CanPanic = false,
         
         //CanJumpkick means it can jumpkick from 3 hexes away. I'm not sure where damage component for a jumpkick is pulled though so I don't know whether Charge or JK is the proper variable
-        CanJumpkick = true,
+        CanJumpkick = false,
         
         //If set to false, monster cannot walk on land and will stay in water.
         CanWalk = true,
@@ -105369,15 +105687,10 @@
     drake.AddGold(5000);
     drake.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new PearDiamond(10000u),    100, gemsPriceMutator),
-        new LootPackEntry(true, (from, container) => new StrongShieldRing(),    50),
         new LootPackEntry(true, (from, container) => new PermanentConstitutionPotion(),     100),
-        new LootPackEntry(true, (from, container) => new LightningShield(),     10),
-        new LootPackEntry(true, (from, container) => new StrongStrengthBracelet(),    50),
-        new LootPackEntry(true, (from, container) => new GriffinSkull(),    100),
-        new LootPackEntry(true, (from, container) => new ManaPotion(),    100),
-        new LootPackEntry(true, (from, container) => new StunResistanceBracelet(),    50),
-        new LootPackEntry(true, (from, container) => new FeatherFallBoots(),    100),
-        new LootPackEntry(true, (from, container) => new DexterityRing(),    10)
+        new LootPackEntry(true, DrakeTreasure,     100.0), 
+        new LootPackEntry(true, DrakeTreasure2,     100.0),
+        new LootPackEntry(true, (from, container) => new ManaPotion(),    100)
     ));
     
     return drake;
@@ -105390,8 +105703,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="uppericeDragon">
+    <entity name="upperBossDragon">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105400,7 +105719,7 @@
     {
         MaxHealth = 5000, Health = 5000,
         BaseDodge = 19,
-        
+        Body = 135,
         Experience = 75000,
         
         CanFly = true,
@@ -105426,7 +105745,7 @@
     dragon.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(21,      40, 65,      "The Ice Dragon slashes you with a claw.",
+            new CreatureAttack(21,      50, 70,      "The Ice Dragon slashes you with a claw.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
@@ -105436,7 +105755,7 @@
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(17,      75, 100,     "The Ice Dragon buffets you with its wings.",
+            new CreatureAttack(18,      75, 110,     "The Ice Dragon buffets you with its wings.",
                                                         new AttackProneComponent(35), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -105454,16 +105773,14 @@
         new CreatureSpell<DragonBreathIceSpell>(
             skillLevel: 21), 
     };
-    //todo: add griffin figurine, protection from cold amulet (replaces f/i ammy)
+    //todo: add griffin figurine, protection from cold amulet (replaces f/i ammy?)
     dragon.AddGold(6000);
     dragon.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new PearDiamond(25000u),    100, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new IceDragonScaleArmor(),        100),
         new LootPackEntry(true, (from, container) => new DragonSkull(),        100),
-        new LootPackEntry(true, (from, container) => new IvoryBrooch(),        25),
-        new LootPackEntry(true, (from, container) => new ShieldBracelet(),        25),
-        new LootPackEntry(true, (from, container) => new FireProtectionAmulet(),        25),
-        new LootPackEntry(true, (from, container) => new StrengthRing(),        25),
-        new LootPackEntry(true, (from, container) => new FeatherFallBoots(),        100),
+        new LootPackEntry(true, MamaTreasure,     100.0), 
+        new LootPackEntry(true, MamaTreasure2,     100.0),
         new LootPackEntry(true, (from, container) => new ManaPotion(),        100)
     ));
     
@@ -105477,8 +105794,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperyeti">
+    <entity name="upperBossYeti">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105509,12 +105832,12 @@
     yeti.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(13,      50, 70,      "The yeti smashes you with his fist.",
+            new CreatureAttack(20,      50, 70,      "The yeti smashes you with his fist.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(13,      60, 80,     "The yeti stomps on you.",
+            new CreatureAttack(18,      60, 80,     "The yeti stomps on you.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               40
         },
@@ -105541,11 +105864,8 @@
    yeti.AddGold(12000);
    yeti.AddLoot(new LootPack(
        new LootPackEntry(true, (from, container) => new PearDiamond(20000u),    100, gemsPriceMutator),
-       new LootPackEntry(true, (from, container) => new BearSkull(),        100),
-       new LootPackEntry(true, (from, container) => new BreatheWaterBracelet(),        33),
+       new LootPackEntry(true, YetiTreasure,     100.0),       
        new LootPackEntry(true, (from, container) => new ManaPotion(),        100),
-       new LootPackEntry(true, (from, container) => new SaffronRobe(),        33),
-       new LootPackEntry(true, (from, container) => new FeatherFallBoots(),        100),
        new LootPackEntry(true, (from, container) => new MisericordeDagger(),        100)
    ));
     
@@ -105559,8 +105879,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axeconfessorGhost">
+    <entity name="axeConfessorGhost">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105574,8 +105900,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axebalmVendor">
+    <entity name="axeBalmVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105597,6 +105929,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -105632,6 +105970,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
     <entity name="axeBanker">
       <script name="OnSpawn" enabled="true">
@@ -105660,8 +106004,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axeojouleWizard">
+    <entity name="axeOjouleWizard">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105690,8 +106040,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axerecallVendor">
+    <entity name="axeRecallVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105718,8 +106074,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axestatue">
+    <entity name="axeStatue">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105758,8 +106120,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axewepTrainTemp">
+    <entity name="axeWeaponTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105785,8 +106153,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axetailorVendor">
+    <entity name="axeTailorVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105812,8 +106186,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axephredrickThaum">
+    <entity name="axePhredrickThaum">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105845,8 +106225,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="uppershadow">
+    <entity name="upperShadow">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105882,6 +106268,7 @@
     shadow.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105890,6 +106277,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -105949,6 +106342,7 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105957,6 +106351,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -106006,6 +106406,7 @@
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106014,6 +106415,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -106065,6 +106472,7 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106078,8 +106486,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="magicPeacekeeperTemplate">
+    <entity name="axeMagicPeacekeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106111,8 +106525,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axethaumTemplate">
+    <entity name="axeThaumTemplate">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106143,8 +106563,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axewizTrainer">
+    <entity name="axeWizardTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106175,8 +106601,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axelawfulGryphon">
+    <entity name="axeLawfulGryphon">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106234,8 +106666,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axePresence">
+    <entity name="upperPresence">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106290,8 +106728,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperyetiGoblin">
+    <entity name="upperYetiGoblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106317,6 +106761,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106330,8 +106775,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="upperyetiGoblinSentry">
+    <entity name="upperYetiGoblinSentry">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106356,6 +106807,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106369,8 +106821,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
-    <entity name="axethiefTrainer">
+    <entity name="axeThiefTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106397,6 +106855,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
     <entity name="axeVulcan">
       <script name="OnSpawn" enabled="true">
@@ -106407,6 +106871,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -106427,6 +106897,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
     </entity>
     <entity name="axeAlia">
       <script name="OnSpawn" enabled="true">
@@ -106437,6 +106913,12 @@
         <block><![CDATA[]]></block>
       </script>
       <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 ]]></block>
@@ -106544,7 +107026,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axewepTrainTemp" size="1" minimum="1" maximum="1" />
+      <entry entity="axeWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="31" y="29" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="axeOjoule">
@@ -106564,7 +107046,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axeojouleWizard" size="1" minimum="1" maximum="1" />
+      <entry entity="axeOjouleWizard" size="1" minimum="1" maximum="1" />
       <location x="27" y="15" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="axePhredrick">
@@ -106584,7 +107066,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axephredrickThaum" size="1" minimum="1" maximum="1" />
+      <entry entity="axePhredrickThaum" size="1" minimum="1" maximum="1" />
       <location x="32" y="11" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="Statue 1">
@@ -106604,7 +107086,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axestatue" size="1" minimum="1" maximum="1" />
+      <entry entity="axeStatue" size="1" minimum="1" maximum="1" />
       <location x="24" y="16" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="Statue 2">
@@ -106624,7 +107106,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axestatue" size="1" minimum="1" maximum="1" />
+      <entry entity="axeStatue" size="1" minimum="1" maximum="1" />
       <location x="25" y="22" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="Statue 3">
@@ -106644,7 +107126,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axestatue" size="1" minimum="1" maximum="1" />
+      <entry entity="axeStatue" size="1" minimum="1" maximum="1" />
       <location x="31" y="14" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="axePriest">
@@ -106686,7 +107168,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="magicPeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="axeMagicPeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="31" y="6" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="axeBalmVendor">
@@ -106706,12 +107188,13 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axebalmVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="axeBalmVendor" size="1" minimum="1" maximum="1" />
       <location x="33" y="24" region="1" />
     </spawn>
-    <spawn type="LocationSpawner" name="recallVendor">
+    <spawn type="LocationSpawner" name="axeRecallVendor">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>900</maximumDelay>
+      <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -106726,7 +107209,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axerecallVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="axeRecallVendor" size="1" minimum="1" maximum="1" />
       <location x="30" y="24" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="axeThorgen">
@@ -106755,7 +107238,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axewepTrainTemp" size="1" minimum="1" maximum="1" />
+      <entry entity="axeWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="32" y="22" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="axeGhost">
@@ -106775,7 +107258,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axeconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="axeConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="13" y="4" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="lockpickVendor">
@@ -106887,7 +107370,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axebalmVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="axeBalmVendor" size="1" minimum="1" maximum="1" />
       <location x="8" y="15" region="15" />
     </spawn>
     <spawn type="LocationSpawner" name="lockpickWizTrainer">
@@ -106908,7 +107391,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axewizTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="axeWizardTrainer" size="1" minimum="1" maximum="1" />
       <location x="4" y="2" region="15" />
     </spawn>
     <spawn type="LocationSpawner" name="lockpickThaumTrainer">
@@ -106934,7 +107417,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axethaumTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="axeThaumTemplate" size="1" minimum="1" maximum="1" />
       <location x="7" y="3" region="15" />
     </spawn>
     <spawn type="LocationSpawner" name="lockpickMATrainer">
@@ -106963,7 +107446,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axewepTrainTemp" size="1" minimum="1" maximum="1" />
+      <entry entity="axeWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="2" y="5" region="15" />
     </spawn>
     <spawn type="LocationSpawner" name="lockpickWeaponTrainer">
@@ -106992,7 +107475,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axewepTrainTemp" size="1" minimum="1" maximum="1" />
+      <entry entity="axeWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="10" y="22" region="15" />
     </spawn>
     <spawn type="LocationSpawner" name="lawfulGryphon">
@@ -107012,10 +107495,10 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axelawfulGryphon" size="1" minimum="1" maximum="1" />
+      <entry entity="axeLawfulGryphon" size="1" minimum="1" maximum="1" />
       <location x="35" y="34" region="8" />
     </spawn>
-    <spawn type="LocationSpawner" name="tanner">
+    <spawn type="LocationSpawner" name="axeTanner">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>900</maximumDelay>
       <script name="OnAfterSpawn" enabled="false">
@@ -107032,7 +107515,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axetailorVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="axeTailorVendor" size="1" minimum="1" maximum="1" />
       <location x="34" y="36" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="lockpickTanner">
@@ -107054,10 +107537,10 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axetailorVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="axeTailorVendor" size="1" minimum="1" maximum="1" />
       <location x="6" y="18" region="15" />
     </spawn>
-    <spawn type="LocationSpawner" name="figEngraver">
+    <spawn type="LocationSpawner" name="giantFigEngraver">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>900</maximumDelay>
       <script name="OnAfterSpawn" enabled="true">
@@ -107086,6 +107569,7 @@
     <spawn type="LocationSpawner" name="axeMAFoote">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>900</maximumDelay>
+      <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -107109,10 +107593,11 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
+      <entry entity="axeWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="35" y="22" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="Vulcan">
-	  <minimumDelay>900</minimumDelay>
+      <minimumDelay>900</minimumDelay>
       <maximumDelay>900</maximumDelay>
       <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
@@ -107172,7 +107657,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axerecallVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="axeRecallVendor" size="1" minimum="1" maximum="1" />
       <location x="3" y="11" region="15" />
     </spawn>
     <spawn type="RegionSpawner" name="Surface Dungeon">
@@ -107251,14 +107736,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lightningmesaGoblin" size="3" minimum="3" maximum="6" />
+      <entry entity="lightningMesaGoblin" size="3" minimum="3" maximum="6" />
       <entry entity="lightningMesaTroll" size="2" minimum="2" maximum="5" />
       <entry entity="lightningMesaFighter" size="1" minimum="2" maximum="4" />
-      <entry entity="lightningmesaMA" size="1" minimum="2" maximum="4" />
+      <entry entity="lightningMesaMA" size="1" minimum="2" maximum="4" />
       <entry entity="lightningMesaOrc" size="3" minimum="3" maximum="6" />
       <entry entity="lightningMesaGargoyle" size="1" minimum="2" maximum="4" />
       <entry entity="lightningMesaGoblinMage" size="1" minimum="2" maximum="4" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <entry entity="lightningMesaRapier" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaGoblinSentry" size="2" minimum="3" maximum="6" />
       <entry entity="lightningMesaHobgoblin" size="3" minimum="3" maximum="6" />
@@ -107288,7 +107773,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="lightningMesaWraith" size="1" minimum="2" maximum="4" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <entry entity="lightningMesaTroll" size="2" minimum="2" maximum="4" />
       <entry entity="lightningMesaGargoyle" size="1" minimum="0" maximum="0" />
       <entry entity="lightningMesaHobgoblin" size="3" minimum="3" maximum="4" />
@@ -107322,10 +107807,10 @@
       <entry entity="lightningMesaGoblinMage" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaTroll" size="2" minimum="3" maximum="5" />
       <entry entity="lightningMesaFighter" size="1" minimum="1" maximum="3" />
-      <entry entity="lightningmesaMA" size="1" minimum="1" maximum="3" />
+      <entry entity="lightningMesaMA" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaOrc" size="3" minimum="3" maximum="5" />
-      <entry entity="upperrockWorm" size="1" minimum="1" maximum="2" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="upperRockWorm" size="1" minimum="1" maximum="2" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <entry entity="lightningMesaWraith" size="1" minimum="1" maximum="2" />
       <entry entity="lightningMesaGoblinSentry" size="3" minimum="2" maximum="4" />
       <entry entity="lightningMesaOgre" size="1" minimum="1" maximum="2" />
@@ -107355,18 +107840,18 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lightningmesaGoblin" size="3" minimum="3" maximum="5" />
+      <entry entity="lightningMesaGoblin" size="3" minimum="3" maximum="5" />
       <entry entity="lightningMesaTroll" size="2" minimum="3" maximum="5" />
       <entry entity="lightningMesaFighter" size="1" minimum="2" maximum="5" />
-      <entry entity="lightningmesaMA" size="1" minimum="1" maximum="3" />
+      <entry entity="lightningMesaMA" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaOrc" size="3" minimum="3" maximum="5" />
       <entry entity="lightningMesaWolf" size="3" minimum="2" maximum="5" />
       <entry entity="lightningMesaWraith" size="1" minimum="2" maximum="3" />
       <entry entity="lightningMesaGoblinMage" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaRapier" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaGoblinSentry" size="3" minimum="1" maximum="3" />
-      <entry entity="upperrockWorm" size="1" minimum="1" maximum="2" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="upperRockWorm" size="1" minimum="1" maximum="2" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <bounds region="6">
         <inclusion left="2" top="4" right="25" bottom="12" />
         <inclusion left="5" top="13" right="7" bottom="21" />
@@ -107397,7 +107882,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="lightningMesaRapier" size="1" minimum="1" maximum="4" />
-      <entry entity="lightningmesaMA" size="1" minimum="1" maximum="5" />
+      <entry entity="lightningMesaMA" size="1" minimum="1" maximum="5" />
       <entry entity="lightningMesaFighter" size="1" minimum="1" maximum="5" />
       <entry entity="lightningMesaArcher" size="1" minimum="1" maximum="3" />
       <bounds region="6">
@@ -107426,7 +107911,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="lightningMesaGoblinSentry" size="3" minimum="1" maximum="1" />
-      <entry entity="lightningmesaMA" size="1" minimum="1" maximum="3" />
+      <entry entity="lightningMesaMA" size="1" minimum="1" maximum="3" />
       <entry entity="lightningMesaArcher" size="1" minimum="2" maximum="3" />
       <entry entity="lightningMesaFighter" size="1" minimum="3" maximum="4" />
       <bounds region="8">
@@ -107453,8 +107938,8 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lightningmesagiant" size="1" minimum="1" maximum="1" />
-      <entry entity="lightningmesagoose" size="1" minimum="1" maximum="1" />
+      <entry entity="lightningMesaBossGiant" size="1" minimum="1" maximum="1" />
+      <entry entity="lightningMesagoose" size="1" minimum="1" maximum="1" />
       <bounds region="8">
         <inclusion left="18" top="13" right="20" bottom="16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -107479,7 +107964,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="lightningMesaArcher" size="1" minimum="2" maximum="4" />
-      <entry entity="lightningmesaMA" size="1" minimum="2" maximum="3" />
+      <entry entity="lightningMesaMA" size="1" minimum="2" maximum="3" />
       <entry entity="lightningMesaFighter" size="1" minimum="2" maximum="4" />
       <entry entity="lightningMesaRapier" size="1" minimum="2" maximum="4" />
       <bounds region="8">
@@ -107508,17 +107993,17 @@
       <entry entity="upperGoblinSentry" size="3" minimum="5" maximum="8" />
       <entry entity="upperOgre" size="1" minimum="3" maximum="5" />
       <entry entity="upperWolf" size="3" minimum="4" maximum="7" />
-      <entry entity="uppershadow" size="1" minimum="3" maximum="5" />
+      <entry entity="upperShadow" size="1" minimum="3" maximum="5" />
       <entry entity="upperHobgoblin" size="3" minimum="4" maximum="7" />
       <entry entity="upperGoblinMage" size="1" minimum="2" maximum="4" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="2" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="2" />
       <entry entity="upperTroll" size="2" minimum="3" maximum="6" />
       <entry entity="upperGoblin" size="3" minimum="4" maximum="7" />
       <entry entity="upperWraith" size="1" minimum="3" maximum="6" />
-      <entry entity="upperhardBear" size="1" minimum="1" maximum="1" />
-      <entry entity="upperrockWorm" size="1" minimum="1" maximum="2" />
+      <entry entity="upperHardBear" size="1" minimum="1" maximum="1" />
+      <entry entity="upperRockWorm" size="1" minimum="1" maximum="2" />
       <entry entity="upperOrc" size="3" minimum="4" maximum="7" />
-      <entry entity="uppereasyBear" size="1" minimum="1" maximum="3" />
+      <entry entity="upperEasyBear" size="1" minimum="1" maximum="3" />
       <bounds region="12">
         <inclusion left="1" top="1" right="24" bottom="38" />
         <inclusion left="25" top="9" right="29" bottom="38" />
@@ -107545,8 +108030,8 @@
       </script>
       <entry entity="upperLizard" size="1" minimum="3" maximum="4" />
       <entry entity="upperWolf" size="3" minimum="2" maximum="4" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
-      <entry entity="uppereasyBear" size="1" minimum="1" maximum="2" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="upperEasyBear" size="1" minimum="1" maximum="2" />
       <bounds region="12">
         <inclusion left="25" top="3" right="32" bottom="8" />
         <inclusion left="30" top="9" right="34" bottom="31" />
@@ -107578,10 +108063,10 @@
       <entry entity="upperWraith" size="1" minimum="1" maximum="3" />
       <entry entity="upperHobgoblin" size="3" minimum="1" maximum="5" />
       <entry entity="upperWolf" size="3" minimum="2" maximum="5" />
-      <entry entity="uppershadow" size="1" minimum="2" maximum="4" />
-      <entry entity="uppereasyBear" size="1" minimum="1" maximum="2" />
-      <entry entity="upperrockWorm" size="1" minimum="1" maximum="2" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="upperShadow" size="1" minimum="2" maximum="4" />
+      <entry entity="upperEasyBear" size="1" minimum="1" maximum="2" />
+      <entry entity="upperRockWorm" size="1" minimum="1" maximum="2" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <entry entity="upperOrc" size="3" minimum="2" maximum="4" />
       <bounds region="12">
         <inclusion left="38" top="4" right="46" bottom="36" />
@@ -107613,12 +108098,12 @@
       <entry entity="lightningMesaWraith" size="1" minimum="1" maximum="2" />
       <entry entity="lightningMesaOgre" size="1" minimum="2" maximum="4" />
       <entry entity="lightningMesaOrc" size="3" minimum="3" maximum="5" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="2" />
-      <entry entity="uppereasyBear" size="1" minimum="1" maximum="2" />
-      <entry entity="upperhardBear" size="1" minimum="0" maximum="1" />
-      <entry entity="upperrockWorm" size="1" minimum="1" maximum="2" />
-      <entry entity="lightningmesaGoblin" size="3" minimum="2" maximum="4" />
-      <entry entity="upperkWolf" size="1" minimum="0" maximum="1" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="2" />
+      <entry entity="upperEasyBear" size="1" minimum="1" maximum="2" />
+      <entry entity="upperHardBear" size="1" minimum="0" maximum="1" />
+      <entry entity="upperRockWorm" size="1" minimum="1" maximum="2" />
+      <entry entity="lightningMesaGoblin" size="3" minimum="2" maximum="4" />
+      <entry entity="upperBossKingWolf" size="1" minimum="0" maximum="1" />
       <bounds region="10">
         <inclusion left="1" top="3" right="25" bottom="39" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -107668,7 +108153,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <entry entity="upperLizard" size="1" minimum="2" maximum="3" />
       <bounds region="23">
         <inclusion left="2" top="8" right="7" bottom="27" />
@@ -107726,8 +108211,8 @@
       <entry entity="upperHobgoblin" size="3" minimum="1" maximum="2" />
       <entry entity="upperTroll" size="2" minimum="1" maximum="2" />
       <entry entity="upperGoblinSentry" size="3" minimum="1" maximum="2" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
-      <entry entity="upperkWolf" size="1" minimum="0" maximum="1" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="upperBossKingWolf" size="1" minimum="0" maximum="1" />
       <entry entity="upperWraith" size="1" minimum="0" maximum="1" />
       <bounds region="23">
         <inclusion left="11" top="3" right="16" bottom="20" />
@@ -107754,7 +108239,7 @@
       </script>
       <entry entity="upperLizard" size="1" minimum="2" maximum="4" />
       <entry entity="upperWolf" size="3" minimum="2" maximum="3" />
-      <entry entity="upperhardBear" size="1" minimum="1" maximum="2" />
+      <entry entity="upperHardBear" size="1" minimum="1" maximum="2" />
       <bounds region="45">
         <inclusion left="1" top="5" right="10" bottom="20" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -107778,9 +108263,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="upperyetiGoblin" size="1" minimum="3" maximum="4" />
-      <entry entity="upperyetiGoblinSentry" size="1" minimum="3" maximum="4" />
-      <entry entity="upperyeti" size="1" minimum="1" maximum="1" />
+      <entry entity="upperYetiGoblin" size="1" minimum="3" maximum="4" />
+      <entry entity="upperYetiGoblinSentry" size="1" minimum="3" maximum="4" />
+      <entry entity="upperBossYeti" size="1" minimum="1" maximum="1" />
       <bounds region="45">
         <inclusion left="11" top="9" right="15" bottom="14" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -107912,7 +108397,7 @@
       <entry entity="chaosMA" size="1" minimum="2" maximum="4" />
       <entry entity="chaosWizard" size="1" minimum="1" maximum="2" />
       <entry entity="upperWolf" size="3" minimum="2" maximum="3" />
-      <entry entity="lightningmesapwolf" size="1" minimum="0" maximum="1" />
+      <entry entity="lightningMesaPwolf" size="1" minimum="0" maximum="1" />
       <entry entity="chaosThaum" size="1" minimum="1" maximum="2" />
       <bounds region="18">
         <inclusion left="7" top="4" right="14" bottom="28" />
@@ -107968,7 +108453,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uppericeDragon" size="1" minimum="1" maximum="1" />
+      <entry entity="upperBossDragon" size="1" minimum="1" maximum="1" />
       <bounds region="39">
         <inclusion left="0" top="0" right="5" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -107992,7 +108477,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="upperdrake" size="1" minimum="1" maximum="1" />
+      <entry entity="upperBossDrake" size="1" minimum="1" maximum="1" />
       <bounds region="36">
         <inclusion left="0" top="0" right="7" bottom="7" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -108016,7 +108501,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="axePresence" size="1" minimum="1" maximum="1" />
+      <entry entity="upperPresence" size="1" minimum="1" maximum="1" />
       <bounds region="36">
         <inclusion left="0" top="0" right="7" bottom="7" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -108044,7 +108529,7 @@
       <entry entity="surfaceGoblin" size="3" minimum="2" maximum="2" />
       <entry entity="lightningMesaWraith" size="1" minimum="2" maximum="2" />
       <entry entity="lightningMesaWolf" size="3" minimum="2" maximum="2" />
-      <entry entity="lightningmesaGoblin" size="3" minimum="2" maximum="2" />
+      <entry entity="lightningMesaGoblin" size="3" minimum="2" maximum="2" />
       <bounds region="6">
         <inclusion left="33" top="11" right="54" bottom="39" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -108120,7 +108605,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -108142,7 +108627,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new ShieldRing();
+	return new WeakShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -108245,7 +108730,7 @@
       </entry>
     </treasure>
     <treasure name="upperTreasure">
-      <entry weight="5">
+      <entry weight="15">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -108263,7 +108748,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -108272,20 +108757,20 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new StrongShieldRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
+      <entry weight="7">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -108315,6 +108800,217 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new UncutDiamond(2000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="AxePotions">
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentStrengthPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentConstitutionPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWillpowerPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentDexterityPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentIntelligencePotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="MamaTreasure">
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new IvoryBrooch();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="YetiTreasure">
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BreatheWaterBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BearSkull();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SaffronRobe();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FeatherFallBoots();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="DrakeTreasure">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new WeakDexterityRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="6">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new GriffinSkull();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StunResistanceBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="MamaTreasure2">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentConstitutionPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+    //todo add griffin fig
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FeatherFallBoots();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="DrakeTreasure2">
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new LightningShield();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -96738,7 +96738,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="elderTroll">
+    <entity name="dungeon1BossTrogg">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96807,7 +96807,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="recallVendor">
+    <entity name="kesRecallVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96841,7 +96841,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="balmVendor">
+    <entity name="kesBalmVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96875,7 +96875,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="mugwortVendor">
+    <entity name="kesMugwortVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96909,7 +96909,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="marlisBanker">
+    <entity name="kesMarlisBanker">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96942,7 +96942,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="tailorVendor">
+    <entity name="kesTailorVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96975,7 +96975,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="shopkeeperTemplate">
+    <entity name="kesShopkeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[/*  This is a template from which all shopkeepers are created. 
     Check each individual spawner for counter assignments. 
@@ -97011,7 +97011,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="weaponTrainerTemplate">
+    <entity name="kesWeaponTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97044,7 +97044,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="svenThaumaturge">
+    <entity name="kesSvenThaumaturge">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97083,7 +97083,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oskarWizard">
+    <entity name="kesOskarWizard">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97119,7 +97119,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="larsThief">
+    <entity name="kesLarsThief">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97156,7 +97156,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="meleePeacekeeperTemplate">
+    <entity name="kesMeleePeacekeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[/* Template used by Ingrid, Val, and Tak. */
 ]]></block>
@@ -97195,7 +97195,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="magicPeacekeeperTemplate">
+    <entity name="kesMagicPeacekeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[/* Template used by Maria */
 ]]></block>
@@ -97235,7 +97235,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="rangedPeacekeeperTemplate">
+    <entity name="kesRangedPeacekeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97294,7 +97294,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="confessorGhost">
+    <entity name="kesConfessorGhost">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97315,7 +97315,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="crocodileLawful">
+    <entity name="kesCrocodileLawful">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97367,7 +97367,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="biscuit">
+    <entity name="kesBiscuit">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97418,7 +97418,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="sharkLawful">
+    <entity name="kesSharkLawful">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97472,7 +97472,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="hermann">
+    <entity name="knightHermann">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97502,7 +97502,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="harriette">
+    <entity name="knightHarriette">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97987,7 +97987,7 @@ return orc;
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="enragedTroll">
+    <entity name="dungeon1EnragedTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98034,7 +98034,7 @@ return orc;
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="kesmaiSpider">
+    <entity name="dungeon2Spider">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -100165,7 +100165,7 @@ return orc;
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="abesh">
+    <entity name="ydnacAbesh">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -100655,7 +100655,7 @@ return orc;
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="kesmaiSherriff">
+    <entity name="kesSherriff">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -100776,7 +100776,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="elderTroll" size="1" minimum="1" maximum="1" />
+      <entry entity="dungeon1BossTrogg" size="1" minimum="1" maximum="1" />
       <location x="15" y="39" region="11" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiRecallVendor">
@@ -100796,7 +100796,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="recallVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="kesRecallVendor" size="1" minimum="1" maximum="1" />
       <location x="41" y="27" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiBalmVendor">
@@ -100816,7 +100816,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="balmVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="kesBalmVendor" size="1" minimum="1" maximum="1" />
       <location x="29" y="8" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiMugwortVendor">
@@ -100836,7 +100836,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="mugwortVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMugwortVendor" size="1" minimum="1" maximum="1" />
       <location x="40" y="19" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiMarlis">
@@ -100857,7 +100857,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="marlisBanker" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMarlisBanker" size="1" minimum="1" maximum="1" />
       <location x="28" y="23" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiTailor">
@@ -100877,7 +100877,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="tailorVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="kesTailorVendor" size="1" minimum="1" maximum="1" />
       <location x="22" y="20" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiJeweler">
@@ -100951,7 +100951,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="34" y="28" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiArmorer">
@@ -101027,7 +101027,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="25" y="21" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiWeaponsmith">
@@ -101089,7 +101089,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="34" y="21" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiPawnshop">
@@ -101112,7 +101112,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="40" y="32" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiApothecary">
@@ -101190,7 +101190,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="42" y="16" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiRolf">
@@ -101219,7 +101219,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="24" y="14" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiRocky.T.Orc">
@@ -101247,7 +101247,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="67" y="35" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiOlaf">
@@ -101276,7 +101276,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="weaponTrainerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="38" y="16" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiNeela">
@@ -101305,7 +101305,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="weaponTrainerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="22" y="22" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiPhong">
@@ -101334,7 +101334,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="weaponTrainerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="85" y="35" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiWulfgar">
@@ -101363,7 +101363,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="weaponTrainerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="5" y="27" region="12" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiSven">
@@ -101383,7 +101383,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="svenThaumaturge" size="1" minimum="1" maximum="1" />
+      <entry entity="kesSvenThaumaturge" size="1" minimum="1" maximum="1" />
       <location x="30" y="6" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiOskar">
@@ -101403,7 +101403,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oskarWizard" size="1" minimum="1" maximum="1" />
+      <entry entity="kesOskarWizard" size="1" minimum="1" maximum="1" />
       <location x="40" y="23" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiLars">
@@ -101423,7 +101423,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="larsThief" size="1" minimum="1" maximum="1" />
+      <entry entity="kesLarsThief" size="1" minimum="1" maximum="1" />
       <location x="45" y="29" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiIngrid">
@@ -101455,7 +101455,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="meleePeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMeleePeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="31" y="28" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiVal">
@@ -101487,7 +101487,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="meleePeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMeleePeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="29" y="12" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiTak">
@@ -101520,7 +101520,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="meleePeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMeleePeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="32" y="12" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiMaria">
@@ -101559,7 +101559,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="magicPeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMagicPeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="30" y="30" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiSheriff">
@@ -101578,7 +101578,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="kesmaiSherriff" size="1" minimum="1" maximum="1" />
+      <entry entity="kesSherriff" size="1" minimum="1" maximum="1" />
       <location x="39" y="26" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiPriest">
@@ -101620,7 +101620,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="magicPeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="kesMagicPeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="28" y="6" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiIronbar">
@@ -101660,7 +101660,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="confessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="kesConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="33" y="6" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiCrocodile">
@@ -101680,7 +101680,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="crocodileLawful" size="1" minimum="1" maximum="1" />
+      <entry entity="kesCrocodileLawful" size="1" minimum="1" maximum="1" />
       <location x="30" y="16" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiBiscuit">
@@ -101700,7 +101700,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="biscuit" size="1" minimum="1" maximum="1" />
+      <entry entity="kesBiscuit" size="1" minimum="1" maximum="1" />
       <location x="33" y="13" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kesmaiShark">
@@ -101720,7 +101720,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="sharkLawful" size="1" minimum="1" maximum="1" />
+      <entry entity="kesSharkLawful" size="1" minimum="1" maximum="1" />
       <location x="30" y="38" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="questHermann">
@@ -101740,7 +101740,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="hermann" size="1" minimum="1" maximum="1" />
+      <entry entity="knightHermann" size="1" minimum="1" maximum="1" />
       <location x="127" y="3" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="questHarriette">
@@ -101760,7 +101760,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="harriette" size="1" minimum="1" maximum="1" />
+      <entry entity="knightHarriette" size="1" minimum="1" maximum="1" />
       <location x="129" y="4" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="cryptMinions">
@@ -101804,7 +101804,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="kesmaiSpider" size="1" minimum="1" maximum="1" />
+      <entry entity="dungeon2Spider" size="1" minimum="1" maximum="1" />
       <location x="15" y="33" region="12" />
     </spawn>
     <spawn type="LocationSpawner" name="cryptTrolls">
@@ -101824,7 +101824,7 @@ return orc;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="enragedTroll" size="1" minimum="1" maximum="2" />
+      <entry entity="dungeon1EnragedTroll" size="1" minimum="1" maximum="2" />
       <location x="24" y="33" region="12" />
     </spawn>
     <spawn type="LocationSpawner" name="ydnacMummy">
@@ -102160,7 +102160,7 @@ return orc;
         <block><![CDATA[]]></block>
       </script>
       <entry entity="ydnac" size="1" minimum="1" maximum="1" />
-      <entry entity="abesh" size="1" minimum="1" maximum="1" />
+      <entry entity="ydnacAbesh" size="1" minimum="1" maximum="1" />
       <bounds region="1">
         <inclusion left="138" top="3" right="141" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -74781,6 +74781,7 @@
     skeleton.AddGold(150);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems, 33, gemsPriceMutator),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausBottles, 16)
     ));
     
@@ -74801,7 +74802,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengbalmVendor">
+    <entity name="lengBalmVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -74835,7 +74836,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengconfessorGhost">
+    <entity name="lengConfessorGhost">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -74856,7 +74857,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengthiefTrainer">
+    <entity name="lengThiefTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -74890,7 +74891,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengweaponTrainer">
+    <entity name="lengWeaponTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -74923,7 +74924,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengwizTrainer">
+    <entity name="lengWizTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -74958,7 +74959,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengthaumTrainer">
+    <entity name="lengThaumTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -74993,7 +74994,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengshopkeeperTemplate">
+    <entity name="lengShopkeeperTemplate">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75025,7 +75026,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengbankerTemplate">
+    <entity name="lengBankerTemplate">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75057,7 +75058,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengmugwortVendor">
+    <entity name="lengMugwortVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75091,7 +75092,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengrecallVendor">
+    <entity name="lengRecallVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75125,7 +75126,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="lengtannerTemplate">
+    <entity name="lengTannerTemplate">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75196,6 +75197,7 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75268,6 +75270,7 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75334,6 +75337,7 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75396,6 +75400,7 @@
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75445,6 +75450,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75504,6 +75510,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75556,6 +75563,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)        
     ));
     
@@ -75576,7 +75584,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="mausraven">
+    <entity name="mausRaven">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75631,7 +75639,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacebridgeTroll">
+    <entity name="surfaceBridgeTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75661,7 +75669,7 @@
     bridgeTroll.AddGold(500);
     
     bridgeTroll.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new WingedHelm(),         40.0),
+        new LootPackEntry(true, LengPotions,    0.05),
         new LootPackEntry(true, MinotaurGems,       10,     gemsPriceMutator)
     ));
     
@@ -75682,7 +75690,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacepowerTroll">
+    <entity name="surfacePowerTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75714,7 +75722,9 @@
     powerTroll.AddGold(800);
     
     powerTroll.AddLoot(new LootPack(
+        new LootPackEntry(true, (from, container) => new WingedHelm(),         40.0),
         new LootPackEntry(true, (from, container) => new PearDiamond(1200u),         40.0),
+        new LootPackEntry(true, LengPotions,    0.05),
         new LootPackEntry(true, (from, container) => new Diamond(1500u),         50.0)
     ));
     
@@ -75803,7 +75813,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="mauspresence">
+    <entity name="mausPresence">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75946,7 +75956,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="shidninjaguardians">
+    <entity name="shidNinja">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76000,6 +76010,7 @@
    ninja.AddGold(500);
    ninja.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausBottles,    20)
    ));
        
@@ -76081,7 +76092,7 @@
     dragon.AddGold(10000);
     dragon.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new GriffinSkull(),        100),
-        new LootPackEntry(true, (from, container) => new BlindFearProtectionBracelet(),        100),
+        new LootPackEntry(true, (from, container) => new BlindFearProtectionBracelet(),        33),
         new LootPackEntry(true, (from, container) => new FeatherFallBoots(),        100),
         new LootPackEntry(true, (from, container) => new RedRobe(),        100),
         new LootPackEntry(true, KoshOptions,    100),
@@ -76275,7 +76286,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="cliffgryphon">
+    <entity name="cliffGryphon">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76313,6 +76324,7 @@
     griffin.AddLoot(new LootPack(
         
         new LootPackEntry(true, (from, container) => new OchreEgg(), 25.0), 
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, (from, container) => new GriffinSkull(), 10)
     ));
         
@@ -76333,7 +76345,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="cliffnomad">
+    <entity name="cliffNomad">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76364,6 +76376,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -76384,7 +76397,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="cliffscorpion">
+    <entity name="cliffScorpion">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76473,6 +76486,7 @@
     lich.AddLoot(new LootPack(
         new LootPackEntry(true, MinotaurGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
     
@@ -76493,7 +76507,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="cliffnomadArcher">
+    <entity name="cliffNomadArcher">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76524,6 +76538,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -76588,6 +76603,7 @@
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, MinotaurGems,       50,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
     
@@ -76711,8 +76727,10 @@
     griffin.AddGold(800);
     griffin.AddLoot(new LootPack(
         
-        new LootPackEntry(true, (from, container) => new OchreEgg(), 25.0), 
-        new LootPackEntry(true, (from, container) => new GriffinSkull(), 10)
+        new LootPackEntry(true, (from, container) => new OchreEgg(), 25.0),  
+        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, (from, container) => new GriffinSkull(), 10),
+        new LootPackEntry(true, MinotaurTreasures,  0.63)
     ));
         
     return griffin;
@@ -76732,7 +76750,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacecentaur">
+    <entity name="surfaceCentaur">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76755,6 +76773,7 @@
     centaur.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.05),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -76775,7 +76794,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacesandworm">
+    <entity name="surfaceSandworm">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76832,7 +76851,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacemanticore">
+    <entity name="surfaceManticore">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76886,7 +76905,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacebee">
+    <entity name="surfaceBee">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76965,8 +76984,9 @@
     fighter.AddGold(700);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, MausTreasure,  0.63)
+        new LootPackEntry(true, MausBottles,    20), 
+        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, MinotaurTreasures,  0.63)
     ));
     
     return fighter;
@@ -77016,8 +77036,10 @@
     
     fighter.AddGold(750);
     fighter.AddLoot(new LootPack(
-        new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, MausBottles,    20)
+        new LootPackEntry(true, MausGems,       25,     gemsPriceMutator),  
+        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, MinotaurTreasures,  0.63)
         
     ));
     
@@ -77083,8 +77105,9 @@
     thaum.AddGold(650);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, MausTreasure,  0.63)
+        new LootPackEntry(true, MausBottles,    20), 
+        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, MinotaurTreasures,  0.63)
     ));
     
     return thaum;
@@ -77127,6 +77150,7 @@
     centaur.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77147,7 +77171,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="clifftiger">
+    <entity name="cliffTiger">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77202,7 +77226,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="cliffdoomDuck">
+    <entity name="cliffDoomDuck">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77216,7 +77240,7 @@
         CanJumpkick = true,
         CanStrikeCritically = false,
                 
-        Experience = 22000,
+        Experience = 15000,
         Alignment = Alignment.Chaotic,
     };
     
@@ -77244,6 +77268,7 @@
     };
     duck.AddGold(5000);
     duck.AddLoot(new LootPack(
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, (from, container) => new OchreEgg(), 100.0)  /* TODO: add another piece of minor loot just added egg because it made sense*/
     ));
         
@@ -77289,6 +77314,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77344,6 +77370,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
         
@@ -77388,6 +77415,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77408,7 +77436,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacehyena">
+    <entity name="surfaceHyena">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77482,6 +77510,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77542,6 +77571,7 @@
     manticora.AddLoot(new LootPack(
         new LootPackEntry(true, MinotaurGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
     
@@ -77562,7 +77592,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacewight">
+    <entity name="surfaceWight">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77596,6 +77626,7 @@
     wight.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.05),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     return wight;
@@ -77615,7 +77646,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="magicPeacekeeperTemplate">
+    <entity name="lengMagicPeacekeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77715,6 +77746,7 @@
     mummy.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       40,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, LengPotions,    0.1),
         new LootPackEntry(true, MausTreasure,  0.63)
         
     ));
@@ -77778,7 +77810,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="magicPeacekeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengMagicPeacekeeper" size="1" minimum="1" maximum="1" />
       <location x="2" y="1" region="254" />
     </spawn>
     <spawn type="LocationSpawner" name="thaumTrainer">
@@ -77805,7 +77837,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengthaumTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="lengThaumTrainer" size="1" minimum="1" maximum="1" />
       <location x="4" y="4" region="254" />
     </spawn>
     <spawn type="LocationSpawner" name="tanner">
@@ -77826,7 +77858,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengtannerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengTannerTemplate" size="1" minimum="1" maximum="1" />
       <location x="3" y="25" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="nwvendor">
@@ -77850,7 +77882,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengShopkeeperTemplate" size="1" minimum="1" maximum="1" />
       <location x="11" y="8" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="banker">
@@ -77873,7 +77905,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengbankerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengBankerTemplate" size="1" minimum="1" maximum="1" />
       <location x="15" y="4" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="northvendor">
@@ -77896,7 +77928,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengShopkeeperTemplate" size="1" minimum="1" maximum="1" />
       <location x="20" y="9" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="nevendor">
@@ -77919,7 +77951,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengShopkeeperTemplate" size="1" minimum="1" maximum="1" />
       <location x="26" y="14" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="sevendor">
@@ -77942,7 +77974,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengShopkeeperTemplate" size="1" minimum="1" maximum="1" />
       <location x="27" y="21" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="svendor">
@@ -77966,7 +77998,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="lengShopkeeperTemplate" size="1" minimum="1" maximum="1" />
       <location x="20" y="22" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="wiztrainer">
@@ -77988,7 +78020,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengwizTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="lengWizTrainer" size="1" minimum="1" maximum="1" />
       <location x="20" y="17" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="weapontrainer">
@@ -78017,7 +78049,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengweaponTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="lengWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="12" y="15" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="Puck">
@@ -78059,7 +78091,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengbalmVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="lengBalmVendor" size="1" minimum="1" maximum="1" />
       <location x="18" y="19" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="recallvendor">
@@ -78080,7 +78112,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengrecallVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="lengRecallVendor" size="1" minimum="1" maximum="1" />
       <location x="20" y="19" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="kingplaceholder">
@@ -78101,7 +78133,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="lengConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="10" y="20" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="queenplaceholder">
@@ -78122,7 +78154,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="lengConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="12" y="20" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="confessorghost">
@@ -78143,7 +78175,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="lengConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="1" y="6" region="254" />
     </spawn>
     <spawn type="LocationSpawner" name="Iantaplaceholder">
@@ -78164,7 +78196,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="lengConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="24" y="4" region="35" />
     </spawn>
     <spawn type="LocationSpawner" name="thiefTrainer">
@@ -78189,7 +78221,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengthiefTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="lengThiefTrainer" size="1" minimum="1" maximum="1" />
       <location x="5" y="28" region="20" />
     </spawn>
     <spawn type="LocationSpawner" name="lengMATrainer">
@@ -78219,7 +78251,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="lengweaponTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="lengWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="4" y="4" region="4" />
     </spawn>
     <spawn type="RegionSpawner" name="sandyPath">
@@ -78269,7 +78301,7 @@
       <entry entity="mausSkeleton" size="3" minimum="2" maximum="8" />
       <entry entity="mausWraith" size="1" minimum="2" maximum="3" />
       <entry entity="mausWretch" size="3" minimum="2" maximum="8" />
-      <entry entity="mausraven" size="1" minimum="2" maximum="7" />
+      <entry entity="mausRaven" size="1" minimum="2" maximum="7" />
       <entry entity="mausHobgoblin" size="1" minimum="4" maximum="10" />
       <entry entity="mausHobgobMage" size="1" minimum="2" maximum="3" />
       <bounds region="10">
@@ -78324,7 +78356,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="mausraven" size="3" minimum="2" maximum="4" />
+      <entry entity="mausRaven" size="3" minimum="2" maximum="4" />
       <entry entity="mausWretch" size="3" minimum="2" maximum="12" />
       <entry entity="mausHobgoblin" size="3" minimum="2" maximum="12" />
       <entry entity="mausHobgobMage" size="1" minimum="2" maximum="5" />
@@ -78353,7 +78385,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="mauspresence" size="1" minimum="1" maximum="1" />
+      <entry entity="mausPresence" size="1" minimum="1" maximum="1" />
       <bounds region="10">
         <inclusion left="33" top="9" right="39" bottom="11" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78406,12 +78438,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="cliffnomadArcher" size="3" minimum="2" maximum="10" />
-      <entry entity="cliffnomad" size="3" minimum="3" maximum="10" />
+      <entry entity="cliffNomadArcher" size="3" minimum="2" maximum="10" />
+      <entry entity="cliffNomad" size="3" minimum="3" maximum="10" />
       <entry entity="cliffCentaur" size="1" minimum="1" maximum="3" />
-      <entry entity="cliffscorpion" size="1" minimum="1" maximum="5" />
-      <entry entity="surfacebee" size="3" minimum="1" maximum="3" />
-      <entry entity="mausraven" size="1" minimum="2" maximum="2" />
+      <entry entity="cliffScorpion" size="1" minimum="1" maximum="5" />
+      <entry entity="surfaceBee" size="3" minimum="1" maximum="3" />
+      <entry entity="mausRaven" size="1" minimum="2" maximum="2" />
       <bounds region="20">
         <inclusion left="9" top="3" right="37" bottom="9" />
         <inclusion left="5" top="10" right="25" bottom="23" />
@@ -78436,7 +78468,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="cliffgryphon" size="1" minimum="1" maximum="1" />
+      <entry entity="cliffGryphon" size="1" minimum="1" maximum="1" />
       <bounds region="20">
         <inclusion left="3" top="5" right="8" bottom="9" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78460,9 +78492,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="cliffgryphon" size="1" minimum="2" maximum="2" />
-      <entry entity="cliffnomad" size="3" minimum="2" maximum="3" />
-      <entry entity="cliffnomadArcher" size="3" minimum="2" maximum="2" />
+      <entry entity="cliffGryphon" size="1" minimum="2" maximum="2" />
+      <entry entity="cliffNomad" size="3" minimum="2" maximum="3" />
+      <entry entity="cliffNomadArcher" size="3" minimum="2" maximum="2" />
       <bounds region="20">
         <inclusion left="18" top="2" right="23" bottom="9" />
         <inclusion left="24" top="3" right="36" bottom="6" />
@@ -78670,7 +78702,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="shidShidosha" size="1" minimum="1" maximum="1" />
-      <entry entity="shidninjaguardians" size="1" minimum="1" maximum="1" />
+      <entry entity="shidNinja" size="1" minimum="1" maximum="1" />
       <bounds region="255">
         <inclusion left="1" top="1" right="5" bottom="7" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78718,7 +78750,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacebridgeTroll" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceBridgeTroll" size="1" minimum="1" maximum="1" />
       <bounds region="1">
         <inclusion left="36" top="15" right="40" bottom="16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78797,7 +78829,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacewight" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceWight" size="1" minimum="1" maximum="1" />
       <bounds region="2">
         <inclusion left="16" top="4" right="22" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78853,9 +78885,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacebee" size="3" minimum="2" maximum="2" />
-      <entry entity="surfacecentaur" size="1" minimum="1" maximum="1" />
-      <entry entity="surfacesandworm" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceBee" size="3" minimum="2" maximum="2" />
+      <entry entity="surfaceCentaur" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceSandworm" size="1" minimum="1" maximum="1" />
       <bounds region="1">
         <inclusion left="42" top="21" right="54" bottom="27" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78879,9 +78911,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacecentaur" size="1" minimum="1" maximum="1" />
-      <entry entity="surfacehyena" size="2" minimum="2" maximum="2" />
-      <entry entity="surfacesandworm" size="1" minimum="1" maximum="2" />
+      <entry entity="surfaceCentaur" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceHyena" size="2" minimum="2" maximum="2" />
+      <entry entity="surfaceSandworm" size="1" minimum="1" maximum="2" />
       <bounds region="1">
         <inclusion left="44" top="9" right="56" bottom="17" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78905,9 +78937,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacecentaur" size="1" minimum="1" maximum="1" />
-      <entry entity="surfacehyena" size="2" minimum="1" maximum="2" />
-      <entry entity="surfacesandworm" size="1" minimum="1" maximum="2" />
+      <entry entity="surfaceCentaur" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceHyena" size="2" minimum="1" maximum="2" />
+      <entry entity="surfaceSandworm" size="1" minimum="1" maximum="2" />
       <bounds region="1">
         <inclusion left="28" top="4" right="33" bottom="20" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -78931,9 +78963,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacemanticore" size="1" minimum="1" maximum="1" />
-      <entry entity="surfacesandworm" size="1" minimum="2" maximum="4" />
-      <entry entity="surfacehyena" size="2" minimum="2" maximum="3" />
+      <entry entity="surfaceManticore" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceSandworm" size="1" minimum="2" maximum="4" />
+      <entry entity="surfaceHyena" size="2" minimum="2" maximum="3" />
       <bounds region="1">
         <inclusion left="1" top="3" right="7" bottom="38" />
         <exclusion left="3" top="23" right="4" bottom="25" />
@@ -78984,7 +79016,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacepowerTroll" size="1" minimum="1" maximum="1" />
+      <entry entity="surfacePowerTroll" size="1" minimum="1" maximum="1" />
       <bounds region="236">
         <inclusion left="3" top="6" right="6" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79008,8 +79040,8 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="cliffdoomDuck" size="1" minimum="1" maximum="1" />
-      <entry entity="clifftiger" size="1" minimum="1" maximum="1" />
+      <entry entity="cliffDoomDuck" size="1" minimum="1" maximum="1" />
+      <entry entity="cliffTiger" size="1" minimum="1" maximum="1" />
       <bounds region="35">
         <inclusion left="3" top="4" right="9" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79110,7 +79142,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shidninjaguardians" size="3" minimum="1" maximum="1" />
+      <entry entity="shidNinja" size="3" minimum="1" maximum="1" />
       <bounds region="4">
         <inclusion left="1" top="1" right="9" bottom="7" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79134,7 +79166,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shidninjaguardians" size="3" minimum="1" maximum="1" />
+      <entry entity="shidNinja" size="3" minimum="1" maximum="1" />
       <bounds region="4">
         <inclusion left="1" top="1" right="13" bottom="7" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79158,7 +79190,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="shidninjaguardians" size="3" minimum="1" maximum="1" />
+      <entry entity="shidNinja" size="3" minimum="1" maximum="1" />
       <bounds region="4">
         <inclusion left="1" top="1" right="15" bottom="7" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79303,20 +79335,20 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="3">
+      <entry weight="4">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongStrengthRing();
+	return new StrengthRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="3">
+      <entry weight="4">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongShieldRing();
+	return new WeakShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -79325,7 +79357,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentConstitutionPotion();
+	return new DeathResistanceBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -79336,7 +79368,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentStrengthPotion();
+	return new WeakDexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -79345,12 +79377,32 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentDexterityPotion();
+	return new StrengthRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
       <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrengthBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new GriffinSkull();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="MinotaurTreasures">
+      <entry weight="40">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -79359,40 +79411,38 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-    </treasure>
-    <treasure name="MinotaurTreasures">
-      <entry weight="2">
+      <entry weight="25">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongStrengthRing();
+	return new StrengthBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="8">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongStrengthBracelet();
+	return new DeathResistanceRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="4">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentIntelligencePotion();
+	return new SilverDaggerAmulet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="4">
+      <entry weight="25">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentWillpowerPotion();
+	return new StrengthRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -79455,7 +79505,18 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="3">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentConstitutionPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="LengPotions">
+      <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -79464,11 +79525,47 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentIntelligencePotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new PermanentConstitutionPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWillpowerPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentStrengthPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -83970,7 +83970,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakconfessorGhost">
+    <entity name="oakConfessorGhost">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -83992,7 +83992,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakbankerTemplate">
+    <entity name="oaBanker">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84024,7 +84024,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oaktannerTemplate">
+    <entity name="oakTanner">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84091,7 +84091,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakmugwortVendor">
+    <entity name="oakMugwortVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84126,7 +84126,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakshopkeeperTemplate">
+    <entity name="oakShopkeepers">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84159,7 +84159,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakthaumTrainerTemplate">
+    <entity name="oakThaumTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84419,7 +84419,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakaniet">
+    <entity name="oakAniet">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84506,7 +84506,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oaktagget">
+    <entity name="oakTagget">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84541,7 +84541,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakcudyl">
+    <entity name="oakCudyl">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84567,7 +84567,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakpeyton">
+    <entity name="oakPeyton">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -84607,7 +84607,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakkarin">
+    <entity name="oakKarin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88320,7 +88320,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="oakvaelDragon">
+    <entity name="dungeon5Dragon">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88877,7 +88877,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakShopkeepers" size="1" minimum="1" maximum="1" />
       <location x="31" y="27" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakApothecary">
@@ -88901,7 +88901,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakShopkeepers" size="1" minimum="1" maximum="1" />
       <location x="8" y="7" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakArmourer">
@@ -88925,7 +88925,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakShopkeepers" size="1" minimum="1" maximum="1" />
       <location x="4" y="11" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakPawner">
@@ -88949,7 +88949,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakShopkeepers" size="1" minimum="1" maximum="1" />
       <location x="17" y="27" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakWeaponsmith">
@@ -88974,7 +88974,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakShopkeepers" size="1" minimum="1" maximum="1" />
       <location x="11" y="24" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakJeweler">
@@ -88996,7 +88996,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakshopkeeperTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakShopkeepers" size="1" minimum="1" maximum="1" />
       <location x="4" y="16" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakTailor">
@@ -89067,7 +89067,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakthaumTrainerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oakThaumTrainer" size="1" minimum="1" maximum="1" />
       <location x="26" y="6" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="oakBalmVendor">
@@ -89110,7 +89110,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakbankerTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="oaBanker" size="1" minimum="1" maximum="1" />
       <location x="6" y="24" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="surfaceThiefTrainer">
@@ -89170,7 +89170,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakaniet" size="1" minimum="1" maximum="1" />
+      <entry entity="oakAniet" size="1" minimum="1" maximum="1" />
       <location x="4" y="1" region="255" />
     </spawn>
     <spawn type="LocationSpawner" name="oakPriest">
@@ -89210,7 +89210,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oaktagget" size="1" minimum="1" maximum="1" />
+      <entry entity="oakTagget" size="1" minimum="1" maximum="1" />
       <location x="13" y="37" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="cudyl">
@@ -89230,7 +89230,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakcudyl" size="1" minimum="1" maximum="1" />
+      <entry entity="oakCudyl" size="1" minimum="1" maximum="1" />
       <location x="77" y="18" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="surfaceShark">
@@ -89432,7 +89432,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakvaelDragon" size="1" minimum="1" maximum="1" />
+      <entry entity="dungeon5Dragon" size="1" minimum="1" maximum="1" />
       <location x="9" y="9" region="225" />
     </spawn>
     <spawn type="LocationSpawner" name="groveBear">
@@ -89515,8 +89515,8 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="oakpeyton" size="1" minimum="1" maximum="1" />
-      <entry entity="oakkarin" size="1" minimum="1" maximum="1" />
+      <entry entity="oakPeyton" size="1" minimum="1" maximum="1" />
+      <entry entity="oakKarin" size="1" minimum="1" maximum="1" />
       <bounds region="1">
         <inclusion left="24" top="17" right="29" bottom="22" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -89883,47 +89883,11 @@
   </spawns>
   <treasures>
     <treasure name="oakvaelPotions">
-      <entry weight="20">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentStrengthPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="20">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentDexterityPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="20">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWillpowerPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
       <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentIntelligencePotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="10">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWisdomPotion();
+	return new PermanentConstitutionPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -89932,7 +89896,43 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new PermanentConstitutionPotion();
+	return new PermanentWillpowerPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentStrengthPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentIntelligencePotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentDexterityPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -90628,15 +90628,6 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="8">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWisdomPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="dungeon4Rings">
       <entry weight="2">
@@ -90816,24 +90807,6 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="10">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWillpowerPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="10">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWisdomPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="dungeon5Rings">
       <entry weight="1">
@@ -90921,7 +90894,7 @@
       </entry>
     </treasure>
     <treasure name="groveTreasure">
-      <entry weight="20">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -90930,7 +90903,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="20">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -90939,29 +90912,20 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="20">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new FireIceProtectionRing();
+	return new WeakDexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new BlindFearProtectionBracelet();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="3">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new ScorpionBracelet();
+	return new StrongShieldBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -59,6 +59,60 @@
         
         item.Price = Utility.RandomBetween(-lesserPrice, higherPrice);
     }
+    public class HummingGuardian : CreatureEntity
+    {
+        public HummingGuardian()
+        {
+            Name = "guardian";
+            Alignment = Alignment.Chaotic;
+            Body = 45;
+        }
+
+        public override int GetNearbySound() => 289;
+        public override int GetAttackSound() => 290;
+        public override int GetDeathSound() => 291;
+
+        public HummingGuardian(Serial serial) : base(serial)
+        {
+        }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+
+            if (_brain != null)
+                return;
+
+            if (RightHand is ProjectileWeapon)
+                _brain = new RangedAI(this);
+            else
+                _brain = new CombatAI(this);
+        }
+
+        public override void OnSpellTarget(Target target, MobileEntity combatant)
+        {
+            if (Spell is WhirlwindSpell whirlwind)
+            {
+                var direction = GetDirectionTo(combatant.Location);
+                var distance = GetDistanceToMax(combatant.Location);
+
+                if (direction == Direction.None)
+                    direction = Direction.Cardinal.Random();
+
+                if (distance >= 3)
+                    whirlwind.CastAt(direction);
+                else
+                    whirlwind.CastAt(direction, direction.Opposite);
+
+                if (target != null)
+                    target.Cancel(this, TargetCancel.Canceled);
+            }
+            else
+            {
+                base.OnSpellTarget(target, combatant);
+            }
+        }
+    }
 ]]></block>
     <block><![CDATA[]]></block>
   </script>
@@ -95829,7 +95883,7 @@
     </subregion>
   </subregions>
   <entities>
-    <entity name="townukbalmVendor">
+    <entity name="townBalmVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -95862,7 +95916,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townukBanker">
+    <entity name="townBanker">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -95894,7 +95948,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townconfessorGhost">
+    <entity name="townConfessorGhost">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -95915,7 +95969,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townmugwortVendor">
+    <entity name="townMugwortVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -95949,7 +96003,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townrecallVendor">
+    <entity name="townRecallVendor">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -95982,7 +96036,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townshopTemplate">
+    <entity name="townShopkeeper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96048,7 +96102,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="towntrainerThaum">
+    <entity name="townTrainerThaum">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96083,7 +96137,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="towntrainerThief">
+    <entity name="townTrainerThief">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96116,7 +96170,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townWepTrainTemp">
+    <entity name="townWeaponTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96149,7 +96203,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="townwizTrainer">
+    <entity name="townWizTrainer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96333,7 +96387,8 @@
     
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       5,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    15), 
+        new LootPackEntry(true, UKPotions,    0.05)
     ));
     
     return wyvern;
@@ -96395,7 +96450,8 @@
     
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       5,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    15), 
+        new LootPackEntry(true, UKPotions,    0.05)
     ));
     
     return wyvern;
@@ -96457,7 +96513,8 @@
     
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       5,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    15), 
+        new LootPackEntry(true, UKPotions,    0.05)
     ));
     
     return wyvern;
@@ -96519,7 +96576,8 @@
     
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       5,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    15)
+        new LootPackEntry(true, GenericBottles,    15), 
+        new LootPackEntry(true, UKPotions,    0.05)
     ));
     
     return wyvern;
@@ -96539,15 +96597,15 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="surfacedrake">
+    <entity name="surfaceDrake">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
     var drake = new Drake()
     {
         Name = "Drake",
-        MaxHealth = 2500, Health = 2500,
-        BaseDodge = 18,
+        MaxHealth = 2200, Health = 2200,
+        BaseDodge = 19,
     
         Alignment = Alignment.Chaotic,
         HideDetection = 24,
@@ -96594,10 +96652,10 @@
         new CreatureBlock(3, "a wing"),
     };
         
-    drake.Spells = new CreatureSpellCollection(20.0)
+    drake.Spells = new CreatureSpellCollection(15.0)
     {
         new CreatureSpell<LightningBoltSpell>(
-            skillLevel: 9),
+            skillLevel: 8),
     };
     
     drake.AddGold(2000);
@@ -96623,7 +96681,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="yascarfel">
+    <entity name="yasnakiBossCarfel">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96690,7 +96748,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="yasshelob">
+    <entity name="yasnakiBossShelob">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96742,12 +96800,12 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="tktrollKing">
+    <entity name="tkTrollKing">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
     //todo add Troll king sprite template / check stats. Needs immunity to death/lightning but no other magic. Need variables for such.
-    var trollKing = new Panda()
+    var trollKing = new ElderTroll()
     {
         Name = "Troll.King",
         MaxHealth = 5000, Health = 5000,
@@ -96757,8 +96815,7 @@
         HideDetection = 30,
         Experience = 56000,
         
-        Immunity = CreatureImmunity.Magic,
-        Weakness = CreatureWeakness.IceSpearSpell,
+        DeathResistance = 100,
         
         CanCharge = true,
         
@@ -96778,12 +96835,13 @@
     trollKing.Wield(new Greatsword());
     trollKing.Equip(new DragonScaleArmor());
     
-    trollKing.AddGold(2000);
+    trollKing.AddGold(10000);
     trollKing.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       100,     gemsPriceMutator), 
         new LootPackEntry(true, drop3gems,       100,     gemsPriceMutator), 
         new LootPackEntry(true, drop3gems,       100,     gemsPriceMutator), 
-        new LootPackEntry(true, (from, container) => new HummingbirdAmulet(),     100)
+        new LootPackEntry(true, (from, container) => new HummingbirdAmulet(),     100), 
+        new LootPackEntry(true, UpperTreasure,    100)
     ));
     
     return trollKing;
@@ -96803,7 +96861,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="udorugugra">
+    <entity name="udBossOrugugra">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96842,7 +96900,8 @@
     lurker.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new PermanentStrengthPotion(),       100),
         new LootPackEntry(true, (from, container) => new YouthPotion(),       50),
-        new LootPackEntry(true, (from, container) => new ManaPotion(),       100)
+        new LootPackEntry(true, (from, container) => new ManaPotion(),       100), 
+        new LootPackEntry(true, UndeadTreasure,    10)
     ));
     
     return lurker;
@@ -96862,7 +96921,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="udswordmaster">
+    <entity name="udBossSwordmaster">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96898,7 +96957,8 @@
         
     swordmaster.AddGold(5000);
     swordmaster.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new PearDiamond(15000u),    100, gemsPriceMutator)
+        new LootPackEntry(true, (from, container) => new PearDiamond(15000u),    100, gemsPriceMutator), 
+        new LootPackEntry(true, UndeadTreasure,    0.15)
     ));
     
     return swordmaster;
@@ -96918,7 +96978,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="udoverlord">
+    <entity name="udBossOverlord">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -96993,7 +97053,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300orc">
+    <entity name="uk300Orc">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97018,7 +97078,9 @@
     orc.AddGold(400);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return orc;
@@ -97038,7 +97100,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk100200mino">
+    <entity name="uk100200Mino">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97081,7 +97143,9 @@
     minotaur.AddGold(1000);
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       33,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return minotaur;
@@ -97101,7 +97165,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk100magob">
+    <entity name="uk100MaGoblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97134,7 +97198,9 @@
     goblin.AddGold(800);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       33,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return goblin;
@@ -97155,7 +97221,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk100200troll">
+    <entity name="uk100200Troll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97181,7 +97247,9 @@
     troll.AddGold(500);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return troll;
@@ -97201,7 +97269,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk100200archer">
+    <entity name="uk100200Archer">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97227,7 +97295,9 @@
     orc.AddGold(300);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return orc;
@@ -97247,7 +97317,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300lightningHob">
+    <entity name="uk300LightningHob">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97278,7 +97348,9 @@
     hobgoblin.AddGold(550);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return hobgoblin;
@@ -97298,7 +97370,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300hob">
+    <entity name="uk300Hob">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97322,7 +97394,9 @@
     hobgoblin.AddGold(500);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return hobgoblin;
@@ -97342,7 +97416,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300rhammertroll">
+    <entity name="uk300RhammerTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97372,7 +97446,9 @@
     troll.AddGold(500);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return troll;
@@ -97392,7 +97468,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300troll">
+    <entity name="uk300Troll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97418,7 +97494,9 @@
     troll.AddGold(450);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return troll;
@@ -97438,7 +97516,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="tkelitetrollguard">
+    <entity name="tkEliteTrollGuard">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97469,7 +97547,9 @@
     trollguard.AddGold(1000);
     trollguard.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       15,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
         ));
     
     return trollguard;
@@ -97489,7 +97569,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300Speedyhobs">
+    <entity name="uk300SpeedyHobs">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97514,7 +97594,9 @@
     hobgoblin.AddGold(500);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, speedygems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return hobgoblin;
@@ -97534,7 +97616,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnellightningOrc">
+    <entity name="ukTunnelLightningOrc">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97565,7 +97647,9 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return orc;
@@ -97585,7 +97669,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnelcursetroll">
+    <entity name="ukTunnelCursetroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97617,7 +97701,9 @@
     troll.AddGold(250);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return troll;
@@ -97637,7 +97723,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk300deathtroll">
+    <entity name="uk300DeathTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97669,7 +97755,9 @@
     troll.AddGold(380);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return troll;
@@ -97689,7 +97777,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnelorcmage">
+    <entity name="ukTunnelOrcMage">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97723,7 +97811,9 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25)
+        new LootPackEntry(true, GenericBottles,    25), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return orc;
@@ -97743,7 +97833,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk100goblinmage">
+    <entity name="uk100GoblinMage">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -97777,7 +97867,9 @@
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return goblin;
@@ -97830,7 +97922,9 @@
     banshee.AddGold(480);
     banshee.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    15)
+        new LootPackEntry(true, undeadBottles,    15), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
     return banshee;
@@ -97890,7 +97984,9 @@
     ghoul.AddGold(1000);
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       33,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    50)
+        new LootPackEntry(true, undeadBottles,    50), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
     return ghoul;
@@ -97937,7 +98033,9 @@
     
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    33)
+        new LootPackEntry(true, undeadBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
     return skeleton;
@@ -97995,7 +98093,9 @@
     spectre.AddGold(650);
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    33)
+        new LootPackEntry(true, undeadBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
     return spectre;
@@ -98056,7 +98156,9 @@
     mummy.AddGold(1000);
     mummy.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       33,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    50)
+        new LootPackEntry(true, undeadBottles,    50), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
     return mummy;
@@ -98080,7 +98182,7 @@
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
-    var wraith = new Wraith()
+    var mummy = new Mummy()
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 12,
@@ -98088,21 +98190,21 @@
         Experience = 2725,
         
     };
-    wraith.AddStatus(new NightVisionStatus(wraith));
+    mummy.AddStatus(new NightVisionStatus(wraith));
         
-    wraith.Attacks = new CreatureAttackCollection()
+    mummy.Attacks = new CreatureAttackCollection()
     {
         new CreatureBasicAttack(7)
     };
     
-    wraith.Spells =  new CreatureSpellCollection()
+    mummy.Spells =  new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
             skillLevel: 12,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
-    wraith.Wield(new WoodenStaff());
+    mummy.Wield(new WoodenStaff());
     
     return wraith;
 ]]></block>
@@ -98147,7 +98249,9 @@
     knight.AddGold(600);
     knight.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    33)
+        new LootPackEntry(true, yasnakiBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
     return knight;
@@ -98201,7 +98305,9 @@
     lich.AddGold(700);
     lich.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    50)
+        new LootPackEntry(true, undeadBottles,    50), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
     return lich;
@@ -98258,9 +98364,10 @@
     
     lurker.AddGold(2000);
     lurker.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new PermanentStrengthPotion(),       10),
-        new LootPackEntry(true, (from, container) => new YouthPotion(),       10),
-        new LootPackEntry(true, (from, container) => new ManaPotion(),       10)
+        new LootPackEntry(true, (from, container) => new PermanentStrengthPotion(),       5),
+        new LootPackEntry(true, (from, container) => new YouthPotion(),       5),
+        new LootPackEntry(true, (from, container) => new ManaPotion(),       5), 
+        new LootPackEntry(true, UKPotions,    0.05)
     ));
     
     return lurker;
@@ -98306,7 +98413,9 @@
     martialartist.AddGold(650);
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    33)
+        new LootPackEntry(true, yasnakiBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
     return martialartist;
@@ -98368,7 +98477,9 @@
     wizard.AddGold(650);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       33,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    33)
+        new LootPackEntry(true, yasnakiBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
     return wizard;
@@ -98426,7 +98537,9 @@
     thaum.AddGold(750);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    33)
+        new LootPackEntry(true, yasnakiBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
     return thaum;
@@ -98446,7 +98559,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="tkprincessPlaceholder">
+    <entity name="tkPrincessPlaceholder">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98460,14 +98573,15 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <script name="OnIncomingPlayer" enabled="false">
+      <script name="OnIncomingPlayer" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
+    source.Say($"You've got to help me!");
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uk100goblin">
+    <entity name="uk100Goblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98491,7 +98605,9 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33)
+        new LootPackEntry(true, GenericBottles,    33), 
+        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
     return goblin;
@@ -98511,7 +98627,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnelgobs">
+    <entity name="ukTunnelGoblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98534,7 +98650,9 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25)
+        new LootPackEntry(true, GenericBottles,    25), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return goblin;
@@ -98554,7 +98672,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnelarcher">
+    <entity name="ukTunnelArcher">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98579,7 +98697,9 @@
     orc.AddGold(250);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25)
+        new LootPackEntry(true, GenericBottles,    25), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return orc;
@@ -98599,7 +98719,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunneltroll">
+    <entity name="ukTunnelTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98623,7 +98743,9 @@
     troll.AddGold(370);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25)
+        new LootPackEntry(true, GenericBottles,    25), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return troll;
@@ -98643,7 +98765,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnelorc">
+    <entity name="ukTunnelOrc">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98668,7 +98790,9 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25)
+        new LootPackEntry(true, GenericBottles,    25), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     return orc;
 ]]></block>
@@ -98687,7 +98811,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="uktunnelgobsentry">
+    <entity name="ukTunnelGoblinSentry">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -98710,7 +98834,9 @@
     goblin.AddGold(300);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25)
+        new LootPackEntry(true, GenericBottles,    25), 
+        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
     return goblin;
@@ -98769,13 +98895,14 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="tkhummingghost">
+    <entity name="tkHummerGuardian">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
-    var wraith = new Wraith()
+    var wraith = new HummingGuardian()
     {
-        MaxHealth = 65, Health = 65,
+        Name = "Guardian",
+        MaxHealth = 200, Health = 200,
         BaseDodge = 12,
         IsInvisible = true,
         Experience = 1,
@@ -98794,7 +98921,7 @@
     wraith.Spells = new CreatureSpellCollection(100)
     {
        { new CreatureSpell<WhirlwindSpell>(
-            skillLevel: 8), 100, TimeSpan.FromSeconds(12.0) }
+            skillLevel: 9.5), 100, TimeSpan.FromSeconds(12.0) }
     };
     
     wraith.AddLoot(new LootPack(
@@ -98810,9 +98937,10 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <script name="OnIncomingPlayer" enabled="false">
+      <script name="OnIncomingPlayer" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
+    source.Say($"Are.... you... worthy?.");
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -98869,7 +98997,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townshopTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="townShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="2" y="6" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="sEShopkeeper">
@@ -98921,7 +99049,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townshopTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="townShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="15" y="14" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="lowershop1">
@@ -98973,7 +99101,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townshopTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="townShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="26" y="16" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="lowershop2">
@@ -99025,7 +99153,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townshopTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="townShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="28" y="16" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="lowershop3">
@@ -99077,7 +99205,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townshopTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="townShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="30" y="16" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="lowershop4">
@@ -99129,7 +99257,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townshopTemplate" size="1" minimum="1" maximum="1" />
+      <entry entity="townShopkeeper" size="1" minimum="1" maximum="1" />
       <location x="32" y="16" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="thaumTrainer">
@@ -99157,7 +99285,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="towntrainerThaum" size="1" minimum="1" maximum="1" />
+      <entry entity="townTrainerThaum" size="1" minimum="1" maximum="1" />
       <location x="27" y="4" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="weaponTrainer">
@@ -99187,7 +99315,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townWepTrainTemp" size="1" minimum="1" maximum="1" />
+      <entry entity="townWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="32" y="11" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="wizardTrainer">
@@ -99208,7 +99336,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townwizTrainer" size="1" minimum="1" maximum="1" />
+      <entry entity="townWizTrainer" size="1" minimum="1" maximum="1" />
       <location x="13" y="5" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="maTrainer">
@@ -99238,7 +99366,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townWepTrainTemp" size="1" minimum="1" maximum="1" />
+      <entry entity="townWeaponTrainer" size="1" minimum="1" maximum="1" />
       <location x="13" y="3" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="priest">
@@ -99305,7 +99433,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townukBanker" size="1" minimum="1" maximum="1" />
+      <entry entity="townBanker" size="1" minimum="1" maximum="1" />
       <location x="5" y="5" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="tanner">
@@ -99394,7 +99522,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="towntrainerThief" size="1" minimum="1" maximum="1" />
+      <entry entity="townTrainerThief" size="1" minimum="1" maximum="1" />
       <location x="18" y="11" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="secretThiefTrainer">
@@ -99416,7 +99544,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="towntrainerThief" size="1" minimum="1" maximum="1" />
+      <entry entity="townTrainerThief" size="1" minimum="1" maximum="1" />
       <location x="49" y="35" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="googogTEMP">
@@ -99437,7 +99565,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="townConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="17" y="24" region="5" />
     </spawn>
     <spawn type="LocationSpawner" name="princessTEMP">
@@ -99458,7 +99586,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="townConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="4" y="8" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="koboldkingTEMP">
@@ -99479,7 +99607,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townconfessorGhost" size="1" minimum="1" maximum="1" />
+      <entry entity="townConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="20" y="5" region="2" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll1">
@@ -99500,7 +99628,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="4" y="4" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll2">
@@ -99520,7 +99648,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="4" y="6" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll3">
@@ -99541,7 +99669,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="4" y="10" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll4">
@@ -99562,7 +99690,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="9" y="4" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll5">
@@ -99583,7 +99711,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="9" y="6" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll6">
@@ -99604,7 +99732,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="9" y="8" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="jailtroll7">
@@ -99625,7 +99753,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="1" minimum="1" maximum="1" />
+      <entry entity="uk300RhammerTroll" size="1" minimum="1" maximum="1" />
       <location x="9" y="10" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="olwraith1">
@@ -99793,7 +99921,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="tkhummingghost" size="1" minimum="1" maximum="1" />
+      <entry entity="tkHummerGuardian" size="1" minimum="1" maximum="1" />
       <location x="7" y="19" region="10" />
     </spawn>
     <spawn type="LocationSpawner" name="balmVendor">
@@ -99814,7 +99942,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townukbalmVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="townBalmVendor" size="1" minimum="1" maximum="1" />
       <location x="11" y="8" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="recallVendor">
@@ -99834,7 +99962,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="townrecallVendor" size="1" minimum="1" maximum="1" />
+      <entry entity="townRecallVendor" size="1" minimum="1" maximum="1" />
       <location x="13" y="14" region="1" />
     </spawn>
     <spawn type="RegionSpawner" name="wyverns">
@@ -99883,7 +100011,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacedrake" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceDrake" size="1" minimum="1" maximum="1" />
       <bounds region="1">
         <inclusion left="17" top="2" right="49" bottom="33" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -99955,12 +100083,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uktunnelgobs" size="3" minimum="2" maximum="5" />
-      <entry entity="uktunnelarcher" size="4" minimum="2" maximum="4" />
-      <entry entity="uktunneltroll" size="3" minimum="2" maximum="4" />
-      <entry entity="uktunnelorc" size="3" minimum="4" maximum="5" />
-      <entry entity="uktunnelgobsentry" size="3" minimum="2" maximum="4" />
-      <entry entity="uktunnelcursetroll" size="1" minimum="1" maximum="3" />
+      <entry entity="ukTunnelGoblin" size="3" minimum="2" maximum="5" />
+      <entry entity="ukTunnelArcher" size="4" minimum="2" maximum="4" />
+      <entry entity="ukTunnelTroll" size="3" minimum="2" maximum="4" />
+      <entry entity="ukTunnelOrc" size="3" minimum="4" maximum="5" />
+      <entry entity="ukTunnelGoblinSentry" size="3" minimum="2" maximum="4" />
+      <entry entity="ukTunnelCursetroll" size="1" minimum="1" maximum="3" />
       <bounds region="3">
         <inclusion left="3" top="3" right="33" bottom="11" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -99984,12 +100112,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk100200mino" size="1" minimum="3" maximum="4" />
-      <entry entity="uk100200troll" size="3" minimum="5" maximum="6" />
-      <entry entity="uk100200archer" size="3" minimum="6" maximum="7" />
-      <entry entity="uk100magob" size="1" minimum="1" maximum="1" />
-      <entry entity="uk100goblinmage" size="4" minimum="2" maximum="2" />
-      <entry entity="uk100goblin" size="3" minimum="4" maximum="5" />
+      <entry entity="uk100200Mino" size="1" minimum="3" maximum="4" />
+      <entry entity="uk100200Troll" size="3" minimum="5" maximum="6" />
+      <entry entity="uk100200Archer" size="3" minimum="6" maximum="7" />
+      <entry entity="uk100MaGoblin" size="1" minimum="1" maximum="1" />
+      <entry entity="uk100GoblinMage" size="4" minimum="2" maximum="2" />
+      <entry entity="uk100Goblin" size="3" minimum="4" maximum="5" />
       <bounds region="4">
         <inclusion left="3" top="3" right="19" bottom="27" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100013,12 +100141,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk100200mino" size="1" minimum="3" maximum="3" />
-      <entry entity="uk100200troll" size="3" minimum="3" maximum="4" />
-      <entry entity="uk100200archer" size="3" minimum="4" maximum="6" />
-      <entry entity="uk100goblinmage" size="4" minimum="2" maximum="2" />
-      <entry entity="uk100goblin" size="3" minimum="4" maximum="6" />
-      <entry entity="uk100magob" size="1" minimum="1" maximum="1" />
+      <entry entity="uk100200Mino" size="1" minimum="3" maximum="3" />
+      <entry entity="uk100200Troll" size="3" minimum="3" maximum="4" />
+      <entry entity="uk100200Archer" size="3" minimum="4" maximum="6" />
+      <entry entity="uk100GoblinMage" size="4" minimum="2" maximum="2" />
+      <entry entity="uk100Goblin" size="3" minimum="4" maximum="6" />
+      <entry entity="uk100MaGoblin" size="1" minimum="1" maximum="1" />
       <bounds region="5">
         <inclusion left="3" top="3" right="13" bottom="25" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100042,13 +100170,13 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uktunnellightningOrc" size="1" minimum="3" maximum="3" />
-      <entry entity="uktunnelorcmage" size="1" minimum="5" maximum="5" />
-      <entry entity="uktunneltroll" size="3" minimum="7" maximum="10" />
-      <entry entity="uktunnelorc" size="3" minimum="10" maximum="10" />
-      <entry entity="uktunnelcursetroll" size="1" minimum="5" maximum="5" />
-      <entry entity="uktunnelgobs" size="3" minimum="10" maximum="10" />
-      <entry entity="uktunnelgobsentry" size="3" minimum="7" maximum="10" />
+      <entry entity="ukTunnelLightningOrc" size="1" minimum="3" maximum="3" />
+      <entry entity="ukTunnelOrcMage" size="1" minimum="5" maximum="5" />
+      <entry entity="ukTunnelTroll" size="3" minimum="7" maximum="10" />
+      <entry entity="ukTunnelOrc" size="3" minimum="10" maximum="10" />
+      <entry entity="ukTunnelCursetroll" size="1" minimum="5" maximum="5" />
+      <entry entity="ukTunnelGoblin" size="3" minimum="10" maximum="10" />
+      <entry entity="ukTunnelGoblinSentry" size="3" minimum="7" maximum="10" />
       <entry entity="surfaceLurker" size="2" minimum="2" maximum="2" />
       <bounds region="11">
         <inclusion left="3" top="3" right="34" bottom="39" />
@@ -100073,7 +100201,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="tkelitetrollguard" size="1" minimum="7" maximum="7" />
+      <entry entity="tkEliteTrollGuard" size="1" minimum="7" maximum="7" />
       <bounds region="9">
         <inclusion left="4" top="11" right="13" bottom="20" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100097,7 +100225,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="tktrollKing" size="1" minimum="1" maximum="1" />
+      <entry entity="tkTrollKing" size="1" minimum="1" maximum="1" />
       <bounds region="9">
         <inclusion left="6" top="22" right="11" bottom="25" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100121,12 +100249,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300lightningHob" size="1" minimum="2" maximum="2" />
-      <entry entity="uk300orc" size="3" minimum="3" maximum="4" />
-      <entry entity="uk300hob" size="4" minimum="4" maximum="4" />
-      <entry entity="uk300rhammertroll" size="3" minimum="3" maximum="3" />
-      <entry entity="uk300troll" size="3" minimum="4" maximum="4" />
-      <entry entity="uk300deathtroll" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300LightningHob" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300Orc" size="3" minimum="3" maximum="4" />
+      <entry entity="uk300Hob" size="4" minimum="4" maximum="4" />
+      <entry entity="uk300RhammerTroll" size="3" minimum="3" maximum="3" />
+      <entry entity="uk300Troll" size="3" minimum="4" maximum="4" />
+      <entry entity="uk300DeathTroll" size="1" minimum="2" maximum="2" />
       <bounds region="8">
         <inclusion left="2" top="2" right="24" bottom="14" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100150,11 +100278,11 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="3" minimum="4" maximum="4" />
-      <entry entity="uk300deathtroll" size="1" minimum="2" maximum="2" />
-      <entry entity="uk300hob" size="4" minimum="5" maximum="5" />
-      <entry entity="uk300troll" size="3" minimum="4" maximum="4" />
-      <entry entity="uk300lightningHob" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300RhammerTroll" size="3" minimum="4" maximum="4" />
+      <entry entity="uk300DeathTroll" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300Hob" size="4" minimum="5" maximum="5" />
+      <entry entity="uk300Troll" size="3" minimum="4" maximum="4" />
+      <entry entity="uk300LightningHob" size="1" minimum="2" maximum="2" />
       <bounds region="8">
         <inclusion left="29" top="-1" right="53" bottom="3" />
         <inclusion left="38" top="4" right="53" bottom="14" />
@@ -100180,7 +100308,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="tkelitetrollguard" size="1" minimum="4" maximum="4" />
+      <entry entity="tkEliteTrollGuard" size="1" minimum="4" maximum="4" />
       <bounds region="10">
         <inclusion left="2" top="1" right="11" bottom="2" />
         <inclusion left="6" top="3" right="7" bottom="10" />
@@ -100205,12 +100333,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300Speedyhobs" size="4" minimum="5" maximum="7" />
-      <entry entity="uk300orc" size="3" minimum="4" maximum="6" />
-      <entry entity="uk300troll" size="3" minimum="4" maximum="6" />
-      <entry entity="uk300rhammertroll" size="3" minimum="3" maximum="5" />
-      <entry entity="uk300lightningHob" size="1" minimum="2" maximum="2" />
-      <entry entity="uk300deathtroll" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300SpeedyHobs" size="4" minimum="5" maximum="7" />
+      <entry entity="uk300Orc" size="3" minimum="4" maximum="6" />
+      <entry entity="uk300Troll" size="3" minimum="4" maximum="6" />
+      <entry entity="uk300RhammerTroll" size="3" minimum="3" maximum="5" />
+      <entry entity="uk300LightningHob" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300DeathTroll" size="1" minimum="2" maximum="2" />
       <bounds region="12">
         <inclusion left="2" top="3" right="49" bottom="16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100234,11 +100362,11 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="uk300rhammertroll" size="3" minimum="2" maximum="2" />
-      <entry entity="uk300lightningHob" size="1" minimum="2" maximum="2" />
-      <entry entity="uk300hob" size="4" minimum="3" maximum="2" />
-      <entry entity="uk300troll" size="3" minimum="2" maximum="2" />
-      <entry entity="uk300orc" size="3" minimum="3" maximum="3" />
+      <entry entity="uk300RhammerTroll" size="3" minimum="2" maximum="2" />
+      <entry entity="uk300LightningHob" size="1" minimum="2" maximum="2" />
+      <entry entity="uk300Hob" size="4" minimum="3" maximum="2" />
+      <entry entity="uk300Troll" size="3" minimum="2" maximum="2" />
+      <entry entity="uk300Orc" size="3" minimum="3" maximum="3" />
       <bounds region="13">
         <inclusion left="2" top="2" right="21" bottom="11" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100287,7 +100415,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="udoverlord" size="1" minimum="1" maximum="1" />
+      <entry entity="udBossOverlord" size="1" minimum="1" maximum="1" />
       <bounds region="15">
         <inclusion left="-1" top="15" right="5" bottom="17" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100311,7 +100439,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="yascarfel" size="1" minimum="1" maximum="1" />
+      <entry entity="yasnakiBossCarfel" size="1" minimum="1" maximum="1" />
       <bounds region="16">
         <inclusion left="17" top="2" right="20" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100335,7 +100463,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="yasshelob" size="1" minimum="1" maximum="1" />
+      <entry entity="yasnakiBossShelob" size="1" minimum="1" maximum="1" />
       <bounds region="16">
         <inclusion left="2" top="5" right="4" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100415,7 +100543,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="udorugugra" size="1" minimum="1" maximum="1" />
+      <entry entity="udBossOrugugra" size="1" minimum="1" maximum="1" />
       <bounds region="17">
         <inclusion left="19" top="4" right="20" bottom="13" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100439,7 +100567,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="udswordmaster" size="1" minimum="1" maximum="1" />
+      <entry entity="udBossSwordmaster" size="1" minimum="1" maximum="1" />
       <bounds region="17">
         <inclusion left="15" top="3" right="24" bottom="16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -100480,33 +100608,6 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new NaphthaPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentStrengthPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentDexterityPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWillpowerPotion();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -100781,24 +100882,6 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentWisdomPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new PermanentIntelligencePotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="yasnakiGems">
       <entry weight="10">
@@ -100839,7 +100922,7 @@
       </entry>
     </treasure>
     <treasure name="overlordTreasure">
-      <entry weight="1">
+      <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -100848,11 +100931,199 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new StunDeathProtectionBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="UKPotions">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentConstitutionPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentDexterityPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentIntelligencePotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentStrengthPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWillpowerPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PermanentWisdomPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ManaPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="yasnakiTreasure">
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="UpperTreasure">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireIceProtectionRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="UndeadTreasure">
+      <entry weight="15">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="15">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="12">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongShieldBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
Added an experiment where I use the dragon's Dragon Breath to create a more dynamic encounter in the hummingbird sword's guardian chamber, much more similar to OG if it works. If not please return and I can delete that change.

Added a more comprehensive loot system: 

Every zone has it's unique main "Permanent potion" drop. IE Leng drops primary Dexterity, secondary Intelligence, scaling down from all potions to the last one which is Strength. Oakvael is Constitution and Willpower scaled down. UK is balanced. 

Leng now has the loot "specialization" of Dexterity rings (and they're turned from normal to weak).

Oakvael "specializes" in shielders.

Axe "specializes" in glowers.

Targetted loot drops should lead to people spreading out more - Implementation is crude, will need work. 

I left Kesmai alone for the most part.

Other items included in pull are some naming convention changes. 