### PR TITLE
Tile fixes and Oak thief protection

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Axe Glacier" version="0.73.1.0">
+<segment name="Axe Glacier" version="0.74.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -91843,14 +91843,8 @@
         </component>
       </tile>
       <tile x="43" y="7">
-        <component type="StaticComponent">
-          <static>264</static>
-        </component>
-        <component type="WallComponent">
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -94272,12 +94266,12 @@
         </component>
       </tile>
       <tile x="4" y="13">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
-          <destroyed>0</destroyed>
+          <destroyed>162</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
@@ -95559,12 +95553,12 @@
         </component>
       </tile>
       <tile x="9" y="16">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
-          <destroyed>0</destroyed>
+          <destroyed>162</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
@@ -95645,12 +95639,12 @@
         </component>
       </tile>
       <tile x="19" y="16">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
-          <destroyed>0</destroyed>
+          <destroyed>162</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
@@ -97953,12 +97947,12 @@
         </component>
       </tile>
       <tile x="55" y="21">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
-          <destroyed>0</destroyed>
+          <destroyed>162</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Kesmai" version="0.73.1.0">
+<segment name="Kesmai" version="0.74.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -5400,11 +5400,8 @@
         </component>
       </tile>
       <tile x="38" y="6">
-        <component type="ShaftComponent">
-          <destinationX>22</destinationX>
-          <destinationY>35</destinationY>
-          <destinationRegion>14</destinationRegion>
-          <teleporterId>182</teleporterId>
+        <component type="FloorComponent">
+          <ground>182</ground>
         </component>
         <component type="StaticComponent">
           <static>209</static>
@@ -34319,8 +34316,8 @@
         </component>
       </tile>
       <tile x="28" y="33">
-        <component type="StaticComponent">
-          <static>13</static>
+        <component type="FloorComponent">
+          <ground>13</ground>
         </component>
         <component type="TrashComponent">
           <static>88</static>
@@ -82619,8 +82616,8 @@
         </component>
       </tile>
       <tile x="20" y="23">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="DoorComponent">
           <openId>74</openId>
@@ -85325,14 +85322,15 @@
         </component>
       </tile>
       <tile x="24" y="33">
-        <component type="StaticComponent">
-          <static>1</static>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
         <component type="DoorComponent">
           <openId>75</openId>
           <closedId>63</closedId>
           <secretId>26</secretId>
           <destroyedId>81</destroyedId>
+          <isSecret>true</isSecret>
         </component>
       </tile>
       <tile x="25" y="33">
@@ -90420,8 +90418,11 @@
           <destinationRegion>1</destinationRegion>
           <teleporterId>9</teleporterId>
         </component>
-        <component type="StaticComponent">
-          <static>383</static>
+        <component type="WallComponent">
+          <wall>383</wall>
+          <destroyed>396</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="2">
@@ -90484,9 +90485,6 @@
         </component>
       </tile>
       <tile x="8" y="2">
-        <component type="StaticComponent">
-          <static>388</static>
-        </component>
         <component type="HiddenTeleporterComponent">
           <destinationX>3</destinationX>
           <destinationY>7</destinationY>
@@ -90495,6 +90493,9 @@
           <moonphases select="all" />
           <professions select="all" />
           <alignments select="all" />
+        </component>
+        <component type="FloorComponent">
+          <ground>388</ground>
         </component>
       </tile>
       <tile x="9" y="2">
@@ -90589,8 +90590,11 @@
           <ruins>45</ruins>
           <indestructible>true</indestructible>
         </component>
-        <component type="StaticComponent">
-          <static>384</static>
+        <component type="WallComponent">
+          <wall>384</wall>
+          <destroyed>397</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="4">

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Leng" version="0.73.1.0">
+<segment name="Leng" version="0.74.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -14473,7 +14473,7 @@
       </tile>
       <tile x="10" y="38">
         <component type="StaticComponent">
-          <static>23</static>
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -14788,7 +14788,7 @@
       </tile>
       <tile x="10" y="39">
         <component type="StaticComponent">
-          <static>23</static>
+          <static>12</static>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
@@ -15089,12 +15089,6 @@
         </component>
       </tile>
       <tile x="10" y="40">
-        <component type="WallComponent">
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
         <component type="StaticComponent">
           <static>12</static>
         </component>
@@ -15102,6 +15096,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="40">
@@ -54166,8 +54161,8 @@
         </component>
         <component type="DoorComponent">
           <openId>76</openId>
-          <closedId>157</closedId>
-          <secretId>27</secretId>
+          <closedId>64</closedId>
+          <secretId>157</secretId>
           <destroyedId>80</destroyedId>
           <isSecret>true</isSecret>
         </component>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.73.1.0">
+<segment name="Oakvael" version="0.74.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -3968,7 +3968,7 @@
           <ground>3</ground>
         </component>
         <component type="DoorComponent">
-          <openId>74</openId>
+          <openId>77</openId>
           <closedId>65</closedId>
           <secretId>224</secretId>
           <destroyedId>80</destroyedId>
@@ -14103,18 +14103,6 @@
       <tile x="83" y="21">
         <component type="SkyComponent">
           <teleporterId>9</teleporterId>
-        </component>
-      </tile>
-      <tile x="122" y="21">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
-        <component type="DoorComponent">
-          <openId>74</openId>
-          <closedId>62</closedId>
-          <secretId>25</secretId>
-          <destroyedId>80</destroyedId>
-          <isSecret>true</isSecret>
         </component>
       </tile>
       <tile x="0" y="22">
@@ -75468,7 +75456,7 @@
         <component type="DoorComponent">
           <openId>75</openId>
           <closedId>63</closedId>
-          <secretId>26</secretId>
+          <secretId>158</secretId>
           <destroyedId>81</destroyedId>
           <isSecret>true</isSecret>
         </component>
@@ -75515,7 +75503,7 @@
         <component type="DoorComponent">
           <openId>75</openId>
           <closedId>63</closedId>
-          <secretId>26</secretId>
+          <secretId>158</secretId>
           <destroyedId>81</destroyedId>
           <isSecret>true</isSecret>
         </component>
@@ -75600,7 +75588,7 @@
         <component type="DoorComponent">
           <openId>75</openId>
           <closedId>63</closedId>
-          <secretId>26</secretId>
+          <secretId>158</secretId>
           <destroyedId>81</destroyedId>
           <isSecret>true</isSecret>
         </component>
@@ -79964,11 +79952,16 @@
           <ground>23</ground>
         </component>
         <component type="DoorComponent">
+          <color r="255" g="210" b="95" a="255" />
           <openId>75</openId>
           <closedId>63</closedId>
-          <secretId>157</secretId>
-          <destroyedId>81</destroyedId>
+          <secretId>158</secretId>
+          <destroyedId>80</destroyedId>
           <isSecret>true</isSecret>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="36" y="0">
@@ -80539,11 +80532,16 @@
           <ground>23</ground>
         </component>
         <component type="DoorComponent">
+          <color r="255" g="210" b="95" a="255" />
           <openId>74</openId>
           <closedId>62</closedId>
-          <secretId>25</secretId>
+          <secretId>157</secretId>
           <destroyedId>80</destroyedId>
           <isSecret>true</isSecret>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="12" y="2">
@@ -81647,6 +81645,17 @@
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -91309,6 +91318,7 @@
         <inclusion left="0" top="0" right="0" bottom="0" />
         <exclusion left="21" top="14" right="32" bottom="25" />
         <exclusion left="41" top="35" right="54" bottom="40" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="undeadSpawner">

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.74.0.0">
+<segment name="Oakvael" version="0.73.1.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -2611,6 +2611,7 @@
           <professions>Fighter,Martial Artist,Thaumaturge,Wizard,Knight</professions>
           <alignments select="all" />
           <message>6300344</message>
+          <allowNPC>true</allowNPC>
         </component>
       </tile>
       <tile x="8" y="4">
@@ -5933,6 +5934,7 @@
           <professions>Fighter,Martial Artist,Thaumaturge,Wizard,Knight</professions>
           <alignments select="all" />
           <message>6300344</message>
+          <allowNPC>true</allowNPC>
         </component>
       </tile>
       <tile x="5" y="9">


### PR DESCRIPTION
A few missed tiles or ones overridden by other pulls. Statics under doors, breakable corner columns next to indestructible walls, etc.
Fixed a few secret doors that weren't so secret.
Adjusted spawn for surface in Oak to exclude the thief trainer and added the allowNPC flag to the teleports to keep mobs out.