### PR TITLE
Oak tile fixes

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1400,8 +1400,8 @@
         </component>
       </tile>
       <tile x="2" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -2763,8 +2763,8 @@
         </component>
       </tile>
       <tile x="2" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -2800,8 +2800,8 @@
         </component>
       </tile>
       <tile x="5" y="5">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -4152,8 +4152,8 @@
         </component>
       </tile>
       <tile x="5" y="7">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -9289,6 +9289,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="15">
@@ -10055,13 +10056,14 @@
         </component>
       </tile>
       <tile x="26" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="16">
@@ -10654,13 +10656,14 @@
         </component>
       </tile>
       <tile x="24" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="17">
@@ -10679,13 +10682,14 @@
         </component>
       </tile>
       <tile x="28" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="29" y="17">
@@ -11901,13 +11905,14 @@
         </component>
       </tile>
       <tile x="23" y="19">
-        <component type="FloorComponent">
-          <ground>13</ground>
+        <component type="StaticComponent">
+          <static>13</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="19">
@@ -11941,13 +11946,14 @@
         </component>
       </tile>
       <tile x="29" y="19">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="30" y="19">
@@ -13172,13 +13178,14 @@
         </component>
       </tile>
       <tile x="24" y="21">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="21">
@@ -13197,13 +13204,14 @@
         </component>
       </tile>
       <tile x="28" y="21">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="29" y="21">
@@ -13823,13 +13831,14 @@
         </component>
       </tile>
       <tile x="26" y="22">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="22">
@@ -18810,6 +18819,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="30">
@@ -24577,6 +24587,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="79" y="38">
@@ -24584,6 +24595,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="80" y="38">
@@ -25256,6 +25268,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="79" y="39">
@@ -25263,6 +25276,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="80" y="39">
@@ -25270,6 +25284,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="81" y="39">
@@ -25891,6 +25906,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="81" y="40">
@@ -25898,6 +25914,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="41">
@@ -27310,8 +27327,8 @@
         </component>
       </tile>
       <tile x="6" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -27321,8 +27338,8 @@
         </component>
       </tile>
       <tile x="7" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -27332,8 +27349,8 @@
         </component>
       </tile>
       <tile x="8" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -27343,8 +27360,8 @@
         </component>
       </tile>
       <tile x="9" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -27416,8 +27433,8 @@
         </component>
       </tile>
       <tile x="6" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -27442,8 +27459,8 @@
         </component>
       </tile>
       <tile x="10" y="7">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -27581,8 +27598,8 @@
         </component>
       </tile>
       <tile x="6" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -27629,8 +27646,8 @@
         </component>
       </tile>
       <tile x="10" y="8">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -27777,8 +27794,8 @@
         </component>
       </tile>
       <tile x="6" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -28036,8 +28053,8 @@
         </component>
       </tile>
       <tile x="3" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -28047,8 +28064,8 @@
         </component>
       </tile>
       <tile x="4" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -28058,8 +28075,8 @@
         </component>
       </tile>
       <tile x="5" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -28069,8 +28086,8 @@
         </component>
       </tile>
       <tile x="6" y="10">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -28694,8 +28711,8 @@
         </component>
       </tile>
       <tile x="2" y="12">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -28705,8 +28722,8 @@
         </component>
       </tile>
       <tile x="3" y="12">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -29889,8 +29906,8 @@
       </tile>
       <tile x="2" y="16" />
       <tile x="3" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -30163,8 +30180,8 @@
         </component>
       </tile>
       <tile x="2" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -30174,8 +30191,8 @@
         </component>
       </tile>
       <tile x="3" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -31022,8 +31039,8 @@
         </component>
       </tile>
       <tile x="3" y="20">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -31033,8 +31050,8 @@
         </component>
       </tile>
       <tile x="4" y="20">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -31044,8 +31061,8 @@
         </component>
       </tile>
       <tile x="5" y="20">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -31277,8 +31294,8 @@
         </component>
       </tile>
       <tile x="5" y="21">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -31469,8 +31486,8 @@
         </component>
       </tile>
       <tile x="5" y="22">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -31686,8 +31703,8 @@
         </component>
       </tile>
       <tile x="5" y="23">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -31946,8 +31963,8 @@
         </component>
       </tile>
       <tile x="5" y="24">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -32154,8 +32171,8 @@
         </component>
       </tile>
       <tile x="6" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32165,8 +32182,8 @@
         </component>
       </tile>
       <tile x="7" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32176,8 +32193,8 @@
         </component>
       </tile>
       <tile x="8" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32187,8 +32204,8 @@
         </component>
       </tile>
       <tile x="9" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -32203,8 +32220,8 @@
         </component>
       </tile>
       <tile x="10" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32214,8 +32231,8 @@
         </component>
       </tile>
       <tile x="11" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32225,8 +32242,8 @@
         </component>
       </tile>
       <tile x="12" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32236,8 +32253,8 @@
         </component>
       </tile>
       <tile x="13" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32247,8 +32264,8 @@
         </component>
       </tile>
       <tile x="14" y="25">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -32678,8 +32695,8 @@
         </component>
       </tile>
       <tile x="33" y="28">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -32700,8 +32717,8 @@
       <name>Spider City</name>
       <height>-50</height>
       <tile x="0" y="0">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -32711,8 +32728,8 @@
         </component>
       </tile>
       <tile x="1" y="0">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -33534,8 +33551,8 @@
         </component>
       </tile>
       <tile x="48" y="1">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -33942,8 +33959,8 @@
         </component>
       </tile>
       <tile x="48" y="2">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -34259,8 +34276,8 @@
         </component>
       </tile>
       <tile x="49" y="3">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -34711,8 +34728,8 @@
         </component>
       </tile>
       <tile x="49" y="4">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -35051,8 +35068,8 @@
         </component>
       </tile>
       <tile x="50" y="5">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -35490,8 +35507,8 @@
         </component>
       </tile>
       <tile x="50" y="6">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -35840,8 +35857,8 @@
         </component>
       </tile>
       <tile x="50" y="7">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36182,13 +36199,14 @@
         </component>
       </tile>
       <tile x="36" y="8">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="8">
@@ -36292,8 +36310,8 @@
         </component>
       </tile>
       <tile x="50" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36605,8 +36623,8 @@
         </component>
       </tile>
       <tile x="49" y="9">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36616,8 +36634,8 @@
         </component>
       </tile>
       <tile x="50" y="9">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36641,8 +36659,8 @@
         </component>
       </tile>
       <tile x="1" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36652,8 +36670,8 @@
         </component>
       </tile>
       <tile x="2" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36663,8 +36681,8 @@
         </component>
       </tile>
       <tile x="3" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36674,8 +36692,8 @@
         </component>
       </tile>
       <tile x="4" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36690,8 +36708,8 @@
         </component>
       </tile>
       <tile x="5" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36701,8 +36719,8 @@
         </component>
       </tile>
       <tile x="6" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36712,8 +36730,8 @@
         </component>
       </tile>
       <tile x="7" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36723,8 +36741,8 @@
         </component>
       </tile>
       <tile x="8" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36734,8 +36752,8 @@
         </component>
       </tile>
       <tile x="9" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36745,8 +36763,8 @@
         </component>
       </tile>
       <tile x="10" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36756,8 +36774,8 @@
         </component>
       </tile>
       <tile x="11" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36767,8 +36785,8 @@
         </component>
       </tile>
       <tile x="12" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36778,8 +36796,8 @@
         </component>
       </tile>
       <tile x="13" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36789,8 +36807,8 @@
         </component>
       </tile>
       <tile x="14" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36805,8 +36823,8 @@
         </component>
       </tile>
       <tile x="15" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36816,8 +36834,8 @@
         </component>
       </tile>
       <tile x="16" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36847,8 +36865,8 @@
         </component>
       </tile>
       <tile x="20" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -36858,8 +36876,8 @@
         </component>
       </tile>
       <tile x="21" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36869,8 +36887,8 @@
         </component>
       </tile>
       <tile x="22" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -36885,8 +36903,8 @@
         </component>
       </tile>
       <tile x="23" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36896,8 +36914,8 @@
         </component>
       </tile>
       <tile x="24" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36907,8 +36925,8 @@
         </component>
       </tile>
       <tile x="25" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36918,8 +36936,8 @@
         </component>
       </tile>
       <tile x="26" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36929,8 +36947,8 @@
         </component>
       </tile>
       <tile x="27" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36940,8 +36958,8 @@
         </component>
       </tile>
       <tile x="28" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36951,8 +36969,8 @@
         </component>
       </tile>
       <tile x="29" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36962,8 +36980,8 @@
         </component>
       </tile>
       <tile x="30" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36973,8 +36991,8 @@
         </component>
       </tile>
       <tile x="31" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36984,8 +37002,8 @@
         </component>
       </tile>
       <tile x="32" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -36995,8 +37013,8 @@
         </component>
       </tile>
       <tile x="33" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37006,8 +37024,8 @@
         </component>
       </tile>
       <tile x="34" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37017,8 +37035,8 @@
         </component>
       </tile>
       <tile x="35" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37028,8 +37046,8 @@
         </component>
       </tile>
       <tile x="36" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37044,8 +37062,8 @@
         </component>
       </tile>
       <tile x="38" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -37055,8 +37073,8 @@
         </component>
       </tile>
       <tile x="39" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37066,8 +37084,8 @@
         </component>
       </tile>
       <tile x="40" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37077,8 +37095,8 @@
         </component>
       </tile>
       <tile x="41" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37088,8 +37106,8 @@
         </component>
       </tile>
       <tile x="42" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37099,8 +37117,8 @@
         </component>
       </tile>
       <tile x="43" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37110,8 +37128,8 @@
         </component>
       </tile>
       <tile x="44" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37121,8 +37139,8 @@
         </component>
       </tile>
       <tile x="45" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37132,8 +37150,8 @@
         </component>
       </tile>
       <tile x="46" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37143,8 +37161,8 @@
         </component>
       </tile>
       <tile x="47" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -37154,8 +37172,8 @@
         </component>
       </tile>
       <tile x="48" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37212,8 +37230,8 @@
         </component>
       </tile>
       <tile x="20" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37248,8 +37266,8 @@
         </component>
       </tile>
       <tile x="38" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37270,8 +37288,8 @@
       <name>Hobgoblin Caves</name>
       <height>-170</height>
       <tile x="1" y="0">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -37476,8 +37494,8 @@
         </component>
       </tile>
       <tile x="1" y="1">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37583,8 +37601,8 @@
         </component>
       </tile>
       <tile x="19" y="1">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37602,8 +37620,8 @@
         </component>
       </tile>
       <tile x="1" y="2">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37747,8 +37765,8 @@
         </component>
       </tile>
       <tile x="20" y="2">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37766,8 +37784,8 @@
         </component>
       </tile>
       <tile x="0" y="3">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -37777,8 +37795,8 @@
         </component>
       </tile>
       <tile x="1" y="3">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -37933,8 +37951,8 @@
         </component>
       </tile>
       <tile x="0" y="4">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38095,8 +38113,8 @@
         </component>
       </tile>
       <tile x="0" y="5">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38241,8 +38259,8 @@
         </component>
       </tile>
       <tile x="0" y="6">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38414,8 +38432,8 @@
         </component>
       </tile>
       <tile x="0" y="7">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38586,8 +38604,8 @@
         </component>
       </tile>
       <tile x="20" y="7">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38613,8 +38631,8 @@
         </component>
       </tile>
       <tile x="0" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38755,8 +38773,8 @@
         </component>
       </tile>
       <tile x="20" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38797,8 +38815,8 @@
         </component>
       </tile>
       <tile x="0" y="9">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38949,8 +38967,8 @@
         </component>
       </tile>
       <tile x="20" y="9">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -38983,8 +39001,8 @@
         </component>
       </tile>
       <tile x="0" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39123,8 +39141,8 @@
         </component>
       </tile>
       <tile x="20" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39157,8 +39175,8 @@
         </component>
       </tile>
       <tile x="0" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39299,8 +39317,8 @@
         </component>
       </tile>
       <tile x="20" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39310,8 +39328,8 @@
         </component>
       </tile>
       <tile x="0" y="12">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39462,8 +39480,8 @@
         </component>
       </tile>
       <tile x="20" y="12">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39473,8 +39491,8 @@
         </component>
       </tile>
       <tile x="0" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39610,8 +39628,8 @@
         </component>
       </tile>
       <tile x="20" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39621,8 +39639,8 @@
         </component>
       </tile>
       <tile x="0" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39751,8 +39769,8 @@
         </component>
       </tile>
       <tile x="20" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39762,8 +39780,8 @@
         </component>
       </tile>
       <tile x="0" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39913,8 +39931,8 @@
         </component>
       </tile>
       <tile x="18" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -39941,8 +39959,8 @@
         </component>
       </tile>
       <tile x="20" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -39958,8 +39976,8 @@
         </component>
       </tile>
       <tile x="0" y="16">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -40067,8 +40085,8 @@
         </component>
       </tile>
       <tile x="17" y="16">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -40312,8 +40330,8 @@
         </component>
       </tile>
       <tile x="12" y="18">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -40373,8 +40391,8 @@
         </component>
       </tile>
       <tile x="17" y="18">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -40530,8 +40548,8 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -40541,8 +40559,8 @@
         </component>
       </tile>
       <tile x="5" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -40552,8 +40570,8 @@
         </component>
       </tile>
       <tile x="6" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -40563,8 +40581,8 @@
         </component>
       </tile>
       <tile x="7" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -40638,8 +40656,8 @@
         </component>
       </tile>
       <tile x="4" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -40663,8 +40681,8 @@
         </component>
       </tile>
       <tile x="7" y="7">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -40765,8 +40783,8 @@
         </component>
       </tile>
       <tile x="4" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -40786,8 +40804,8 @@
         </component>
       </tile>
       <tile x="7" y="8">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -40902,8 +40920,8 @@
         </component>
       </tile>
       <tile x="4" y="9">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -40924,8 +40942,8 @@
         </component>
       </tile>
       <tile x="6" y="9">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -40935,8 +40953,8 @@
         </component>
       </tile>
       <tile x="7" y="9">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -41616,8 +41634,8 @@
       <name>Gym</name>
       <height>50</height>
       <tile x="3" y="2">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -41694,8 +41712,8 @@
         </component>
       </tile>
       <tile x="7" y="3">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -41843,8 +41861,8 @@
         </component>
       </tile>
       <tile x="7" y="5">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -41865,8 +41883,8 @@
         </component>
       </tile>
       <tile x="9" y="5">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -41902,8 +41920,8 @@
         </component>
       </tile>
       <tile x="3" y="6">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -41913,8 +41931,8 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -41935,8 +41953,8 @@
         </component>
       </tile>
       <tile x="6" y="6">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -41946,8 +41964,8 @@
         </component>
       </tile>
       <tile x="7" y="6">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -42559,8 +42577,8 @@
         </component>
       </tile>
       <tile x="2" y="11">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>225</wall>
@@ -42581,8 +42599,8 @@
         </component>
       </tile>
       <tile x="4" y="11">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -42762,8 +42780,8 @@
         </component>
       </tile>
       <tile x="6" y="14">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>224</wall>
@@ -43169,8 +43187,8 @@
       <name>Berg's Pit</name>
       <height>-20</height>
       <tile x="1" y="1">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -43372,8 +43390,8 @@
         </component>
       </tile>
       <tile x="3" y="5">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -43400,8 +43418,8 @@
         </component>
       </tile>
       <tile x="5" y="5">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43422,8 +43440,8 @@
       <name>Knight Cove</name>
       <height>0</height>
       <tile x="1" y="0">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>33</wall>
@@ -43569,8 +43587,8 @@
         </component>
       </tile>
       <tile x="4" y="3">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>33</wall>
@@ -43580,8 +43598,8 @@
         </component>
       </tile>
       <tile x="5" y="3">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -43630,8 +43648,8 @@
         </component>
       </tile>
       <tile x="4" y="4">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -43647,8 +43665,8 @@
         </component>
       </tile>
       <tile x="1" y="5">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43674,8 +43692,8 @@
         </component>
       </tile>
       <tile x="4" y="5">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43693,8 +43711,8 @@
         </component>
       </tile>
       <tile x="2" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -43704,8 +43722,8 @@
         </component>
       </tile>
       <tile x="3" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -43715,8 +43733,8 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43821,8 +43839,8 @@
         </component>
       </tile>
       <tile x="13" y="0">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43832,8 +43850,8 @@
         </component>
       </tile>
       <tile x="7" y="1">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43883,8 +43901,8 @@
         </component>
       </tile>
       <tile x="13" y="1">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43945,8 +43963,8 @@
         </component>
       </tile>
       <tile x="13" y="2">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43956,8 +43974,8 @@
         </component>
       </tile>
       <tile x="8" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -43993,8 +44011,8 @@
         </component>
       </tile>
       <tile x="13" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44004,8 +44022,8 @@
         </component>
       </tile>
       <tile x="8" y="4">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44046,8 +44064,8 @@
         </component>
       </tile>
       <tile x="13" y="4">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44057,8 +44075,8 @@
         </component>
       </tile>
       <tile x="7" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -44068,8 +44086,8 @@
         </component>
       </tile>
       <tile x="8" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44111,8 +44129,8 @@
         </component>
       </tile>
       <tile x="13" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44122,8 +44140,8 @@
         </component>
       </tile>
       <tile x="1" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -44133,8 +44151,8 @@
         </component>
       </tile>
       <tile x="2" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44144,8 +44162,8 @@
         </component>
       </tile>
       <tile x="3" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44155,8 +44173,8 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44166,8 +44184,8 @@
         </component>
       </tile>
       <tile x="5" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44177,8 +44195,8 @@
         </component>
       </tile>
       <tile x="6" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44188,8 +44206,8 @@
         </component>
       </tile>
       <tile x="7" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44231,8 +44249,8 @@
         </component>
       </tile>
       <tile x="12" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -44242,8 +44260,8 @@
         </component>
       </tile>
       <tile x="13" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44259,8 +44277,8 @@
         </component>
       </tile>
       <tile x="1" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44323,8 +44341,8 @@
         </component>
       </tile>
       <tile x="12" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44334,8 +44352,8 @@
         </component>
       </tile>
       <tile x="1" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44355,8 +44373,8 @@
         </component>
       </tile>
       <tile x="4" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -44366,8 +44384,8 @@
         </component>
       </tile>
       <tile x="5" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44377,8 +44395,8 @@
         </component>
       </tile>
       <tile x="6" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44388,8 +44406,8 @@
         </component>
       </tile>
       <tile x="7" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -44429,8 +44447,8 @@
         </component>
       </tile>
       <tile x="12" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44440,8 +44458,8 @@
         </component>
       </tile>
       <tile x="1" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44461,8 +44479,8 @@
         </component>
       </tile>
       <tile x="4" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44476,6 +44494,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="9">
@@ -44483,11 +44502,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44524,8 +44544,8 @@
         </component>
       </tile>
       <tile x="12" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44535,8 +44555,8 @@
         </component>
       </tile>
       <tile x="1" y="10">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44556,8 +44576,8 @@
         </component>
       </tile>
       <tile x="4" y="10">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44571,11 +44591,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -44585,8 +44606,8 @@
         </component>
       </tile>
       <tile x="7" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44628,8 +44649,8 @@
         </component>
       </tile>
       <tile x="12" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44639,8 +44660,8 @@
         </component>
       </tile>
       <tile x="1" y="11">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44660,8 +44681,8 @@
         </component>
       </tile>
       <tile x="4" y="11">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44675,11 +44696,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="11">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44726,8 +44748,8 @@
         </component>
       </tile>
       <tile x="12" y="11">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44737,8 +44759,8 @@
         </component>
       </tile>
       <tile x="1" y="12">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44758,8 +44780,8 @@
         </component>
       </tile>
       <tile x="4" y="12">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44773,11 +44795,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="12">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44812,8 +44835,8 @@
         </component>
       </tile>
       <tile x="12" y="12">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44823,8 +44846,8 @@
         </component>
       </tile>
       <tile x="1" y="13">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44844,8 +44867,8 @@
         </component>
       </tile>
       <tile x="4" y="13">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44859,11 +44882,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="13">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44907,8 +44931,8 @@
         </component>
       </tile>
       <tile x="12" y="13">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44918,8 +44942,8 @@
         </component>
       </tile>
       <tile x="1" y="14">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44939,8 +44963,8 @@
         </component>
       </tile>
       <tile x="4" y="14">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44954,11 +44978,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="14">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -44999,8 +45024,8 @@
         </component>
       </tile>
       <tile x="12" y="14">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45010,8 +45035,8 @@
         </component>
       </tile>
       <tile x="1" y="15">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45031,8 +45056,8 @@
         </component>
       </tile>
       <tile x="4" y="15">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45046,11 +45071,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="15">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45086,8 +45112,8 @@
         </component>
       </tile>
       <tile x="11" y="15">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -45097,8 +45123,8 @@
         </component>
       </tile>
       <tile x="12" y="15">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45114,8 +45140,8 @@
         </component>
       </tile>
       <tile x="1" y="16">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45135,8 +45161,8 @@
         </component>
       </tile>
       <tile x="4" y="16">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45150,11 +45176,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45190,8 +45217,8 @@
         </component>
       </tile>
       <tile x="11" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45205,11 +45232,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="17">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45229,8 +45257,8 @@
         </component>
       </tile>
       <tile x="4" y="17">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45244,11 +45272,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45278,8 +45307,8 @@
         </component>
       </tile>
       <tile x="11" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45293,11 +45322,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="18">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45317,8 +45347,8 @@
         </component>
       </tile>
       <tile x="4" y="18">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45332,6 +45362,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="18">
@@ -45339,6 +45370,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="18">
@@ -45361,6 +45393,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="18">
@@ -45368,6 +45401,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="18">
@@ -45375,11 +45409,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="19">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45399,8 +45434,8 @@
         </component>
       </tile>
       <tile x="4" y="19">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45410,8 +45445,8 @@
         </component>
       </tile>
       <tile x="5" y="19">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -45425,11 +45460,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="20">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45454,8 +45490,8 @@
         </component>
       </tile>
       <tile x="5" y="20">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45469,6 +45505,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="21">
@@ -45480,8 +45517,8 @@
         </component>
       </tile>
       <tile x="2" y="21">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -45504,8 +45541,8 @@
         </component>
       </tile>
       <tile x="5" y="21">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45519,6 +45556,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="22">
@@ -45530,8 +45568,8 @@
         </component>
       </tile>
       <tile x="3" y="22">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -45541,8 +45579,8 @@
         </component>
       </tile>
       <tile x="4" y="22">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -45552,8 +45590,8 @@
         </component>
       </tile>
       <tile x="5" y="22">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -45573,6 +45611,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
     </region>
@@ -45581,8 +45620,8 @@
       <name>Troll Temple</name>
       <height>-240</height>
       <tile x="4" y="3">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>143</wall>
@@ -45868,8 +45907,8 @@
         </component>
       </tile>
       <tile x="12" y="4">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -45885,8 +45924,8 @@
         </component>
       </tile>
       <tile x="13" y="4">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -45919,8 +45958,8 @@
         </component>
       </tile>
       <tile x="17" y="4">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="DoorComponent">
           <openId>79</openId>
@@ -46031,8 +46070,8 @@
         </component>
       </tile>
       <tile x="12" y="5">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46048,8 +46087,8 @@
         </component>
       </tile>
       <tile x="13" y="5">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46079,8 +46118,8 @@
         <component type="FloorComponent">
           <ground>178</ground>
         </component>
-        <component type="StaticComponent">
-          <static>86</static>
+        <component type="CounterComponent">
+          <counter>86</counter>
         </component>
       </tile>
       <tile x="16" y="5">
@@ -46095,8 +46134,8 @@
         </component>
       </tile>
       <tile x="17" y="5">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46157,8 +46196,8 @@
         </component>
       </tile>
       <tile x="23" y="5">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -46167,8 +46206,8 @@
         </component>
       </tile>
       <tile x="24" y="5">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46183,8 +46222,8 @@
         </component>
       </tile>
       <tile x="1" y="6">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>143</wall>
@@ -46224,8 +46263,8 @@
         </component>
       </tile>
       <tile x="5" y="6">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46385,8 +46424,8 @@
         </component>
       </tile>
       <tile x="4" y="7">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46402,8 +46441,8 @@
         </component>
       </tile>
       <tile x="5" y="7">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46741,8 +46780,8 @@
         </component>
       </tile>
       <tile x="23" y="8">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -46751,8 +46790,8 @@
         </component>
       </tile>
       <tile x="24" y="8">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46788,8 +46827,8 @@
         </component>
       </tile>
       <tile x="4" y="9">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -46995,8 +47034,8 @@
         </component>
       </tile>
       <tile x="4" y="10">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="DoorComponent">
           <openId>79</openId>
@@ -47072,18 +47111,19 @@
         </component>
       </tile>
       <tile x="17" y="10">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>182</static>
         </component>
         <component type="WallComponent">
           <wall>33</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="10">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -47107,8 +47147,8 @@
         </component>
       </tile>
       <tile x="22" y="10">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -47117,8 +47157,8 @@
         </component>
       </tile>
       <tile x="23" y="10">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -47127,8 +47167,8 @@
         </component>
       </tile>
       <tile x="24" y="10">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -47176,8 +47216,8 @@
         </component>
       </tile>
       <tile x="4" y="11">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -47304,8 +47344,8 @@
         </component>
       </tile>
       <tile x="17" y="11">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -47379,6 +47419,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="12">
@@ -47452,13 +47493,14 @@
         </component>
       </tile>
       <tile x="15" y="12">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="12">
@@ -47467,8 +47509,8 @@
         </component>
       </tile>
       <tile x="17" y="12">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -47521,8 +47563,8 @@
         </component>
       </tile>
       <tile x="24" y="12">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -47561,6 +47603,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="13">
@@ -47646,8 +47689,8 @@
         </component>
       </tile>
       <tile x="17" y="13">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -47715,8 +47758,8 @@
         </component>
       </tile>
       <tile x="25" y="13">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -47746,6 +47789,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="14">
@@ -47753,6 +47797,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="14">
@@ -47864,22 +47909,17 @@
       </tile>
       <tile x="17" y="14">
         <component type="FloorComponent">
-          <ground>3</ground>
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
         </component>
-        <component type="WallComponent">
-          <wall>33</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-        </component>
       </tile>
       <tile x="18" y="14">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -47888,8 +47928,8 @@
         </component>
       </tile>
       <tile x="19" y="14">
-        <component type="StaticComponent">
-          <static>23</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -47898,8 +47938,8 @@
         </component>
       </tile>
       <tile x="20" y="14">
-        <component type="StaticComponent">
-          <static>23</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="DoorComponent">
           <openId>76</openId>
@@ -47910,8 +47950,8 @@
         </component>
       </tile>
       <tile x="21" y="14">
-        <component type="StaticComponent">
-          <static>23</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -47920,8 +47960,8 @@
         </component>
       </tile>
       <tile x="22" y="14">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="DoorComponent">
           <openId>76</openId>
@@ -48006,8 +48046,8 @@
         </component>
       </tile>
       <tile x="4" y="15">
-        <component type="FloorComponent">
-          <ground>182</ground>
+        <component type="StaticComponent">
+          <static>182</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -48056,8 +48096,8 @@
         <component type="StaticComponent">
           <static>3</static>
         </component>
-        <component type="StaticComponent">
-          <static>166</static>
+        <component type="ObstructionComponent">
+          <obstruction>166</obstruction>
         </component>
       </tile>
       <tile x="11" y="15">
@@ -48097,8 +48137,8 @@
         </component>
       </tile>
       <tile x="17" y="15">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48122,8 +48162,8 @@
         </component>
       </tile>
       <tile x="21" y="15">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>3</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48142,8 +48182,8 @@
         </component>
       </tile>
       <tile x="24" y="15">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>33</wall>
@@ -48153,8 +48193,8 @@
         </component>
       </tile>
       <tile x="25" y="15">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48298,17 +48338,12 @@
       </tile>
       <tile x="17" y="16">
         <component type="FloorComponent">
-          <ground>3</ground>
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>33</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
         </component>
       </tile>
       <tile x="18" y="16">
@@ -48372,8 +48407,8 @@
         </component>
       </tile>
       <tile x="24" y="16">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48398,8 +48433,8 @@
         </component>
       </tile>
       <tile x="1" y="17">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -48409,8 +48444,8 @@
         </component>
       </tile>
       <tile x="2" y="17">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -48515,8 +48550,8 @@
         </component>
       </tile>
       <tile x="17" y="17">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48540,8 +48575,8 @@
         </component>
       </tile>
       <tile x="21" y="17">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>3</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48704,8 +48739,8 @@
         </component>
       </tile>
       <tile x="17" y="18">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48714,8 +48749,8 @@
         </component>
       </tile>
       <tile x="18" y="18">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>3</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -48735,8 +48770,8 @@
         </component>
       </tile>
       <tile x="20" y="18">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>3</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -48760,8 +48795,8 @@
         </component>
       </tile>
       <tile x="22" y="18">
-        <component type="StaticComponent">
-          <static>3</static>
+        <component type="FloorComponent">
+          <ground>3</ground>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
@@ -48781,8 +48816,8 @@
         </component>
       </tile>
       <tile x="24" y="18">
-        <component type="FloorComponent">
-          <ground>3</ground>
+        <component type="StaticComponent">
+          <static>3</static>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
@@ -48873,13 +48908,14 @@
         </component>
       </tile>
       <tile x="15" y="19">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="19">
@@ -48985,8 +49021,8 @@
         </component>
       </tile>
       <tile x="8" y="20">
-        <component type="StaticComponent">
-          <static>182</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -48995,8 +49031,8 @@
         </component>
       </tile>
       <tile x="9" y="20">
-        <component type="StaticComponent">
-          <static>182</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="DoorComponent">
           <openId>78</openId>
@@ -49007,8 +49043,8 @@
         </component>
       </tile>
       <tile x="10" y="20">
-        <component type="StaticComponent">
-          <static>182</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -49017,8 +49053,8 @@
         </component>
       </tile>
       <tile x="11" y="20">
-        <component type="StaticComponent">
-          <static>182</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -49027,8 +49063,8 @@
         </component>
       </tile>
       <tile x="12" y="20">
-        <component type="StaticComponent">
-          <static>182</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -49037,8 +49073,8 @@
         </component>
       </tile>
       <tile x="13" y="20">
-        <component type="StaticComponent">
-          <static>182</static>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="WallComponent">
           <wall>139</wall>
@@ -49116,8 +49152,8 @@
         </component>
       </tile>
       <tile x="2" y="21">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -49127,8 +49163,8 @@
         </component>
       </tile>
       <tile x="3" y="21">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -49149,8 +49185,8 @@
         </component>
       </tile>
       <tile x="5" y="21">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -49171,8 +49207,8 @@
         </component>
       </tile>
       <tile x="7" y="21">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49196,8 +49232,8 @@
         </component>
       </tile>
       <tile x="11" y="21">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49211,8 +49247,8 @@
         </component>
       </tile>
       <tile x="13" y="21">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49251,13 +49287,14 @@
         </component>
       </tile>
       <tile x="19" y="21">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="21">
@@ -49271,13 +49308,14 @@
         </component>
       </tile>
       <tile x="22" y="21">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="21">
@@ -49313,8 +49351,8 @@
         </component>
       </tile>
       <tile x="7" y="22">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49345,8 +49383,8 @@
         </component>
       </tile>
       <tile x="10" y="22">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>143</wall>
@@ -49356,8 +49394,8 @@
         </component>
       </tile>
       <tile x="11" y="22">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49473,8 +49511,8 @@
         </component>
       </tile>
       <tile x="7" y="23">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49490,8 +49528,8 @@
         </component>
       </tile>
       <tile x="8" y="23">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49523,8 +49561,8 @@
         </component>
       </tile>
       <tile x="11" y="23">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49583,13 +49621,14 @@
         </component>
       </tile>
       <tile x="19" y="23">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="23">
@@ -49603,13 +49642,14 @@
         </component>
       </tile>
       <tile x="22" y="23">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>104</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="23">
@@ -49645,8 +49685,8 @@
         </component>
       </tile>
       <tile x="7" y="24">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="DoorComponent">
           <openId>79</openId>
@@ -49675,8 +49715,8 @@
         </component>
       </tile>
       <tile x="11" y="24">
-        <component type="StaticComponent">
-          <static>178</static>
+        <component type="FloorComponent">
+          <ground>178</ground>
         </component>
         <component type="DoorComponent">
           <openId>79</openId>
@@ -49794,8 +49834,8 @@
         </component>
       </tile>
       <tile x="7" y="25">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49843,19 +49883,19 @@
         </component>
       </tile>
       <tile x="11" y="25">
-        <component type="FloorComponent">
-          <ground>178</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>140</wall>
-          <destroyed>142</destroyed>
-          <ruins>46</ruins>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>140</wall>
+          <destroyed>142</destroyed>
+          <ruins>46</ruins>
         </component>
       </tile>
       <tile x="12" y="25">
@@ -49914,8 +49954,8 @@
         </component>
       </tile>
       <tile x="17" y="25">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>140</wall>
@@ -49996,8 +50036,8 @@
         </component>
       </tile>
       <tile x="24" y="25">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -50018,8 +50058,8 @@
       <name>Reptile Pit</name>
       <height>-310</height>
       <tile x="1" y="0">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -50040,8 +50080,8 @@
         </component>
       </tile>
       <tile x="3" y="0">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50062,8 +50102,8 @@
         </component>
       </tile>
       <tile x="5" y="0">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50106,8 +50146,8 @@
         </component>
       </tile>
       <tile x="9" y="0">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50172,8 +50212,8 @@
         </component>
       </tile>
       <tile x="15" y="0">
-        <component type="FloorComponent">
-          <ground>178</ground>
+        <component type="StaticComponent">
+          <static>178</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50410,8 +50450,8 @@
         </component>
       </tile>
       <tile x="5" y="2">
-        <component type="FloorComponent">
-          <ground>176</ground>
+        <component type="StaticComponent">
+          <static>176</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -50432,9 +50472,8 @@
         </component>
       </tile>
       <tile x="7" y="2">
-        <component type="WaterComponent">
-          <ground>180</ground>
-          <movementCost>3</movementCost>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50477,9 +50516,8 @@
         </component>
       </tile>
       <tile x="11" y="2">
-        <component type="WaterComponent">
-          <ground>180</ground>
-          <movementCost>3</movementCost>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50489,9 +50527,8 @@
         </component>
       </tile>
       <tile x="12" y="2">
-        <component type="WaterComponent">
-          <ground>180</ground>
-          <movementCost>3</movementCost>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50534,9 +50571,8 @@
         </component>
       </tile>
       <tile x="16" y="2">
-        <component type="WaterComponent">
-          <ground>180</ground>
-          <movementCost>3</movementCost>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -50601,8 +50637,8 @@
         </component>
       </tile>
       <tile x="22" y="2">
-        <component type="FloorComponent">
-          <ground>176</ground>
+        <component type="StaticComponent">
+          <static>176</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -50668,11 +50704,12 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="3">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -50682,8 +50719,8 @@
         </component>
       </tile>
       <tile x="8" y="3">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -50830,6 +50867,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="4">
@@ -50981,8 +51019,8 @@
         </component>
       </tile>
       <tile x="6" y="5">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -50992,8 +51030,8 @@
         </component>
       </tile>
       <tile x="7" y="5">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51014,8 +51052,8 @@
         </component>
       </tile>
       <tile x="9" y="5">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -51025,8 +51063,8 @@
         </component>
       </tile>
       <tile x="10" y="5">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51183,8 +51221,8 @@
         </component>
       </tile>
       <tile x="6" y="6">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51225,6 +51263,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="6">
@@ -51244,8 +51283,8 @@
         </component>
       </tile>
       <tile x="13" y="6">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51277,8 +51316,8 @@
         </component>
       </tile>
       <tile x="16" y="6">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -51288,8 +51327,8 @@
         </component>
       </tile>
       <tile x="17" y="6">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51328,8 +51367,8 @@
         </component>
       </tile>
       <tile x="20" y="6">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51376,8 +51415,8 @@
         </component>
       </tile>
       <tile x="2" y="7">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -51387,8 +51426,8 @@
         </component>
       </tile>
       <tile x="3" y="7">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51430,8 +51469,8 @@
         </component>
       </tile>
       <tile x="8" y="7">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -51441,8 +51480,8 @@
         </component>
       </tile>
       <tile x="9" y="7">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51487,8 +51526,8 @@
         </component>
       </tile>
       <tile x="13" y="7">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51583,8 +51622,8 @@
         </component>
       </tile>
       <tile x="25" y="7">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51600,8 +51639,8 @@
         </component>
       </tile>
       <tile x="1" y="8">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -51611,8 +51650,8 @@
         </component>
       </tile>
       <tile x="2" y="8">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51700,9 +51739,8 @@
         </component>
       </tile>
       <tile x="13" y="8">
-        <component type="FloorComponent">
-          <ground>18</ground>
-          <movementCost>2</movementCost>
+        <component type="StaticComponent">
+          <static>18</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51741,8 +51779,8 @@
         </component>
       </tile>
       <tile x="16" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51785,8 +51823,8 @@
         </component>
       </tile>
       <tile x="20" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -51990,8 +52028,8 @@
         </component>
       </tile>
       <tile x="23" y="9">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -52012,8 +52050,8 @@
         </component>
       </tile>
       <tile x="25" y="9">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52050,8 +52088,8 @@
         </component>
       </tile>
       <tile x="4" y="10">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -52072,8 +52110,8 @@
         </component>
       </tile>
       <tile x="6" y="10">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52157,8 +52195,8 @@
         </component>
       </tile>
       <tile x="16" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52201,8 +52239,8 @@
         </component>
       </tile>
       <tile x="20" y="10">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52248,8 +52286,8 @@
         </component>
       </tile>
       <tile x="0" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -52259,8 +52297,8 @@
         </component>
       </tile>
       <tile x="1" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52313,6 +52351,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="11">
@@ -52361,9 +52400,8 @@
         </component>
       </tile>
       <tile x="11" y="11">
-        <component type="FloorComponent">
-          <ground>18</ground>
-          <movementCost>2</movementCost>
+        <component type="StaticComponent">
+          <static>18</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -52384,9 +52422,8 @@
         </component>
       </tile>
       <tile x="13" y="11">
-        <component type="FloorComponent">
-          <ground>18</ground>
-          <movementCost>2</movementCost>
+        <component type="StaticComponent">
+          <static>18</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52503,8 +52540,8 @@
         </component>
       </tile>
       <tile x="4" y="12">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52531,8 +52568,8 @@
         </component>
       </tile>
       <tile x="6" y="12">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52553,8 +52590,8 @@
         </component>
       </tile>
       <tile x="8" y="12">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52594,9 +52631,8 @@
         </component>
       </tile>
       <tile x="11" y="12">
-        <component type="FloorComponent">
-          <ground>18</ground>
-          <movementCost>2</movementCost>
+        <component type="StaticComponent">
+          <static>18</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52732,8 +52768,8 @@
         </component>
       </tile>
       <tile x="4" y="13">
-        <component type="FloorComponent">
-          <ground>183</ground>
+        <component type="StaticComponent">
+          <static>183</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52817,8 +52853,8 @@
         </component>
       </tile>
       <tile x="16" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52879,8 +52915,8 @@
         </component>
       </tile>
       <tile x="21" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -52948,8 +52984,8 @@
         </component>
       </tile>
       <tile x="6" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -52970,8 +53006,8 @@
         </component>
       </tile>
       <tile x="8" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53162,8 +53198,8 @@
         </component>
       </tile>
       <tile x="6" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53222,8 +53258,8 @@
         </component>
       </tile>
       <tile x="16" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53305,8 +53341,8 @@
         </component>
       </tile>
       <tile x="23" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53396,8 +53432,8 @@
         </component>
       </tile>
       <tile x="16" y="16">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53418,8 +53454,8 @@
       <name>Wyrm Pit</name>
       <height>-190</height>
       <tile x="5" y="2">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -53492,8 +53528,8 @@
         </component>
       </tile>
       <tile x="4" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -53503,8 +53539,8 @@
         </component>
       </tile>
       <tile x="5" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53545,8 +53581,8 @@
         </component>
       </tile>
       <tile x="11" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53556,8 +53592,8 @@
         </component>
       </tile>
       <tile x="4" y="4">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53597,8 +53633,8 @@
         </component>
       </tile>
       <tile x="11" y="4">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53608,8 +53644,8 @@
         </component>
       </tile>
       <tile x="12" y="4">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -53627,8 +53663,8 @@
         </component>
       </tile>
       <tile x="4" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53684,8 +53720,8 @@
         </component>
       </tile>
       <tile x="13" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53695,8 +53731,8 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53753,8 +53789,8 @@
         </component>
       </tile>
       <tile x="13" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53764,8 +53800,8 @@
         </component>
       </tile>
       <tile x="4" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53826,8 +53862,8 @@
         </component>
       </tile>
       <tile x="13" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53837,8 +53873,8 @@
         </component>
       </tile>
       <tile x="4" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53904,8 +53940,8 @@
         </component>
       </tile>
       <tile x="13" y="8">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53920,8 +53956,8 @@
         </component>
       </tile>
       <tile x="4" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -53990,8 +54026,8 @@
         </component>
       </tile>
       <tile x="13" y="9">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54001,8 +54037,8 @@
         </component>
       </tile>
       <tile x="4" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54055,8 +54091,8 @@
         </component>
       </tile>
       <tile x="12" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -54066,8 +54102,8 @@
         </component>
       </tile>
       <tile x="13" y="10">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54083,8 +54119,8 @@
         </component>
       </tile>
       <tile x="4" y="11">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54139,8 +54175,8 @@
         </component>
       </tile>
       <tile x="12" y="11">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54150,8 +54186,8 @@
         </component>
       </tile>
       <tile x="4" y="12">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54208,8 +54244,8 @@
         </component>
       </tile>
       <tile x="12" y="12">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54224,8 +54260,8 @@
         </component>
       </tile>
       <tile x="4" y="13">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54277,8 +54313,8 @@
         </component>
       </tile>
       <tile x="12" y="13">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54288,8 +54324,8 @@
         </component>
       </tile>
       <tile x="4" y="14">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54343,8 +54379,8 @@
         </component>
       </tile>
       <tile x="11" y="14">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -54354,8 +54390,8 @@
         </component>
       </tile>
       <tile x="12" y="14">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54371,8 +54407,8 @@
         </component>
       </tile>
       <tile x="4" y="15">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54418,8 +54454,8 @@
         </component>
       </tile>
       <tile x="11" y="15">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54437,8 +54473,8 @@
         </component>
       </tile>
       <tile x="5" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -54458,8 +54494,8 @@
         </component>
       </tile>
       <tile x="8" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -54469,8 +54505,8 @@
         </component>
       </tile>
       <tile x="9" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -54480,8 +54516,8 @@
         </component>
       </tile>
       <tile x="10" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -54497,8 +54533,8 @@
         </component>
       </tile>
       <tile x="11" y="16">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54514,8 +54550,8 @@
         </component>
       </tile>
       <tile x="5" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54535,8 +54571,8 @@
         </component>
       </tile>
       <tile x="8" y="17">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54554,8 +54590,8 @@
         </component>
       </tile>
       <tile x="6" y="18">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -54570,8 +54606,8 @@
         </component>
       </tile>
       <tile x="8" y="18">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54581,8 +54617,8 @@
         </component>
       </tile>
       <tile x="6" y="19">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54597,8 +54633,8 @@
         </component>
       </tile>
       <tile x="8" y="19">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54608,8 +54644,8 @@
         </component>
       </tile>
       <tile x="6" y="20">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54624,8 +54660,8 @@
         </component>
       </tile>
       <tile x="8" y="20">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54635,8 +54671,8 @@
         </component>
       </tile>
       <tile x="9" y="20">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -54654,8 +54690,8 @@
         </component>
       </tile>
       <tile x="6" y="21">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54680,8 +54716,8 @@
         </component>
       </tile>
       <tile x="10" y="21">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54699,8 +54735,8 @@
         </component>
       </tile>
       <tile x="7" y="22">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -54720,8 +54756,8 @@
         </component>
       </tile>
       <tile x="10" y="22">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54731,8 +54767,8 @@
         </component>
       </tile>
       <tile x="7" y="23">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54752,8 +54788,8 @@
         </component>
       </tile>
       <tile x="10" y="23">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54771,8 +54807,8 @@
         </component>
       </tile>
       <tile x="7" y="24">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54797,8 +54833,8 @@
         </component>
       </tile>
       <tile x="11" y="24">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54816,8 +54852,8 @@
         </component>
       </tile>
       <tile x="7" y="25">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54863,8 +54899,8 @@
         </component>
       </tile>
       <tile x="12" y="25">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54882,8 +54918,8 @@
         </component>
       </tile>
       <tile x="6" y="26">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -54893,8 +54929,8 @@
         </component>
       </tile>
       <tile x="7" y="26">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54935,8 +54971,8 @@
         </component>
       </tile>
       <tile x="13" y="26">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54946,8 +54982,8 @@
         </component>
       </tile>
       <tile x="6" y="27">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -54996,8 +55032,8 @@
         </component>
       </tile>
       <tile x="13" y="27">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55007,8 +55043,8 @@
         </component>
       </tile>
       <tile x="4" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -55018,8 +55054,8 @@
         </component>
       </tile>
       <tile x="5" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -55029,8 +55065,8 @@
         </component>
       </tile>
       <tile x="6" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55066,8 +55102,8 @@
         </component>
       </tile>
       <tile x="11" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55077,8 +55113,8 @@
         </component>
       </tile>
       <tile x="12" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -55088,8 +55124,8 @@
         </component>
       </tile>
       <tile x="13" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55105,8 +55141,8 @@
         </component>
       </tile>
       <tile x="4" y="29">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55136,8 +55172,8 @@
         </component>
       </tile>
       <tile x="9" y="29">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -55147,8 +55183,8 @@
         </component>
       </tile>
       <tile x="10" y="29">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -55158,8 +55194,8 @@
         </component>
       </tile>
       <tile x="11" y="29">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55175,8 +55211,8 @@
         </component>
       </tile>
       <tile x="4" y="30">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55212,8 +55248,8 @@
         </component>
       </tile>
       <tile x="9" y="30">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55223,8 +55259,8 @@
         </component>
       </tile>
       <tile x="4" y="31">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55257,8 +55293,8 @@
         </component>
       </tile>
       <tile x="9" y="31">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55268,8 +55304,8 @@
         </component>
       </tile>
       <tile x="4" y="32">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55300,8 +55336,8 @@
         </component>
       </tile>
       <tile x="8" y="32">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -55311,8 +55347,8 @@
         </component>
       </tile>
       <tile x="9" y="32">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55328,8 +55364,8 @@
         </component>
       </tile>
       <tile x="4" y="33">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55358,8 +55394,8 @@
         </component>
       </tile>
       <tile x="8" y="33">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55369,8 +55405,8 @@
         </component>
       </tile>
       <tile x="4" y="34">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55398,8 +55434,8 @@
         </component>
       </tile>
       <tile x="8" y="34">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55417,8 +55453,8 @@
         </component>
       </tile>
       <tile x="4" y="35">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55455,8 +55491,8 @@
         </component>
       </tile>
       <tile x="9" y="35">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55466,8 +55502,8 @@
         </component>
       </tile>
       <tile x="4" y="36">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55501,8 +55537,8 @@
         </component>
       </tile>
       <tile x="9" y="36">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55512,8 +55548,8 @@
         </component>
       </tile>
       <tile x="4" y="37">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55549,8 +55585,8 @@
         </component>
       </tile>
       <tile x="9" y="37">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55560,8 +55596,8 @@
         </component>
       </tile>
       <tile x="4" y="38">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55598,8 +55634,8 @@
         </component>
       </tile>
       <tile x="9" y="38">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55609,8 +55645,8 @@
         </component>
       </tile>
       <tile x="4" y="39">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55640,8 +55676,8 @@
         </component>
       </tile>
       <tile x="9" y="39">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -55703,8 +55739,8 @@
         </component>
       </tile>
       <tile x="9" y="40">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56099,13 +56135,14 @@
         </component>
       </tile>
       <tile x="6" y="-8">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-8">
@@ -56129,8 +56166,8 @@
         </component>
       </tile>
       <tile x="11" y="-8">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56253,8 +56290,8 @@
         </component>
       </tile>
       <tile x="42" y="-8">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56338,13 +56375,14 @@
         </component>
       </tile>
       <tile x="6" y="-7">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-7">
@@ -56368,8 +56406,8 @@
         </component>
       </tile>
       <tile x="11" y="-7">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56512,8 +56550,8 @@
         </component>
       </tile>
       <tile x="42" y="-7">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56556,6 +56594,9 @@
         </component>
       </tile>
       <tile x="1" y="-6">
+        <component type="FloorComponent">
+          <ground>1</ground>
+        </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
@@ -56628,8 +56669,8 @@
         </component>
       </tile>
       <tile x="11" y="-6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56878,8 +56919,8 @@
         </component>
       </tile>
       <tile x="42" y="-6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -56891,7 +56932,6 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="-5">
@@ -57236,8 +57276,8 @@
         </component>
       </tile>
       <tile x="42" y="-5">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -57315,13 +57355,14 @@
         </component>
       </tile>
       <tile x="4" y="-4">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-4">
@@ -57630,8 +57671,8 @@
         </component>
       </tile>
       <tile x="42" y="-4">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -57699,13 +57740,14 @@
         </component>
       </tile>
       <tile x="4" y="-3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-3">
@@ -57749,13 +57791,14 @@
         </component>
       </tile>
       <tile x="9" y="-3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-3">
@@ -57978,8 +58021,8 @@
         </component>
       </tile>
       <tile x="42" y="-3">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -58092,8 +58135,8 @@
         </component>
       </tile>
       <tile x="11" y="-2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -58316,8 +58359,8 @@
         </component>
       </tile>
       <tile x="42" y="-2">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -58443,8 +58486,8 @@
         </component>
       </tile>
       <tile x="10" y="-1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -58454,8 +58497,8 @@
         </component>
       </tile>
       <tile x="11" y="-1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -58475,6 +58518,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-1">
@@ -58482,6 +58526,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-1">
@@ -58489,6 +58534,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-1">
@@ -58496,6 +58542,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="-1">
@@ -58503,6 +58550,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-1">
@@ -58510,6 +58558,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-1">
@@ -58517,6 +58566,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="-1">
@@ -58524,6 +58574,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="-1">
@@ -58531,6 +58582,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="-1">
@@ -58538,6 +58590,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="-1">
@@ -58719,8 +58772,8 @@
         </component>
       </tile>
       <tile x="42" y="-1">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -58837,8 +58890,8 @@
         </component>
       </tile>
       <tile x="10" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
@@ -58860,6 +58913,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="0">
@@ -58867,6 +58921,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="0">
@@ -58874,6 +58929,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="0">
@@ -58881,6 +58937,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="0">
@@ -58888,6 +58945,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="0">
@@ -58895,6 +58953,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="0">
@@ -58902,6 +58961,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="0">
@@ -58909,6 +58969,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="0">
@@ -58916,6 +58977,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="0">
@@ -59035,8 +59097,8 @@
         </component>
       </tile>
       <tile x="42" y="0">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -59177,6 +59239,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="1">
@@ -59184,6 +59247,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="1">
@@ -59191,6 +59255,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="1">
@@ -59198,6 +59263,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="1">
@@ -59205,6 +59271,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="1">
@@ -59212,6 +59279,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="1">
@@ -59219,6 +59287,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="1">
@@ -59226,6 +59295,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="1">
@@ -59233,6 +59303,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="1">
@@ -59331,7 +59402,6 @@
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="34" y="1">
@@ -59405,8 +59475,8 @@
         </component>
       </tile>
       <tile x="42" y="1">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -59444,13 +59514,14 @@
         </component>
       </tile>
       <tile x="-1" y="2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="2">
@@ -59518,8 +59589,8 @@
         </component>
       </tile>
       <tile x="7" y="2">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -59528,8 +59599,8 @@
         </component>
       </tile>
       <tile x="8" y="2">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -59538,8 +59609,8 @@
         </component>
       </tile>
       <tile x="9" y="2">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -59781,8 +59852,8 @@
         </component>
       </tile>
       <tile x="42" y="2">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -59810,13 +59881,14 @@
         </component>
       </tile>
       <tile x="-1" y="3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="3">
@@ -60145,8 +60217,8 @@
         </component>
       </tile>
       <tile x="42" y="3">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -60158,7 +60230,6 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="4">
@@ -60497,8 +60568,8 @@
         </component>
       </tile>
       <tile x="42" y="4">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -60784,8 +60855,8 @@
         </component>
       </tile>
       <tile x="42" y="5">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -60803,8 +60874,8 @@
         </component>
       </tile>
       <tile x="-3" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60814,8 +60885,8 @@
         </component>
       </tile>
       <tile x="-2" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60825,8 +60896,8 @@
         </component>
       </tile>
       <tile x="-1" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60836,8 +60907,8 @@
         </component>
       </tile>
       <tile x="0" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60847,8 +60918,8 @@
         </component>
       </tile>
       <tile x="1" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60858,8 +60929,8 @@
         </component>
       </tile>
       <tile x="2" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60869,8 +60940,8 @@
         </component>
       </tile>
       <tile x="3" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -60880,8 +60951,8 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>32</wall>
@@ -60901,8 +60972,8 @@
         </component>
       </tile>
       <tile x="5" y="6">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -61155,8 +61226,8 @@
         </component>
       </tile>
       <tile x="42" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -61166,8 +61237,8 @@
         </component>
       </tile>
       <tile x="43" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -61177,8 +61248,8 @@
         </component>
       </tile>
       <tile x="44" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -61188,8 +61259,8 @@
         </component>
       </tile>
       <tile x="45" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -61199,8 +61270,8 @@
         </component>
       </tile>
       <tile x="46" y="6">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -61218,8 +61289,8 @@
         </component>
       </tile>
       <tile x="5" y="7">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -61470,8 +61541,8 @@
         </component>
       </tile>
       <tile x="47" y="7">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -61481,8 +61552,8 @@
         </component>
       </tile>
       <tile x="5" y="8">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -61492,8 +61563,8 @@
         </component>
       </tile>
       <tile x="6" y="8">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -61836,8 +61907,8 @@
         </component>
       </tile>
       <tile x="47" y="8">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -61847,8 +61918,8 @@
         </component>
       </tile>
       <tile x="5" y="9">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -61858,8 +61929,8 @@
         </component>
       </tile>
       <tile x="6" y="9">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -62030,8 +62101,8 @@
         </component>
       </tile>
       <tile x="31" y="9">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="DoorComponent">
           <openId>74</openId>
@@ -62147,8 +62218,8 @@
         </component>
       </tile>
       <tile x="47" y="9">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -62158,8 +62229,8 @@
         </component>
       </tile>
       <tile x="5" y="10">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -62444,8 +62515,8 @@
         </component>
       </tile>
       <tile x="47" y="10">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -62463,8 +62534,8 @@
         </component>
       </tile>
       <tile x="6" y="11">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -62635,8 +62706,8 @@
         </component>
       </tile>
       <tile x="30" y="11">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>32</wall>
@@ -62646,8 +62717,8 @@
         </component>
       </tile>
       <tile x="31" y="11">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -62762,8 +62833,8 @@
         </component>
       </tile>
       <tile x="47" y="11">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -62773,8 +62844,8 @@
         </component>
       </tile>
       <tile x="6" y="12">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -62786,6 +62857,7 @@
           <wall>32</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="12">
@@ -62985,8 +63057,8 @@
         </component>
       </tile>
       <tile x="30" y="12">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -62996,8 +63068,8 @@
         </component>
       </tile>
       <tile x="31" y="12">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -63133,8 +63205,8 @@
         </component>
       </tile>
       <tile x="47" y="12">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -63144,8 +63216,8 @@
         </component>
       </tile>
       <tile x="4" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -63155,8 +63227,8 @@
         </component>
       </tile>
       <tile x="5" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -63166,8 +63238,8 @@
         </component>
       </tile>
       <tile x="6" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -63424,8 +63496,8 @@
         </component>
       </tile>
       <tile x="47" y="13">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -63435,8 +63507,8 @@
         </component>
       </tile>
       <tile x="3" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -63446,8 +63518,8 @@
         </component>
       </tile>
       <tile x="4" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -63668,6 +63740,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="134" b="0" a="255" />
@@ -63679,6 +63752,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="134" b="0" a="255" />
@@ -63686,13 +63760,14 @@
         </component>
       </tile>
       <tile x="34" y="14">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="35" y="14">
@@ -63756,8 +63831,8 @@
         </component>
       </tile>
       <tile x="47" y="14">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -63777,8 +63852,8 @@
         </component>
       </tile>
       <tile x="2" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -63788,8 +63863,8 @@
         </component>
       </tile>
       <tile x="3" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -64086,8 +64161,8 @@
         </component>
       </tile>
       <tile x="2" y="16">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -64458,6 +64533,7 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="17">
@@ -65094,8 +65170,8 @@
         </component>
       </tile>
       <tile x="1" y="19">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -65105,8 +65181,8 @@
         </component>
       </tile>
       <tile x="2" y="19">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -66823,8 +66899,8 @@
         </component>
       </tile>
       <tile x="3" y="24">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -67016,13 +67092,14 @@
         </component>
       </tile>
       <tile x="24" y="24">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>32</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="24">
@@ -67059,8 +67136,8 @@
         </component>
       </tile>
       <tile x="28" y="24">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -67430,6 +67507,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="25">
@@ -67593,8 +67671,8 @@
         </component>
       </tile>
       <tile x="2" y="26">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -67776,6 +67854,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="26">
@@ -68096,8 +68175,8 @@
         </component>
       </tile>
       <tile x="24" y="27">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -68317,8 +68396,8 @@
       <tile x="0" y="28" />
       <tile x="1" y="28" />
       <tile x="2" y="28">
-        <component type="FloorComponent">
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -68804,8 +68883,8 @@
         </component>
       </tile>
       <tile x="21" y="29">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -68984,8 +69063,8 @@
         </component>
       </tile>
       <tile x="51" y="29">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -69366,8 +69445,8 @@
         </component>
       </tile>
       <tile x="51" y="30">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -69672,8 +69751,8 @@
         </component>
       </tile>
       <tile x="51" y="31">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -69825,8 +69904,8 @@
         </component>
       </tile>
       <tile x="21" y="32">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -70003,8 +70082,8 @@
         </component>
       </tile>
       <tile x="51" y="32">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -70082,8 +70161,8 @@
         </component>
       </tile>
       <tile x="11" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -70199,8 +70278,8 @@
         </component>
       </tile>
       <tile x="27" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>32</wall>
@@ -70320,8 +70399,8 @@
         </component>
       </tile>
       <tile x="36" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70336,8 +70415,8 @@
         </component>
       </tile>
       <tile x="37" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70394,8 +70473,8 @@
         </component>
       </tile>
       <tile x="42" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70405,8 +70484,8 @@
         </component>
       </tile>
       <tile x="43" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70416,8 +70495,8 @@
         </component>
       </tile>
       <tile x="44" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70427,8 +70506,8 @@
         </component>
       </tile>
       <tile x="45" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70438,8 +70517,8 @@
         </component>
       </tile>
       <tile x="46" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70449,8 +70528,8 @@
         </component>
       </tile>
       <tile x="47" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70460,8 +70539,8 @@
         </component>
       </tile>
       <tile x="48" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70477,8 +70556,8 @@
         </component>
       </tile>
       <tile x="49" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70488,8 +70567,8 @@
         </component>
       </tile>
       <tile x="50" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70499,8 +70578,8 @@
         </component>
       </tile>
       <tile x="51" y="33">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -70525,8 +70604,8 @@
         </component>
       </tile>
       <tile x="3" y="34">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -70561,8 +70640,8 @@
         </component>
       </tile>
       <tile x="9" y="34">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70573,8 +70652,8 @@
         </component>
       </tile>
       <tile x="10" y="34">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70589,8 +70668,8 @@
         </component>
       </tile>
       <tile x="11" y="34">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70728,8 +70807,8 @@
       <tile x="1" y="35" />
       <tile x="2" y="35" />
       <tile x="3" y="35">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -70754,8 +70833,8 @@
         </component>
       </tile>
       <tile x="7" y="35">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70766,8 +70845,8 @@
         </component>
       </tile>
       <tile x="8" y="35">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70782,8 +70861,8 @@
         </component>
       </tile>
       <tile x="9" y="35">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70931,8 +71010,8 @@
         </component>
       </tile>
       <tile x="6" y="36">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70943,8 +71022,8 @@
         </component>
       </tile>
       <tile x="7" y="36">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -70970,8 +71049,8 @@
         </component>
       </tile>
       <tile x="12" y="36">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -70981,8 +71060,8 @@
         </component>
       </tile>
       <tile x="13" y="36">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -71096,8 +71175,8 @@
         </component>
       </tile>
       <tile x="4" y="37">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71112,8 +71191,8 @@
         </component>
       </tile>
       <tile x="5" y="37">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71128,8 +71207,8 @@
         </component>
       </tile>
       <tile x="6" y="37">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71308,8 +71387,8 @@
         </component>
       </tile>
       <tile x="19" y="38">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -71319,8 +71398,8 @@
         </component>
       </tile>
       <tile x="20" y="38">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71346,9 +71425,8 @@
         </component>
       </tile>
       <tile x="21" y="38">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71369,9 +71447,8 @@
         </component>
       </tile>
       <tile x="22" y="38">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71386,9 +71463,8 @@
         </component>
       </tile>
       <tile x="23" y="38">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71403,9 +71479,8 @@
         </component>
       </tile>
       <tile x="24" y="38">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71420,9 +71495,8 @@
         </component>
       </tile>
       <tile x="25" y="38">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71437,9 +71511,8 @@
         </component>
       </tile>
       <tile x="26" y="38">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71454,8 +71527,8 @@
         </component>
       </tile>
       <tile x="27" y="38">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71536,8 +71609,8 @@
         </component>
       </tile>
       <tile x="13" y="40">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -71565,8 +71638,8 @@
         </component>
       </tile>
       <tile x="17" y="40">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -71576,8 +71649,8 @@
         </component>
       </tile>
       <tile x="18" y="40">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71592,8 +71665,8 @@
         </component>
       </tile>
       <tile x="19" y="40">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71619,8 +71692,8 @@
         </component>
       </tile>
       <tile x="13" y="41">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71657,8 +71730,8 @@
         </component>
       </tile>
       <tile x="16" y="41">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71673,8 +71746,8 @@
         </component>
       </tile>
       <tile x="17" y="41">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71713,8 +71786,8 @@
         </component>
       </tile>
       <tile x="14" y="42">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71729,8 +71802,8 @@
         </component>
       </tile>
       <tile x="15" y="42">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -71761,8 +71834,8 @@
       <name>Temple of the Undead</name>
       <height>-280</height>
       <tile x="12" y="4">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -71924,8 +71997,8 @@
         </component>
       </tile>
       <tile x="0" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -72056,8 +72129,8 @@
         </component>
       </tile>
       <tile x="12" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -72093,8 +72166,8 @@
         </component>
       </tile>
       <tile x="16" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -72110,8 +72183,8 @@
         </component>
       </tile>
       <tile x="17" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -72121,8 +72194,8 @@
         </component>
       </tile>
       <tile x="18" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -72132,8 +72205,8 @@
         </component>
       </tile>
       <tile x="19" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -72143,8 +72216,8 @@
         </component>
       </tile>
       <tile x="20" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -72154,8 +72227,8 @@
         </component>
       </tile>
       <tile x="21" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -72165,8 +72238,8 @@
         </component>
       </tile>
       <tile x="22" y="8">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -72668,8 +72741,8 @@
         </component>
       </tile>
       <tile x="23" y="11">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -72684,8 +72757,8 @@
         </component>
       </tile>
       <tile x="0" y="12">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -73052,8 +73125,8 @@
         </component>
       </tile>
       <tile x="23" y="13">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -73103,8 +73176,8 @@
         </component>
       </tile>
       <tile x="4" y="14">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -73412,8 +73485,8 @@
         </component>
       </tile>
       <tile x="23" y="15">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74085,8 +74158,8 @@
         </component>
       </tile>
       <tile x="16" y="19">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74262,8 +74335,8 @@
         </component>
       </tile>
       <tile x="15" y="20">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74292,8 +74365,8 @@
         </component>
       </tile>
       <tile x="18" y="20">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74312,8 +74385,8 @@
         </component>
       </tile>
       <tile x="21" y="20">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74327,8 +74400,8 @@
         </component>
       </tile>
       <tile x="23" y="20">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74449,22 +74522,18 @@
         </component>
       </tile>
       <tile x="12" y="21">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
         </component>
-        <component type="StaticComponent">
-          <color r="54" g="144" b="255" a="255" />
-          <static>1006</static>
-        </component>
       </tile>
       <tile x="13" y="21">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74494,8 +74563,8 @@
         </component>
       </tile>
       <tile x="16" y="21">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74639,8 +74708,8 @@
         </component>
       </tile>
       <tile x="11" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74673,8 +74742,8 @@
         </component>
       </tile>
       <tile x="16" y="22">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74683,8 +74752,8 @@
         </component>
       </tile>
       <tile x="17" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74693,8 +74762,8 @@
         </component>
       </tile>
       <tile x="18" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74703,8 +74772,8 @@
         </component>
       </tile>
       <tile x="19" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74713,8 +74782,8 @@
         </component>
       </tile>
       <tile x="20" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74723,8 +74792,8 @@
         </component>
       </tile>
       <tile x="21" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74733,8 +74802,8 @@
         </component>
       </tile>
       <tile x="22" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74743,8 +74812,8 @@
         </component>
       </tile>
       <tile x="23" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74753,8 +74822,8 @@
         </component>
       </tile>
       <tile x="24" y="22">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74803,8 +74872,8 @@
         </component>
       </tile>
       <tile x="5" y="23">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -74853,8 +74922,8 @@
         </component>
       </tile>
       <tile x="9" y="23">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -74863,8 +74932,8 @@
         </component>
       </tile>
       <tile x="10" y="23">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75088,8 +75157,8 @@
         </component>
       </tile>
       <tile x="17" y="24">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75098,8 +75167,8 @@
         </component>
       </tile>
       <tile x="18" y="24">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75108,8 +75177,8 @@
         </component>
       </tile>
       <tile x="19" y="24">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75118,8 +75187,8 @@
         </component>
       </tile>
       <tile x="20" y="24">
-        <component type="StaticComponent">
-          <static>12</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75144,8 +75213,8 @@
         </component>
       </tile>
       <tile x="23" y="24">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75219,8 +75288,8 @@
         </component>
       </tile>
       <tile x="9" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -75229,8 +75298,8 @@
         </component>
       </tile>
       <tile x="10" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75254,8 +75323,8 @@
         </component>
       </tile>
       <tile x="12" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75264,8 +75333,8 @@
         </component>
       </tile>
       <tile x="13" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75274,8 +75343,8 @@
         </component>
       </tile>
       <tile x="14" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75284,8 +75353,8 @@
         </component>
       </tile>
       <tile x="15" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75324,8 +75393,8 @@
         </component>
       </tile>
       <tile x="20" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -75334,8 +75403,8 @@
         </component>
       </tile>
       <tile x="21" y="25">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75476,8 +75545,8 @@
         </component>
       </tile>
       <tile x="22" y="26">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -75631,8 +75700,8 @@
         </component>
       </tile>
       <tile x="22" y="27">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -75802,8 +75871,8 @@
         </component>
       </tile>
       <tile x="23" y="28">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75812,8 +75881,8 @@
         </component>
       </tile>
       <tile x="24" y="28">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75838,8 +75907,8 @@
         </component>
       </tile>
       <tile x="1" y="29">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -75860,8 +75929,8 @@
         </component>
       </tile>
       <tile x="3" y="29">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75871,8 +75940,8 @@
         </component>
       </tile>
       <tile x="4" y="29">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -75882,8 +75951,8 @@
         </component>
       </tile>
       <tile x="5" y="29">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76009,8 +76078,8 @@
         </component>
       </tile>
       <tile x="22" y="29">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76226,8 +76295,8 @@
         </component>
       </tile>
       <tile x="1" y="31">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76381,8 +76450,8 @@
         </component>
       </tile>
       <tile x="25" y="31">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -76392,8 +76461,8 @@
         </component>
       </tile>
       <tile x="26" y="31">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76555,8 +76624,8 @@
         </component>
       </tile>
       <tile x="23" y="32">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -76577,8 +76646,8 @@
         </component>
       </tile>
       <tile x="25" y="32">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76594,8 +76663,8 @@
         </component>
       </tile>
       <tile x="1" y="33">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76605,8 +76674,8 @@
         </component>
       </tile>
       <tile x="2" y="33">
-        <component type="StaticComponent">
-          <static>179</static>
+        <component type="FloorComponent">
+          <ground>179</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -76781,8 +76850,8 @@
         </component>
       </tile>
       <tile x="23" y="33">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -76905,8 +76974,8 @@
         </component>
       </tile>
       <tile x="15" y="34">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -76927,8 +76996,8 @@
         </component>
       </tile>
       <tile x="17" y="34">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77078,8 +77147,8 @@
         </component>
       </tile>
       <tile x="14" y="35">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -77089,8 +77158,8 @@
         </component>
       </tile>
       <tile x="15" y="35">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77268,8 +77337,8 @@
         </component>
       </tile>
       <tile x="9" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -77279,8 +77348,8 @@
         </component>
       </tile>
       <tile x="10" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -77290,8 +77359,8 @@
         </component>
       </tile>
       <tile x="11" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77306,8 +77375,8 @@
         </component>
       </tile>
       <tile x="12" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -77328,8 +77397,8 @@
         </component>
       </tile>
       <tile x="14" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77356,8 +77425,8 @@
         </component>
       </tile>
       <tile x="16" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -77367,8 +77436,8 @@
         </component>
       </tile>
       <tile x="17" y="36">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77671,8 +77740,8 @@
         </component>
       </tile>
       <tile x="5" y="38">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77718,8 +77787,8 @@
         </component>
       </tile>
       <tile x="11" y="38">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -77740,8 +77809,8 @@
         </component>
       </tile>
       <tile x="13" y="38">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77924,8 +77993,8 @@
         </component>
       </tile>
       <tile x="16" y="39">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -77987,8 +78056,8 @@
         </component>
       </tile>
       <tile x="25" y="39">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
@@ -77998,8 +78067,8 @@
         </component>
       </tile>
       <tile x="26" y="39">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -78078,8 +78147,8 @@
         </component>
       </tile>
       <tile x="11" y="40">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -78136,8 +78205,8 @@
         </component>
       </tile>
       <tile x="20" y="40">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -78197,8 +78266,8 @@
         </component>
       </tile>
       <tile x="25" y="40">
-        <component type="FloorComponent">
-          <ground>179</ground>
+        <component type="StaticComponent">
+          <static>179</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -78219,25 +78288,25 @@
       <name>Grove</name>
       <height>-230</height>
       <tile x="11" y="-4">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-4">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78245,11 +78314,16 @@
         </component>
       </tile>
       <tile x="13" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78257,22 +78331,25 @@
         </component>
       </tile>
       <tile x="27" y="-4">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="28" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78280,11 +78357,16 @@
         </component>
       </tile>
       <tile x="29" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78292,11 +78374,16 @@
         </component>
       </tile>
       <tile x="30" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78304,11 +78391,16 @@
         </component>
       </tile>
       <tile x="31" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78316,11 +78408,16 @@
         </component>
       </tile>
       <tile x="32" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78328,11 +78425,16 @@
         </component>
       </tile>
       <tile x="33" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78340,11 +78442,16 @@
         </component>
       </tile>
       <tile x="34" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78352,11 +78459,16 @@
         </component>
       </tile>
       <tile x="35" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78364,14 +78476,16 @@
         </component>
       </tile>
       <tile x="36" y="-4">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78379,14 +78493,16 @@
         </component>
       </tile>
       <tile x="37" y="-4">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78394,11 +78510,16 @@
         </component>
       </tile>
       <tile x="38" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78406,11 +78527,16 @@
         </component>
       </tile>
       <tile x="39" y="-4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78418,25 +78544,25 @@
         </component>
       </tile>
       <tile x="9" y="-3">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78444,14 +78570,16 @@
         </component>
       </tile>
       <tile x="11" y="-3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78460,8 +78588,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78475,14 +78604,16 @@
         </component>
       </tile>
       <tile x="13" y="-3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78490,11 +78621,16 @@
         </component>
       </tile>
       <tile x="27" y="-3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78568,11 +78704,16 @@
         </component>
       </tile>
       <tile x="39" y="-3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78580,25 +78721,25 @@
         </component>
       </tile>
       <tile x="7" y="-2">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78606,14 +78747,16 @@
         </component>
       </tile>
       <tile x="9" y="-2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78622,8 +78765,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78649,14 +78793,16 @@
         </component>
       </tile>
       <tile x="13" y="-2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78664,11 +78810,16 @@
         </component>
       </tile>
       <tile x="27" y="-2">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78683,7 +78834,8 @@
       </tile>
       <tile x="29" y="-2">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -78757,11 +78909,16 @@
         </component>
       </tile>
       <tile x="39" y="-2">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78769,25 +78926,25 @@
         </component>
       </tile>
       <tile x="6" y="-1">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78796,8 +78953,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78812,7 +78970,8 @@
       </tile>
       <tile x="9" y="-1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -78838,25 +78997,25 @@
         </component>
       </tile>
       <tile x="12" y="-1">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78865,8 +79024,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78874,11 +79034,16 @@
         </component>
       </tile>
       <tile x="27" y="-1">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -78921,7 +79086,8 @@
       </tile>
       <tile x="32" y="-1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -78932,17 +79098,8 @@
       </tile>
       <tile x="33" y="-1">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -78954,6 +79111,16 @@
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
       </tile>
       <tile x="34" y="-1">
         <component type="FloorComponent">
@@ -78963,7 +79130,8 @@
       </tile>
       <tile x="35" y="-1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -78974,7 +79142,8 @@
       </tile>
       <tile x="36" y="-1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -78989,7 +79158,8 @@
       </tile>
       <tile x="37" y="-1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79019,11 +79189,16 @@
         </component>
       </tile>
       <tile x="39" y="-1">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79041,25 +79216,25 @@
         </component>
       </tile>
       <tile x="0" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79067,14 +79242,16 @@
         </component>
       </tile>
       <tile x="2" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79082,14 +79259,16 @@
         </component>
       </tile>
       <tile x="3" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79097,14 +79276,16 @@
         </component>
       </tile>
       <tile x="4" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79112,14 +79293,16 @@
         </component>
       </tile>
       <tile x="5" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79127,14 +79310,16 @@
         </component>
       </tile>
       <tile x="6" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79143,8 +79328,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79165,7 +79351,8 @@
       </tile>
       <tile x="9" y="0">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79191,14 +79378,16 @@
         </component>
       </tile>
       <tile x="12" y="0">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79206,11 +79395,16 @@
         </component>
       </tile>
       <tile x="27" y="0">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79237,7 +79431,8 @@
       </tile>
       <tile x="31" y="0">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79248,17 +79443,8 @@
       </tile>
       <tile x="32" y="0">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79269,6 +79455,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="33" y="0">
@@ -79285,7 +79481,8 @@
       </tile>
       <tile x="35" y="0">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="DoorComponent">
           <openId>75</openId>
@@ -79314,11 +79511,16 @@
         </component>
       </tile>
       <tile x="39" y="0">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79326,11 +79528,16 @@
         </component>
       </tile>
       <tile x="0" y="1">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79387,7 +79594,8 @@
       </tile>
       <tile x="9" y="1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79413,14 +79621,16 @@
         </component>
       </tile>
       <tile x="12" y="1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79428,25 +79638,25 @@
         </component>
       </tile>
       <tile x="19" y="1">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79454,15 +79664,16 @@
         </component>
       </tile>
       <tile x="21" y="1">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79470,15 +79681,16 @@
         </component>
       </tile>
       <tile x="22" y="1">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79486,15 +79698,16 @@
         </component>
       </tile>
       <tile x="23" y="1">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79502,15 +79715,16 @@
         </component>
       </tile>
       <tile x="24" y="1">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79518,15 +79732,16 @@
         </component>
       </tile>
       <tile x="25" y="1">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79534,15 +79749,16 @@
         </component>
       </tile>
       <tile x="26" y="1">
-        <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79550,14 +79766,16 @@
         </component>
       </tile>
       <tile x="27" y="1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79566,8 +79784,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79588,7 +79807,8 @@
       </tile>
       <tile x="30" y="1">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79599,17 +79819,8 @@
       </tile>
       <tile x="31" y="1">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79620,6 +79831,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="32" y="1">
@@ -79641,11 +79862,16 @@
         </component>
       </tile>
       <tile x="35" y="1">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79653,14 +79879,16 @@
         </component>
       </tile>
       <tile x="36" y="1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79668,14 +79896,16 @@
         </component>
       </tile>
       <tile x="37" y="1">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79683,15 +79913,16 @@
         </component>
       </tile>
       <tile x="38" y="1">
-        <component type="FloorComponent">
+        <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
-          <ground>23</ground>
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79699,11 +79930,16 @@
         </component>
       </tile>
       <tile x="39" y="1">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79712,8 +79948,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79721,11 +79958,16 @@
         </component>
       </tile>
       <tile x="0" y="2">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79798,7 +80040,8 @@
       </tile>
       <tile x="10" y="2">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79813,7 +80056,8 @@
       </tile>
       <tile x="11" y="2">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="DoorComponent">
           <openId>74</openId>
@@ -79824,14 +80068,16 @@
         </component>
       </tile>
       <tile x="12" y="2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79849,14 +80095,16 @@
         </component>
       </tile>
       <tile x="19" y="2">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79909,11 +80157,16 @@
         </component>
       </tile>
       <tile x="27" y="2">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79928,7 +80181,8 @@
       </tile>
       <tile x="29" y="2">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79939,17 +80193,8 @@
       </tile>
       <tile x="30" y="2">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -79960,6 +80205,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="31" y="2">
@@ -79987,11 +80242,16 @@
         </component>
       </tile>
       <tile x="35" y="2">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -79999,11 +80259,16 @@
         </component>
       </tile>
       <tile x="0" y="3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80018,7 +80283,8 @@
       </tile>
       <tile x="2" y="3">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80057,17 +80323,8 @@
       </tile>
       <tile x="7" y="3">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80078,6 +80335,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="8" y="3">
@@ -80105,15 +80372,16 @@
         </component>
       </tile>
       <tile x="12" y="3">
-        <component type="FloorComponent">
+        <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
-          <ground>23</ground>
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80121,11 +80389,16 @@
         </component>
       </tile>
       <tile x="13" y="3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80133,14 +80406,16 @@
         </component>
       </tile>
       <tile x="14" y="3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80148,11 +80423,16 @@
         </component>
       </tile>
       <tile x="15" y="3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80160,25 +80440,25 @@
         </component>
       </tile>
       <tile x="17" y="3">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80186,14 +80466,16 @@
         </component>
       </tile>
       <tile x="19" y="3">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80202,8 +80484,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80256,11 +80539,16 @@
         </component>
       </tile>
       <tile x="27" y="3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80320,11 +80608,16 @@
         </component>
       </tile>
       <tile x="35" y="3">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80332,11 +80625,16 @@
         </component>
       </tile>
       <tile x="0" y="4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80367,7 +80665,8 @@
       </tile>
       <tile x="3" y="4">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80382,7 +80681,8 @@
       </tile>
       <tile x="4" y="4">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80419,7 +80719,8 @@
       </tile>
       <tile x="7" y="4">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80464,7 +80765,8 @@
       </tile>
       <tile x="13" y="4">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80487,14 +80789,16 @@
         </component>
       </tile>
       <tile x="15" y="4">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80502,14 +80806,16 @@
         </component>
       </tile>
       <tile x="17" y="4">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80583,11 +80889,16 @@
         </component>
       </tile>
       <tile x="27" y="4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80620,7 +80931,8 @@
       </tile>
       <tile x="32" y="4">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80631,17 +80943,8 @@
       </tile>
       <tile x="33" y="4">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80653,6 +80956,16 @@
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
       </tile>
       <tile x="34" y="4">
         <component type="FloorComponent">
@@ -80661,11 +80974,16 @@
         </component>
       </tile>
       <tile x="35" y="4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80673,11 +80991,16 @@
         </component>
       </tile>
       <tile x="0" y="5">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80710,7 +81033,8 @@
       </tile>
       <tile x="5" y="5">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80731,7 +81055,8 @@
       </tile>
       <tile x="7" y="5">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80776,7 +81101,8 @@
       </tile>
       <tile x="13" y="5">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80796,15 +81122,16 @@
         </component>
       </tile>
       <tile x="15" y="5">
-        <component type="FloorComponent">
+        <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
-          <ground>23</ground>
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80812,14 +81139,16 @@
         </component>
       </tile>
       <tile x="16" y="5">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80827,24 +81156,16 @@
         </component>
       </tile>
       <tile x="17" y="5">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80924,11 +81245,16 @@
         </component>
       </tile>
       <tile x="27" y="5">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -80955,7 +81281,8 @@
       </tile>
       <tile x="31" y="5">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80966,17 +81293,8 @@
       </tile>
       <tile x="32" y="5">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80987,6 +81305,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="33" y="5">
@@ -81002,11 +81330,16 @@
         </component>
       </tile>
       <tile x="35" y="5">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81014,11 +81347,16 @@
         </component>
       </tile>
       <tile x="0" y="6">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81051,7 +81389,8 @@
       </tile>
       <tile x="5" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81066,7 +81405,8 @@
       </tile>
       <tile x="6" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81081,17 +81421,8 @@
       </tile>
       <tile x="7" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81102,6 +81433,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="8" y="6">
@@ -81136,7 +81477,8 @@
       </tile>
       <tile x="13" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81169,7 +81511,8 @@
       </tile>
       <tile x="17" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81249,11 +81592,16 @@
         </component>
       </tile>
       <tile x="27" y="6">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81274,7 +81622,8 @@
       </tile>
       <tile x="30" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81285,17 +81634,8 @@
       </tile>
       <tile x="31" y="6">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81306,6 +81646,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="32" y="6">
@@ -81327,11 +81677,16 @@
         </component>
       </tile>
       <tile x="35" y="6">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81339,11 +81694,16 @@
         </component>
       </tile>
       <tile x="0" y="7">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81358,7 +81718,8 @@
       </tile>
       <tile x="2" y="7">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81385,7 +81746,8 @@
       </tile>
       <tile x="5" y="7">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81424,7 +81786,8 @@
       </tile>
       <tile x="10" y="7">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81451,7 +81814,8 @@
       </tile>
       <tile x="13" y="7">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81484,7 +81848,8 @@
       </tile>
       <tile x="17" y="7">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81558,11 +81923,16 @@
         </component>
       </tile>
       <tile x="27" y="7">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81571,8 +81941,8 @@
       </tile>
       <tile x="28" y="7">
         <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81587,8 +81957,8 @@
       </tile>
       <tile x="29" y="7">
         <component type="FloorComponent">
-          <color r="225" g="255" b="255" a="255" />
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81603,17 +81973,8 @@
       </tile>
       <tile x="30" y="7">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81624,6 +81985,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="31" y="7">
@@ -81651,11 +82022,16 @@
         </component>
       </tile>
       <tile x="35" y="7">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81663,11 +82039,16 @@
         </component>
       </tile>
       <tile x="0" y="8">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81675,11 +82056,16 @@
         </component>
       </tile>
       <tile x="1" y="8">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81687,6 +82073,10 @@
         </component>
       </tile>
       <tile x="2" y="8">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -81700,8 +82090,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81709,15 +82100,16 @@
         </component>
       </tile>
       <tile x="3" y="8">
-        <component type="FloorComponent">
+        <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
-          <ground>23</ground>
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -81732,7 +82124,8 @@
       </tile>
       <tile x="5" y="8">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81771,7 +82164,8 @@
       </tile>
       <tile x="10" y="8">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81956,17 +82350,8 @@
       </tile>
       <tile x="27" y="8">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -81977,6 +82362,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="28" y="8">
@@ -82022,11 +82417,16 @@
         </component>
       </tile>
       <tile x="35" y="8">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82034,11 +82434,16 @@
         </component>
       </tile>
       <tile x="3" y="9">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82053,7 +82458,8 @@
       </tile>
       <tile x="5" y="9">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82092,7 +82498,8 @@
       </tile>
       <tile x="10" y="9">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82233,7 +82640,8 @@
       </tile>
       <tile x="32" y="9">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82259,11 +82667,16 @@
         </component>
       </tile>
       <tile x="35" y="9">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82271,11 +82684,16 @@
         </component>
       </tile>
       <tile x="3" y="10">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82290,7 +82708,8 @@
       </tile>
       <tile x="5" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82305,7 +82724,8 @@
       </tile>
       <tile x="6" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82320,7 +82740,8 @@
       </tile>
       <tile x="7" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82335,7 +82756,8 @@
       </tile>
       <tile x="8" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82350,7 +82772,8 @@
       </tile>
       <tile x="9" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82365,17 +82788,8 @@
       </tile>
       <tile x="10" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82387,10 +82801,21 @@
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
       </tile>
       <tile x="11" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82405,7 +82830,8 @@
       </tile>
       <tile x="12" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82454,7 +82880,8 @@
       </tile>
       <tile x="17" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82469,7 +82896,8 @@
       </tile>
       <tile x="18" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82484,7 +82912,8 @@
       </tile>
       <tile x="19" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82499,7 +82928,8 @@
       </tile>
       <tile x="20" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82514,7 +82944,8 @@
       </tile>
       <tile x="21" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82593,7 +83024,8 @@
       </tile>
       <tile x="31" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82604,17 +83036,8 @@
       </tile>
       <tile x="32" y="10">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82625,6 +83048,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="33" y="10">
@@ -82640,11 +83073,16 @@
         </component>
       </tile>
       <tile x="35" y="10">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82652,11 +83090,16 @@
         </component>
       </tile>
       <tile x="3" y="11">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82671,7 +83114,8 @@
       </tile>
       <tile x="5" y="11">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82774,7 +83218,8 @@
       </tile>
       <tile x="19" y="11">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82849,7 +83294,8 @@
       </tile>
       <tile x="30" y="11">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82860,17 +83306,8 @@
       </tile>
       <tile x="31" y="11">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -82881,6 +83318,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="32" y="11">
@@ -82902,11 +83349,16 @@
         </component>
       </tile>
       <tile x="35" y="11">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -82914,11 +83366,16 @@
         </component>
       </tile>
       <tile x="3" y="12">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83003,7 +83460,8 @@
       </tile>
       <tile x="15" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83070,7 +83528,8 @@
       </tile>
       <tile x="23" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83081,7 +83540,8 @@
       </tile>
       <tile x="24" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83096,7 +83556,8 @@
       </tile>
       <tile x="25" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83111,7 +83572,8 @@
       </tile>
       <tile x="26" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83126,7 +83588,8 @@
       </tile>
       <tile x="27" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83141,7 +83604,8 @@
       </tile>
       <tile x="28" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83156,7 +83620,8 @@
       </tile>
       <tile x="29" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83171,17 +83636,8 @@
       </tile>
       <tile x="30" y="12">
         <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83192,6 +83648,16 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="31" y="12">
@@ -83219,11 +83685,16 @@
         </component>
       </tile>
       <tile x="35" y="12">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83231,11 +83702,16 @@
         </component>
       </tile>
       <tile x="3" y="13">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83310,7 +83786,8 @@
       </tile>
       <tile x="15" y="13">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83367,7 +83844,8 @@
       </tile>
       <tile x="23" y="13">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83447,11 +83925,16 @@
         </component>
       </tile>
       <tile x="35" y="13">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83459,11 +83942,16 @@
         </component>
       </tile>
       <tile x="3" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83471,11 +83959,16 @@
         </component>
       </tile>
       <tile x="4" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83483,11 +83976,16 @@
         </component>
       </tile>
       <tile x="5" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83495,11 +83993,16 @@
         </component>
       </tile>
       <tile x="6" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83507,11 +84010,16 @@
         </component>
       </tile>
       <tile x="7" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83519,11 +84027,16 @@
         </component>
       </tile>
       <tile x="8" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83531,11 +84044,16 @@
         </component>
       </tile>
       <tile x="9" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83543,11 +84061,16 @@
         </component>
       </tile>
       <tile x="10" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83555,11 +84078,16 @@
         </component>
       </tile>
       <tile x="11" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83567,11 +84095,16 @@
         </component>
       </tile>
       <tile x="12" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83579,11 +84112,16 @@
         </component>
       </tile>
       <tile x="13" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83591,11 +84129,16 @@
         </component>
       </tile>
       <tile x="14" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83603,6 +84146,10 @@
         </component>
       </tile>
       <tile x="15" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83616,8 +84163,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83625,11 +84173,16 @@
         </component>
       </tile>
       <tile x="16" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83637,11 +84190,16 @@
         </component>
       </tile>
       <tile x="17" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83649,11 +84207,16 @@
         </component>
       </tile>
       <tile x="18" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83661,11 +84224,16 @@
         </component>
       </tile>
       <tile x="19" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83673,11 +84241,16 @@
         </component>
       </tile>
       <tile x="20" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83685,11 +84258,16 @@
         </component>
       </tile>
       <tile x="21" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83697,11 +84275,16 @@
         </component>
       </tile>
       <tile x="22" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83709,6 +84292,10 @@
         </component>
       </tile>
       <tile x="23" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83722,8 +84309,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83731,11 +84319,16 @@
         </component>
       </tile>
       <tile x="24" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83743,11 +84336,16 @@
         </component>
       </tile>
       <tile x="25" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83755,11 +84353,16 @@
         </component>
       </tile>
       <tile x="26" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83767,11 +84370,16 @@
         </component>
       </tile>
       <tile x="27" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83779,11 +84387,16 @@
         </component>
       </tile>
       <tile x="28" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83791,11 +84404,16 @@
         </component>
       </tile>
       <tile x="29" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83803,11 +84421,16 @@
         </component>
       </tile>
       <tile x="30" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83815,11 +84438,16 @@
         </component>
       </tile>
       <tile x="31" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83827,11 +84455,16 @@
         </component>
       </tile>
       <tile x="32" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83839,11 +84472,16 @@
         </component>
       </tile>
       <tile x="33" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
@@ -83851,6 +84489,93 @@
         </component>
       </tile>
       <tile x="34" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="35" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="16" y="17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="17" y="17">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="19" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+        </component>
+      </tile>
+      <tile x="20" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
@@ -83862,7 +84587,125 @@
           <static>226</static>
         </component>
       </tile>
-      <tile x="35" y="14">
+      <tile x="16" y="18">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="19" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="17" y="19">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="20" y="19">
+        <component type="FloorComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="17" y="21">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="20" y="21">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83876,8 +84719,9 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />


### PR DESCRIPTION
Fixed multiple walkable staticcomponents into floorcomponents where walls could be destroyed or there were no obstructions (found a bunch of secret doors in TT over staticcomponents). Made the same passes at solid walls being indestructible, indestructible walls not having floorcomponents,
Fixed boundary walls in Grove so they were consistently indestructible, and fixed the floors under the breakable walls to be the right green ground instead of 'light' dungeon tile.