### PR TITLE
World forge enhancements

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/Filters/TerrainSelector.cs
+++ b/Source/Kesmai.WorldForge/Editor/Filters/TerrainSelector.cs
@@ -237,6 +237,26 @@ namespace Kesmai.WorldForge.Editor
 		}
 	}
 
+	public class TeleporterSelector : ComponentSelector<TeleportComponent>
+	{
+		public override string Name => "Filter for only Teleport components.";
+		public override BitmapImage Icon => new BitmapImage(new Uri(@"pack://application:,,,/Kesmai.WorldForge;component/Resources/FilterFloor.png"));
+
+		public override ComponentRender TransformRender(SegmentTile tile, TerrainComponent component, ComponentRender render)
+		{
+			
+			if (component is TeleportComponent tc && (tc.DestinationX == 0 || tc.DestinationY == 0))
+            {
+				render.Color = Color.Red;
+			}
+
+			if (render.Color.Equals(Color.Black))
+				render.Color = Color.DimGray;
+
+			return render;
+		}
+	}
+
 	public class StaticSelector : ComponentSelector<StaticComponent>
 	{
 		public override string Name => "Filter for only static components.";

--- a/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
@@ -184,6 +184,7 @@ namespace Kesmai.WorldForge.Editor
 				new WaterSelector(),
 				new WallSelector(),
 				new StructureSelector(),
+				new TeleporterSelector(),
 			};
 			
 			Tools = new NotifyingCollection<Tool>()

--- a/Source/Kesmai.WorldForge/Game/PresentationTarget.cs
+++ b/Source/Kesmai.WorldForge/Game/PresentationTarget.cs
@@ -32,6 +32,23 @@ namespace Kesmai.WorldForge
 			if (_screen != null)
 				_screen.SetLocation(location.X, location.Y);
 		}
+
+	}
+
+	public class SpawnsPresentationTarget : PresentationTarget
+	{
+		private SpawnsGraphicsScreen _screen;
+
+		public override WorldGraphicsScreen CreateGraphicsScreen(IGraphicsService graphicsService)
+		{
+			return (_screen = new SpawnsGraphicsScreen(this, _uiManager, graphicsService));
+		}
+
+		public void SetLocation(Spawner spawner)
+		{
+			if (_screen != null)
+				_screen.SetSpawner(spawner);
+		}
 	}
 
 	public class SubregionsPresentationTarget : PresentationTarget

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
@@ -25,7 +25,6 @@
         <CollectionViewSource 
             x:Key="collectionViewSourceRegion"
             Source="{Binding Source.Region}">
-            
             <CollectionViewSource.SortDescriptions>
                 <componentModel:SortDescription PropertyName="Name" 
                                                 Direction="Ascending" />
@@ -44,7 +43,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"></RowDefinition>
                         <RowDefinition Height="*"></RowDefinition>
-                        <RowDefinition Height="200"></RowDefinition>
+                        <RowDefinition Height="220"></RowDefinition>
                     </Grid.RowDefinitions>
                     
                     <ToolBar Padding="2" Grid.Row="0">
@@ -65,7 +64,8 @@
                         <ListBox Width="300"
                                  ItemsSource="{Binding Source={StaticResource collectionViewSourceLocation}}" 
                                  SelectedItem="{Binding SelectedLocationSpawner, Mode=TwoWay}"
-                                 SelectionMode="Single">
+                                 SelectionMode="Single"
+                                 SelectedIndex="0">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -92,8 +92,16 @@
                     </syncfusion:PropertyGrid>
                 </Grid>
                 
-                <StackPanel Grid.Column="1">
-                    <TabControl ItemsSource="{Binding SelectedLocationSpawner.Scripts}" x:Name="_scriptsTabControl" 
+                <Grid Grid.Column="1" x:Name="locationGrid">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"></RowDefinition>
+                        <RowDefinition Height="3"></RowDefinition>
+                        <RowDefinition Height="*"></RowDefinition>
+                        <RowDefinition Height="3"></RowDefinition>
+                        <RowDefinition Height="*"></RowDefinition>
+                    </Grid.RowDefinitions>
+                    
+                    <TabControl Grid.Row="0" ItemsSource="{Binding SelectedLocationSpawner.Scripts}" x:Name="_scriptsTabControl" 
                                 Margin="5" MinHeight="300">
                         <TabControl.ItemTemplate>
                             <DataTemplate>
@@ -124,8 +132,8 @@
                             </DataTemplate>
                         </TabControl.ContentTemplate>
                     </TabControl>
-                    
-                    <DataGrid Margin="5" Height="300"
+                    <GridSplitter Grid.Row="1" Height="3" HorizontalAlignment="Stretch" />
+                    <DataGrid Grid.Row="2" Margin="5" Height="300"
                               AutoGenerateColumns="False"
                               ItemsSource="{Binding SelectedLocationSpawner.Entries}">
                         <DataGrid.Resources>
@@ -141,7 +149,9 @@
                             <DataGridTextColumn MinWidth="70" Header="Maximum" Binding="{Binding Maximum, UpdateSourceTrigger=PropertyChanged}"></DataGridTextColumn>
                         </DataGrid.Columns>
                     </DataGrid>
-                </StackPanel>
+                    <GridSplitter Grid.Row="3" Height="3" HorizontalAlignment="Stretch" />
+                    <worldForge:SpawnsPresentationTarget x:Name="_locationPresenter" Grid.Row="4"  Margin="2"  />
+                </Grid>
             </Grid>
         </TabItem>
         
@@ -179,7 +189,8 @@
                     <ScrollViewer Grid.Row="1">
                         <ListBox Width="300"
                                  ItemsSource="{Binding Source={StaticResource collectionViewSourceRegion}}" 
-                                 SelectedItem="{Binding SelectedRegionSpawner, Mode=TwoWay}">
+                                 SelectedItem="{Binding SelectedRegionSpawner, Mode=TwoWay}"
+                                 SelectedIndex="0">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -232,8 +243,13 @@
                     </GroupBox>
                 </Grid>
                 
-                <StackPanel Grid.Column="1">
-                    <DataGrid Margin="5" Height="300"
+                <Grid Grid.Column="1" x:Name="regionGrid">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="auto"></RowDefinition>
+                        <RowDefinition Height="3"></RowDefinition>
+                        <RowDefinition Height="*"></RowDefinition>
+                    </Grid.RowDefinitions>
+                    <DataGrid Grid.Row="0" Margin="5" Height="300"
                               AutoGenerateColumns="False"
                               ItemsSource="{Binding SelectedRegionSpawner.Entries}">
                         <DataGrid.Resources>
@@ -249,7 +265,9 @@
                             <DataGridTextColumn MinWidth="70" Header="Maximum" Binding="{Binding Maximum, UpdateSourceTrigger=PropertyChanged}"></DataGridTextColumn>
                         </DataGrid.Columns>
                     </DataGrid>
-                </StackPanel>
+                    <GridSplitter Grid.Row="1" Height="3" HorizontalAlignment="Stretch" />
+                    <worldForge:SpawnsPresentationTarget Grid.Row="2" x:Name="_regionPresenter" Margin="2" />
+                </Grid>
             </Grid>
         </TabItem>
     </TabControl>

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
@@ -125,7 +125,7 @@ namespace Kesmai.WorldForge.UI.Documents
 			AddRegionSpawnerCommand = new RelayCommand(AddRegionSpawner);
 			RemoveRegionSpawnerCommand = new RelayCommand<RegionSpawner>(RemoveRegionSpawner,
 				(spawner) => SelectedRegionSpawner != null);
-			RemoveLocationSpawnerCommand.DependsOn(() => SelectedRegionSpawner);
+			RemoveRegionSpawnerCommand.DependsOn(() => SelectedRegionSpawner);
 
 			//todo: set location and region spawners so the presenters are fully intialized. Or fix whatever is preventing both renders from accepting input before both are 'targetted'
 		}

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
@@ -19,11 +19,40 @@ namespace Kesmai.WorldForge.UI.Documents
 			WeakReferenceMessenger.Default
 				.Register<SpawnsDocument, SpawnsViewModel.SelectedLocationSpawnerChangedMessage>(
 					this, OnLocationSpawnerChanged);
+
+			WeakReferenceMessenger.Default
+				.Register<SpawnsDocument, SpawnsViewModel.SelectedRegionSpawnerChangedMessage>(
+					this, OnRegionSpawnerChanged);
 		}
 		
 		private void OnLocationSpawnerChanged(SpawnsDocument recipient, SpawnsViewModel.SelectedLocationSpawnerChangedMessage message)
 		{
 			_scriptsTabControl.SelectedIndex = 0;
+			
+			var segmentRequest = WeakReferenceMessenger.Default.Send<GetActiveSegmentRequestMessage>();
+			var segment = segmentRequest.Response;
+
+			var spawn = message.Value;
+			if (spawn != null)
+            {
+				_locationPresenter.Region = segment.GetRegion(spawn.Region);
+				_locationPresenter.SetLocation(spawn);
+			}
+		}
+
+		private void OnRegionSpawnerChanged(SpawnsDocument recipient, SpawnsViewModel.SelectedRegionSpawnerChangedMessage message)
+		{
+			_scriptsTabControl.SelectedIndex = 0;
+
+			var segmentRequest = WeakReferenceMessenger.Default.Send<GetActiveSegmentRequestMessage>();
+			var segment = segmentRequest.Response;
+
+			var spawn = message.Value;
+			if (spawn != null)
+			{
+				_regionPresenter.Region = segment.GetRegion(spawn.Region);
+				_regionPresenter.SetLocation(spawn);
+			}
 		}
 	}
 	
@@ -37,7 +66,14 @@ namespace Kesmai.WorldForge.UI.Documents
 			{
 			}
 		}
-		
+
+		public class SelectedRegionSpawnerChangedMessage : ValueChangedMessage<RegionSpawner>
+		{
+			public SelectedRegionSpawnerChangedMessage(RegionSpawner value) : base(value)
+			{
+			}
+		}
+
 		public string Name => "(Spawns)";
 		
 		private Segment _segment;
@@ -59,7 +95,13 @@ namespace Kesmai.WorldForge.UI.Documents
 		public RegionSpawner SelectedRegionSpawner
 		{
 			get => _selectedRegionSpawner;
-			set => SetProperty(ref _selectedRegionSpawner, value, true);
+			set
+			{
+				SetProperty(ref _selectedRegionSpawner, value, true);
+
+				if (value != null)
+					WeakReferenceMessenger.Default.Send(new SelectedRegionSpawnerChangedMessage(value));
+			}
 		}
 
 		public SegmentSpawns Source => _segment.Spawns;
@@ -83,7 +125,9 @@ namespace Kesmai.WorldForge.UI.Documents
 			AddRegionSpawnerCommand = new RelayCommand(AddRegionSpawner);
 			RemoveRegionSpawnerCommand = new RelayCommand<RegionSpawner>(RemoveRegionSpawner,
 				(spawner) => SelectedRegionSpawner != null);
-			RemoveRegionSpawnerCommand.DependsOn(() => SelectedRegionSpawner);
+			RemoveLocationSpawnerCommand.DependsOn(() => SelectedRegionSpawner);
+
+			//todo: set location and region spawners so the presenters are fully intialized. Or fix whatever is preventing both renders from accepting input before both are 'targetted'
 		}
 		
 		public void AddLocationSpawner()


### PR DESCRIPTION
Added scaling and a world render to spawns. Also added a filter to show teleportcomponents and a hotkey to display coordinates on world renders.
Known issue: spawn document renders don't work right until BOTH tabs have had a selection made. Unsure why, I tried cloning the presentation and graphics screens into a region and location specific version with the same issue.