### PR TITLE
UK - Mummy Reskill

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -101187,10 +101187,10 @@
     mummy.Attacks = new CreatureAttackCollection()
     {
         { 
-            new CreatureAttack(23,     30, 50,     "The mummy strangles you with his bandages"),      70, TimeSpan.Zero 
+            new CreatureAttack(17,     30, 50,     "The mummy strangles you with his bandages"),      70, TimeSpan.Zero 
         }, 
         { 
-            new CreatureAttack(25,    40, 60,     "A mummified claw scratches you.",
+            new CreatureAttack(19,    40, 60,     "A mummified claw scratches you.",
                                                     new AttackAgeComponent(1000, 50)),             30, TimeSpan.Zero
         },
         //todo who added TimeSpan to these?


### PR DESCRIPTION
- Lowered skill level of mummy mobs. These come in packs of 6+ and aren't blockable as it stands.