### PR TITLE
Tile fixes and a few spawn edits

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -37972,7 +37972,7 @@
       </tile>
       <tile x="37" y="30">
         <component type="IceComponent">
-          <ground>373020</ground>
+          <ground>20</ground>
         </component>
       </tile>
       <tile x="38" y="30">

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -17550,7 +17550,7 @@
         </component>
         <component type="WallComponent">
           <wall>149</wall>
-          <destroyed>0</destroyed>
+          <destroyed>150</destroyed>
           <ruins>0</ruins>
         </component>
       </tile>
@@ -37972,7 +37972,7 @@
       </tile>
       <tile x="37" y="30">
         <component type="IceComponent">
-          <ground>20</ground>
+          <ground>373020</ground>
         </component>
       </tile>
       <tile x="38" y="30">
@@ -67369,7 +67369,7 @@
         </component>
         <component type="WallComponent">
           <wall>149</wall>
-          <destroyed>0</destroyed>
+          <destroyed>150</destroyed>
           <ruins>0</ruins>
         </component>
       </tile>
@@ -69207,7 +69207,7 @@
         </component>
         <component type="WallComponent">
           <wall>149</wall>
-          <destroyed>0</destroyed>
+          <destroyed>150</destroyed>
           <ruins>0</ruins>
         </component>
       </tile>
@@ -82519,7 +82519,7 @@
         </component>
         <component type="WallComponent">
           <wall>149</wall>
-          <destroyed>0</destroyed>
+          <destroyed>150</destroyed>
           <ruins>0</ruins>
         </component>
       </tile>
@@ -91843,14 +91843,8 @@
         </component>
       </tile>
       <tile x="43" y="7">
-        <component type="StaticComponent">
-          <static>264</static>
-        </component>
-        <component type="WallComponent">
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
@@ -94272,14 +94266,13 @@
         </component>
       </tile>
       <tile x="4" y="13">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="13">
@@ -95559,14 +95552,13 @@
         </component>
       </tile>
       <tile x="9" y="16">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="16">
@@ -95645,14 +95637,13 @@
         </component>
       </tile>
       <tile x="19" y="16">
-        <component type="StaticComponent">
-          <static>264</static>
+        <component type="FloorComponent">
+          <ground>264</ground>
         </component>
         <component type="WallComponent">
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="16">
@@ -108076,6 +108067,7 @@
       <bounds region="12">
         <inclusion left="25" top="3" right="32" bottom="8" />
         <inclusion left="30" top="9" right="34" bottom="31" />
+        <inclusion left="35" top="21" right="37" bottom="30" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -14458,8 +14458,8 @@
         </component>
       </tile>
       <tile x="109" y="14">
-        <component type="FloorComponent">
-          <ground>22</ground>
+        <component type="StaticComponent">
+          <static>22</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -15487,8 +15487,8 @@
         </component>
       </tile>
       <tile x="109" y="15">
-        <component type="FloorComponent">
-          <ground>22</ground>
+        <component type="StaticComponent">
+          <static>22</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -17146,8 +17146,8 @@
         </component>
       </tile>
       <tile x="59" y="17">
-        <component type="FloorComponent">
-          <ground>601</ground>
+        <component type="StaticComponent">
+          <static>601</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -34333,8 +34333,8 @@
         </component>
       </tile>
       <tile x="28" y="33">
-        <component type="StaticComponent">
-          <static>13</static>
+        <component type="FloorComponent">
+          <ground>13</ground>
         </component>
         <component type="TrashComponent">
           <static>88</static>
@@ -77070,16 +77070,16 @@
         </component>
       </tile>
       <tile x="20" y="4">
-        <component type="FloorComponent">
-          <ground>177</ground>
+        <component type="StaticComponent">
+          <static>177</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="21" y="4">
-        <component type="FloorComponent">
-          <ground>177</ground>
+        <component type="StaticComponent">
+          <static>177</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
@@ -77113,8 +77113,8 @@
         </component>
       </tile>
       <tile x="26" y="4">
-        <component type="FloorComponent">
-          <ground>177</ground>
+        <component type="StaticComponent">
+          <static>177</static>
         </component>
         <component type="FloorComponent">
           <ground>252</ground>
@@ -82582,14 +82582,14 @@
         </component>
       </tile>
       <tile x="15" y="23">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="DoorComponent">
           <openId>74</openId>
           <closedId>62</closedId>
           <secretId>25</secretId>
           <destroyedId>80</destroyedId>
+        </component>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
       </tile>
       <tile x="16" y="23">
@@ -82633,15 +82633,15 @@
         </component>
       </tile>
       <tile x="20" y="23">
-        <component type="StaticComponent">
-          <static>1</static>
-        </component>
         <component type="DoorComponent">
           <openId>74</openId>
           <closedId>62</closedId>
           <secretId>25</secretId>
           <destroyedId>80</destroyedId>
           <isSecret>true</isSecret>
+        </component>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
       </tile>
       <tile x="21" y="23">
@@ -83945,13 +83945,13 @@
         </component>
       </tile>
       <tile x="17" y="28">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
       </tile>
       <tile x="18" y="28">
@@ -84203,13 +84203,13 @@
         </component>
       </tile>
       <tile x="17" y="29">
-        <component type="FloorComponent">
-          <ground>1</ground>
-        </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
       </tile>
       <tile x="18" y="29">
@@ -85327,11 +85327,6 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
       </tile>
       <tile x="23" y="33">
         <component type="FloorComponent">
@@ -85339,14 +85334,14 @@
         </component>
       </tile>
       <tile x="24" y="33">
-        <component type="StaticComponent">
-          <static>1</static>
-        </component>
         <component type="DoorComponent">
           <openId>75</openId>
           <closedId>63</closedId>
           <secretId>26</secretId>
           <destroyedId>81</destroyedId>
+        </component>
+        <component type="FloorComponent">
+          <ground>1</ground>
         </component>
       </tile>
       <tile x="25" y="33">
@@ -88993,15 +88988,10 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>264</static>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="11">
@@ -89619,15 +89609,10 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>264</static>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>221</static>
@@ -90245,16 +90230,13 @@
       <height>50</height>
       <tile x="0" y="0">
         <component type="StaticComponent">
-          <static>9</static>
+          <static>388</static>
         </component>
         <component type="WallComponent">
           <wall>409</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <static>409</static>
         </component>
       </tile>
       <tile x="1" y="0">
@@ -90418,7 +90400,7 @@
       </tile>
       <tile x="8" y="1">
         <component type="StaticComponent">
-          <static>9</static>
+          <static>388</static>
         </component>
         <component type="WallComponent">
           <wall>383</wall>
@@ -90434,13 +90416,16 @@
           <destinationRegion>1</destinationRegion>
           <teleporterId>9</teleporterId>
         </component>
-        <component type="StaticComponent">
-          <static>383</static>
+        <component type="WallComponent">
+          <wall>383</wall>
+          <destroyed>396</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="2">
         <component type="StaticComponent">
-          <static>9</static>
+          <static>388</static>
         </component>
         <component type="WallComponent">
           <wall>384</wall>
@@ -90498,9 +90483,6 @@
         </component>
       </tile>
       <tile x="8" y="2">
-        <component type="StaticComponent">
-          <static>388</static>
-        </component>
         <component type="HiddenTeleporterComponent">
           <destinationX>3</destinationX>
           <destinationY>7</destinationY>
@@ -90509,6 +90491,9 @@
           <moonphases select="all" />
           <professions select="all" />
           <alignments select="all" />
+        </component>
+        <component type="FloorComponent">
+          <ground>388</ground>
         </component>
       </tile>
       <tile x="9" y="2">
@@ -90524,7 +90509,7 @@
       </tile>
       <tile x="0" y="3">
         <component type="StaticComponent">
-          <static>9</static>
+          <static>388</static>
         </component>
         <component type="WallComponent">
           <wall>384</wall>
@@ -90603,13 +90588,16 @@
           <ruins>45</ruins>
           <indestructible>true</indestructible>
         </component>
-        <component type="StaticComponent">
-          <static>384</static>
+        <component type="WallComponent">
+          <wall>384</wall>
+          <destroyed>397</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="4">
         <component type="StaticComponent">
-          <static>9</static>
+          <static>388</static>
         </component>
         <component type="WallComponent">
           <wall>384</wall>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -2776,19 +2776,19 @@
       <tile x="11" y="8">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="12" y="8">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="13" y="8">
@@ -3269,19 +3269,19 @@
       <tile x="11" y="9">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="12" y="9">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="13" y="9">
@@ -4805,10 +4805,10 @@
       <tile x="15" y="13">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="16" y="13">
@@ -5657,10 +5657,10 @@
       <tile x="23" y="15">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="24" y="15">
@@ -5969,10 +5969,10 @@
       <tile x="12" y="16">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="13" y="16">
@@ -6112,10 +6112,10 @@
       <tile x="29" y="16">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="30" y="16">
@@ -6131,10 +6131,10 @@
       <tile x="31" y="16">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="32" y="16">
@@ -6818,10 +6818,10 @@
       <tile x="23" y="18">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="24" y="18">
@@ -7592,10 +7592,10 @@
       <tile x="21" y="20">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="22" y="20">
@@ -7659,10 +7659,10 @@
       <tile x="27" y="20">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="28" y="20">
@@ -8037,10 +8037,10 @@
       <tile x="29" y="21">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="30" y="21">
@@ -8240,10 +8240,10 @@
       <tile x="6" y="22">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="7" y="22">
@@ -8267,10 +8267,10 @@
       <tile x="9" y="22">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="22">
@@ -8720,10 +8720,10 @@
       <tile x="12" y="23">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="13" y="23">
@@ -9033,10 +9033,10 @@
       <tile x="4" y="24">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="5" y="24">
@@ -9051,10 +9051,10 @@
       <tile x="6" y="24">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="7" y="24">
@@ -9456,10 +9456,10 @@
       <tile x="9" y="25">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="25">
@@ -9872,10 +9872,10 @@
       <tile x="11" y="26">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="12" y="26">
@@ -11050,10 +11050,10 @@
       <tile x="13" y="29">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="14" y="29">
@@ -11795,10 +11795,10 @@
       <tile x="3" y="31">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="4" y="31">
@@ -11840,10 +11840,10 @@
       <tile x="10" y="31">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="11" y="31">
@@ -11854,10 +11854,10 @@
       <tile x="12" y="31">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="13" y="31">
@@ -11913,10 +11913,10 @@
       <tile x="23" y="31">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="24" y="31">
@@ -11967,10 +11967,10 @@
       <tile x="33" y="31">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="34" y="31">
@@ -12101,19 +12101,19 @@
       <tile x="3" y="32">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="4" y="32">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="5" y="32">
@@ -12143,10 +12143,10 @@
       <tile x="9" y="32">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="32">
@@ -12207,10 +12207,10 @@
       <tile x="20" y="32">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="21" y="32">
@@ -12378,10 +12378,10 @@
       <tile x="49" y="32">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="50" y="32">
@@ -12429,28 +12429,28 @@
       <tile x="3" y="33">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="4" y="33">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="5" y="33">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="6" y="33">
@@ -12474,10 +12474,10 @@
       <tile x="9" y="33">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="33">
@@ -12548,10 +12548,10 @@
       <tile x="18" y="33">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="19" y="33">
@@ -12607,10 +12607,10 @@
       <tile x="29" y="33">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="30" y="33">
@@ -12836,10 +12836,10 @@
       <tile x="5" y="34">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="6" y="34">
@@ -12857,10 +12857,10 @@
       <tile x="8" y="34">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="9" y="34">
@@ -12931,10 +12931,10 @@
       <tile x="19" y="34">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="20" y="34">
@@ -12960,10 +12960,10 @@
       <tile x="24" y="34">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="25" y="34">
@@ -13211,10 +13211,10 @@
       <tile x="5" y="35">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="6" y="35">
@@ -13232,10 +13232,10 @@
       <tile x="8" y="35">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="9" y="35">
@@ -13550,10 +13550,10 @@
       <tile x="50" y="35">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="51" y="35">
@@ -13596,10 +13596,10 @@
       <tile x="5" y="36">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="6" y="36">
@@ -13617,10 +13617,10 @@
       <tile x="8" y="36">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="9" y="36">
@@ -13785,10 +13785,10 @@
       <tile x="29" y="36">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="30" y="36">
@@ -14035,10 +14035,10 @@
       <tile x="5" y="37">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="6" y="37">
@@ -14680,10 +14680,10 @@
       <tile x="38" y="38">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="39" y="38">
@@ -14734,10 +14734,10 @@
       <tile x="48" y="38">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="49" y="38">
@@ -14955,10 +14955,10 @@
       <tile x="36" y="39">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="37" y="39">
@@ -15012,10 +15012,10 @@
       <tile x="43" y="39">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="44" y="39">
@@ -15026,10 +15026,10 @@
       <tile x="45" y="39">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="46" y="39">
@@ -15089,12 +15089,6 @@
         </component>
       </tile>
       <tile x="10" y="40">
-        <component type="WallComponent">
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
         <component type="StaticComponent">
           <static>12</static>
         </component>
@@ -15102,6 +15096,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="40">
@@ -15512,14 +15507,13 @@
         </component>
       </tile>
       <tile x="15" y="41">
-        <component type="StaticComponent">
-          <static>12</static>
-        </component>
         <component type="WallComponent">
           <wall>159</wall>
-          <destroyed>0</destroyed>
+          <destroyed>162</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
       </tile>
       <tile x="16" y="41">
@@ -22614,10 +22608,10 @@
       <tile x="12" y="22">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="13" y="22">
@@ -37065,10 +37059,10 @@
       <tile x="23" y="34">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="24" y="34">
@@ -37784,37 +37778,37 @@
       <tile x="6" y="38">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="7" y="38">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="8" y="38">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="9" y="38">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="38">
@@ -38025,10 +38019,10 @@
       <tile x="6" y="39">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="7" y="39">
@@ -57486,9 +57480,6 @@
         </component>
       </tile>
       <tile x="2" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>159</wall>
           <destroyed>0</destroyed>
@@ -57497,9 +57488,6 @@
         </component>
       </tile>
       <tile x="3" y="3">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
@@ -57568,9 +57556,6 @@
         </component>
       </tile>
       <tile x="2" y="4">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>158</wall>
           <destroyed>161</destroyed>
@@ -57628,9 +57613,6 @@
         </component>
       </tile>
       <tile x="2" y="5">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>158</wall>
           <destroyed>161</destroyed>
@@ -57694,9 +57676,6 @@
         </component>
       </tile>
       <tile x="2" y="6">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>158</wall>
           <destroyed>161</destroyed>
@@ -57783,9 +57762,6 @@
         </component>
       </tile>
       <tile x="3" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
@@ -57794,9 +57770,6 @@
         </component>
       </tile>
       <tile x="4" y="7">
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
@@ -60422,10 +60395,10 @@
       <tile x="20" y="6">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="21" y="6">
@@ -60822,10 +60795,10 @@
       <tile x="23" y="11">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="24" y="11">
@@ -60896,10 +60869,10 @@
       <tile x="22" y="12">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="23" y="12">
@@ -61205,10 +61178,10 @@
       <tile x="17" y="16">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="18" y="16">
@@ -61567,10 +61540,10 @@
       <tile x="17" y="21">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="18" y="21">
@@ -61693,10 +61666,10 @@
       <tile x="17" y="23">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="18" y="23">
@@ -61753,10 +61726,10 @@
       <tile x="16" y="24">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="17" y="24">
@@ -62297,10 +62270,10 @@
       <tile x="2" y="6">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="3" y="6">
@@ -62384,10 +62357,10 @@
       <tile x="5" y="7">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="6" y="7">
@@ -62535,10 +62508,10 @@
       <tile x="7" y="9">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="8" y="9">
@@ -63320,10 +63293,10 @@
       <tile x="14" y="8">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="15" y="8">
@@ -63506,10 +63479,10 @@
       <tile x="9" y="10">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="10">
@@ -64271,10 +64244,10 @@
       <tile x="7" y="17">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="8" y="17">
@@ -64285,10 +64258,10 @@
       <tile x="9" y="17">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="10" y="17">
@@ -64378,10 +64351,10 @@
       <tile x="7" y="18">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="8" y="18">
@@ -64420,10 +64393,10 @@
       <tile x="13" y="18">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="14" y="18">
@@ -64629,10 +64602,10 @@
       <tile x="8" y="20">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="9" y="20">
@@ -64762,10 +64735,10 @@
       <tile x="7" y="21">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="8" y="21">
@@ -64882,10 +64855,10 @@
       <tile x="11" y="22">
         <component type="FloorComponent">
           <ground>23</ground>
-        </component>
-        <component type="FloorComponent">
-          <ground>205</ground>
           <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>205</static>
         </component>
       </tile>
       <tile x="12" y="22">

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -2612,6 +2612,7 @@
           <professions>Fighter,Martial Artist,Thaumaturge,Wizard,Knight</professions>
           <alignments select="all" />
           <message>6300344</message>
+          <allowNPC>true</allowNPC>
         </component>
       </tile>
       <tile x="8" y="4">
@@ -5934,6 +5935,7 @@
           <professions>Fighter,Martial Artist,Thaumaturge,Wizard,Knight</professions>
           <alignments select="all" />
           <message>6300344</message>
+          <allowNPC>true</allowNPC>
         </component>
       </tile>
       <tile x="5" y="9">
@@ -22015,8 +22017,8 @@
         </component>
       </tile>
       <tile x="36" y="34">
-        <component type="FloorComponent">
-          <ground>22</ground>
+        <component type="StaticComponent">
+          <static>22</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
@@ -27910,6 +27912,7 @@
           <wall>223</wall>
           <destroyed>226</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="7">
@@ -28030,6 +28033,7 @@
           <wall>223</wall>
           <destroyed>226</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="7">
@@ -28139,6 +28143,7 @@
           <wall>223</wall>
           <destroyed>226</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="8">
@@ -31548,6 +31553,7 @@
           <wall>224</wall>
           <destroyed>227</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -32196,6 +32202,7 @@
           <wall>225</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="23">
@@ -32691,6 +32698,7 @@
           <wall>224</wall>
           <destroyed>227</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>223</wall>
@@ -33084,6 +33092,7 @@
           <wall>224</wall>
           <destroyed>227</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="28">
@@ -57896,90 +57905,90 @@
         </component>
       </tile>
       <tile x="12" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="13" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="14" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="15" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="16" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="17" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="18" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="19" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="20" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="21" y="-4">
-        <component type="FloorComponent">
-          <color r="255" g="144" b="23" a="255" />
-          <ground>602</ground>
+        <component type="StaticComponent">
+          <color r="255" g="144" b="24" a="255" />
+          <static>602</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
@@ -63109,72 +63118,72 @@
         </component>
       </tile>
       <tile x="20" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="21" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="22" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="23" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="24" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="25" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="26" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="27" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
         </component>
       </tile>
       <tile x="28" y="11">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>115</ground>
@@ -64588,8 +64597,8 @@
         </component>
       </tile>
       <tile x="41" y="15">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -64930,8 +64939,8 @@
         </component>
       </tile>
       <tile x="41" y="16">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -65228,8 +65237,8 @@
         </component>
       </tile>
       <tile x="41" y="17">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -65597,8 +65606,8 @@
         </component>
       </tile>
       <tile x="41" y="18">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -65915,8 +65924,8 @@
         </component>
       </tile>
       <tile x="41" y="19">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -66263,8 +66272,8 @@
         </component>
       </tile>
       <tile x="41" y="20">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -66614,8 +66623,8 @@
         </component>
       </tile>
       <tile x="41" y="21">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -66964,8 +66973,8 @@
         </component>
       </tile>
       <tile x="41" y="22">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -67315,8 +67324,8 @@
         </component>
       </tile>
       <tile x="41" y="23">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -67748,8 +67757,8 @@
         </component>
       </tile>
       <tile x="41" y="24">
-        <component type="FloorComponent">
-          <ground>180</ground>
+        <component type="StaticComponent">
+          <static>180</static>
         </component>
         <component type="FloorComponent">
           <ground>116</ground>
@@ -91310,7 +91319,8 @@
         <inclusion left="0" top="1" right="82" bottom="42" />
         <inclusion left="0" top="0" right="0" bottom="0" />
         <exclusion left="21" top="14" right="32" bottom="25" />
-        <exclusion left="41" top="35" right="54" bottom="40" />
+        <exclusion left="41" top="35" right="54" bottom="41" />
+        <exclusion left="2" top="3" right="7" bottom="9" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="undeadSpawner">

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -78196,8 +78196,9 @@
         <component type="DoorComponent">
           <openId>75</openId>
           <closedId>63</closedId>
-          <secretId>26</secretId>
+          <secretId>336</secretId>
           <destroyedId>81</destroyedId>
+          <isSecret>true</isSecret>
         </component>
       </tile>
       <tile x="18" y="7">
@@ -103420,7 +103421,7 @@
     <spawn type="RegionSpawner" name="speedyHob">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>22</maximum>
+      <maximum>18</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -103595,8 +103596,10 @@
       <entry entity="yasnakiKnight" size="3" minimum="7" maximum="9" />
       <entry entity="yasnakiMA" size="3" minimum="2" maximum="3" />
       <bounds region="16">
-        <inclusion left="1" top="1" right="37" bottom="21" />
-        <exclusion left="17" top="2" right="20" bottom="5" />
+        <inclusion left="1" top="10" right="37" bottom="21" />
+        <inclusion left="22" top="1" right="37" bottom="9" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+        <exclusion left="1" top="10" right="5" bottom="10" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="undeadlevel">
@@ -103672,6 +103675,34 @@
       <entry entity="udBossSwordmaster" size="1" minimum="1" maximum="1" />
       <bounds region="17">
         <inclusion left="15" top="3" right="24" bottom="16" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="yasnakiLair">
+      <minimumDelay>1200</minimumDelay>
+      <maximumDelay>1500</maximumDelay>
+      <maximum>3</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="yasnakiMA" size="1" minimum="0" maximum="1" />
+      <entry entity="yasnakiWizard" size="1" minimum="0" maximum="1" />
+      <entry entity="yasnakiThaum" size="1" minimum="0" maximum="1" />
+      <entry entity="yasnakiKnight" size="1" minimum="0" maximum="1" />
+      <bounds region="16">
+        <inclusion left="6" top="2" right="15" bottom="8" />
+        <inclusion left="16" top="7" right="20" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -60239,8 +60239,8 @@
           <ground>12</ground>
         </component>
         <component type="DoorComponent">
-          <openId>74</openId>
-          <closedId>62</closedId>
+          <openId>75</openId>
+          <closedId>63</closedId>
           <secretId>334</secretId>
           <destroyedId>80</destroyedId>
           <isSecret>true</isSecret>


### PR DESCRIPTION
Fixed a few places that got missed in previous pass. statics under secret doors, floors under indestructible walls, etc.
Also changed the Leng bushes to static instead of a tile with two floors. Updated the other floor to have the 2 movement cost instead. this was 30-ish replacements across the regions.
Updated Yasnaki level spawns so that they didn't spawn in Shelob's lair, and had a distinct spawner for the area between Shelob and Carfel.
in Oak, I gave the thief trainer an exclusion region and set the thief portal hexes to affect NPCs in order to keep the wildlife out.