### PR TITLE
Orb/wand initial push

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -103614,7 +103614,8 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, AxePotions,     0.15),
-        new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
+        new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
         
     return wolf;
@@ -103706,7 +103707,8 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, AxePotions,     0.15),
-        new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
+        new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
     return goblin;
@@ -103753,7 +103755,8 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, AxePotions,     0.15),
-        new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
+        new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
     return orc;
@@ -103965,7 +103968,8 @@
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, UtilityItems,    2),
         new LootPackEntry(true, AxePotions,     0.15),
-        new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
+        new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
+        new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
     return goblin;

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -103555,8 +103555,9 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
+        new LootPackEntry(true, UtilityItems,    2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103595,7 +103596,7 @@
             new CreatureAttack(5,     3, 7,   "The wolf rakes you with its claws."),  50 
         }, 
         {
-            new CreatureAttack(7,     4, 8,  "The wolf sinks its teeth into you."),   30
+            new CreatureAttack(6,     4, 8,  "The wolf sinks its teeth into you."),   30
         }, 
         {
             new CreatureAttack(7,     5, 10,  "The wolf lunges at you."),             20 
@@ -103612,7 +103613,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
         
@@ -103659,7 +103660,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103704,7 +103705,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103741,7 +103742,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6, 3, 8)
+        new CreatureBasicAttack(6)
     };
     
     orc.Wield(new BattleAxe());
@@ -103751,7 +103752,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103790,7 +103791,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6, 4, 11)
+        new CreatureBasicAttack(7)
     };
     
     troll.Wield(new Greatsword());
@@ -103801,7 +103802,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -103836,7 +103837,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6, 3, 8)
+        new CreatureBasicAttack(6)
     };
     
     goblin.Wield(new Longsword());
@@ -103846,7 +103847,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
         new LootPackEntry(true, (from, container) => new LeatherGauntlets(), 7.5)
     ));
@@ -103906,7 +103907,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.05), 
+        new LootPackEntry(true, AxePotions,     0.15), 
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5),
         new LootPackEntry(true, (from, container) => new IronOre(), 2.6)
     ));
@@ -103962,7 +103963,8 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.05),
+        new LootPackEntry(true, UtilityItems,    2),
+        new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -103997,7 +103999,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(8, 5, 12)
+        new CreatureBasicAttack(8)
     };
     
     goblin.Wield(new BattleAxe());
@@ -104007,7 +104009,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104046,7 +104048,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(9, 7, 13)
+        new CreatureBasicAttack(8)
     };
     
     troll.Wield(new Greatsword());
@@ -104056,7 +104058,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104100,7 +104102,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 9, 15)
+        new CreatureBasicAttack(9)
     };
     
     fighter.Wield(new Longsword());
@@ -104111,7 +104113,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -104155,7 +104157,7 @@
     
     martialartist.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(10, 10, 17)
+        new CreatureBasicAttack(10)
     };   
     
     martialartist.AddGold(550);
@@ -104163,7 +104165,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -104200,7 +104202,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(8, 5, 10)
+        new CreatureBasicAttack(8)
     };
     
     orc.Wield(new BattleAxe());
@@ -104210,7 +104212,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104269,7 +104271,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
@@ -104326,7 +104328,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
         
@@ -104381,7 +104383,8 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, UtilityItems,    3),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104417,7 +104420,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6)
+        new CreatureBasicAttack(7)
     };
     
     goblin.Spells = new CreatureSpellCollection
@@ -104436,7 +104439,8 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, UtilityItems,    3),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104480,7 +104484,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 9, 15)
+        new CreatureBasicAttack(9)
     };
     
     fighter.Wield(new Rapier());
@@ -104490,7 +104494,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104535,7 +104539,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104570,7 +104574,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(8, 6, 12) 
+        new CreatureBasicAttack(8) 
     };
     
     hobgoblin.Wield(new Longsword());
@@ -104580,7 +104584,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -104644,7 +104648,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    50),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -104780,7 +104784,7 @@
     rockworm.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    50),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
         
         ));
@@ -104836,7 +104840,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, (from, container) => new IronOre(), 1.6)
     ));
     
@@ -104873,7 +104877,7 @@
     
     ogre.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11, 12, 18)
+        new CreatureBasicAttack(11)
     };
     
     ogre.AddStatus(new NightVisionStatus(ogre));
@@ -104885,7 +104889,7 @@
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
     
@@ -104949,7 +104953,7 @@
     lizard.AddLoot(new LootPack(
         new LootPackEntry(true, surfaceTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, surfaceTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, AxePotions,     0.2),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.63)
     ));
     
@@ -105116,7 +105120,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(8)
+        new CreatureBasicAttack(9)
     };
     
     goblin.Wield(new Longbow());
@@ -105126,7 +105130,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105180,7 +105184,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105224,7 +105228,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12, 12, 19)
+        new CreatureBasicAttack(12)
     };
     
     fighter.Wield(new Longsword());
@@ -105234,7 +105238,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105294,7 +105298,7 @@
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.2),        
+        new LootPackEntry(true, AxePotions,     0.3),        
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5)
     ));
 
@@ -105329,7 +105333,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 9, 16)
+        new CreatureBasicAttack(10)
     };
     
     goblin.Wield(new BattleAxe());
@@ -105339,7 +105343,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105375,7 +105379,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6)
+        new CreatureBasicAttack(8)
     };
     
     goblin.Spells = new CreatureSpellCollection
@@ -105394,7 +105398,8 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
+        new LootPackEntry(true, UtilityItems,    3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105429,7 +105434,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(10, 11, 16)
+        new CreatureBasicAttack(10)
     };
     
     hobgoblin.Wield(new Longsword());
@@ -105439,7 +105444,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105484,14 +105489,14 @@
     
     martialartist.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12, 13, 21)
+        new CreatureBasicAttack(12)
     };   
     
     martialartist.AddGold(650);
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105530,7 +105535,7 @@
     
     ogre.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(13, 12, 19)
+        new CreatureBasicAttack(12)
     };
 
     ogre.Wield(new Halberd());    
@@ -105540,7 +105545,7 @@
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
         new LootPackEntry(true, upperTreasure,   0.63),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67)
     ));
     
@@ -105577,7 +105582,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-            new CreatureBasicAttack(8, 7, 13)
+            new CreatureBasicAttack(9)
     };
     
     orc.Wield(new ShortSword());
@@ -105587,7 +105592,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105631,7 +105636,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12, 10, 19), 
+        new CreatureBasicAttack(12), 
     };
     
     fighter.Wield(new Rapier());
@@ -105641,7 +105646,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105680,7 +105685,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 8, 15)
+        new CreatureBasicAttack(10)
     };
     
     troll.Wield(new Greatsword());
@@ -105690,7 +105695,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105746,7 +105751,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105801,7 +105806,8 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, UtilityItems,    3),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105864,7 +105870,7 @@
     lizard.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -105923,7 +105929,7 @@
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    50),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -105985,7 +105991,7 @@
     bear.AddLoot(new LootPack(
         new LootPackEntry(true, minibossTreasureGems,       50,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    75),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.5),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
         
@@ -106688,7 +106694,7 @@
         
     shadow.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12, 13, 19)
+        new CreatureBasicAttack(11)
     };
     
     shadow.Spells = new CreatureSpellCollection()
@@ -106704,7 +106710,8 @@
     shadow.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, UtilityItems,    3),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106747,10 +106754,10 @@
         FireProtection = 100,
     };
     
-    //for monsters with weapons equipped and non-multiple attacks we use this basic creature attack collection: 9 is chance to hit, 20 min damage, 28 max damage. It will just display "NPC Name hits you with <Blackstaff>!"
+    //for monsters with weapons equipped and non-multiple attacks we use this basic creature attack collection: 10 is hit chance (* 50). Damage is by "10 skill". It will just display "NPC Name hits you with <Blackstaff>!"
     wizard.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 11, 18)
+        new CreatureBasicAttack(10)
     };
     
     /*for hard casted spells we have this context. This NPC will cast Fireball and MagicMissile at evenly weighted chances. When it runs out of mana it will engage in melee, but in this version of LOK, when it regenerates enough mana for one of it's spells it will leave melee to try and cast. You can decide which spell you want him to cast on second attack chances by making it the one that costs less mana. It's a fairly useful function because you can make it so monsters are higher priority to players by setting values. Fun!
@@ -106778,7 +106785,8 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, UtilityItems,    4),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106821,7 +106829,7 @@
     
     thaum.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 11, 19)
+        new CreatureBasicAttack(11)
     };
     
     thaum.Spells = new CreatureSpellCollection()
@@ -106842,7 +106850,8 @@
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, UtilityItems,    4),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -106887,7 +106896,7 @@
     
     wizard.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11, 12, 19)
+        new CreatureBasicAttack(11)
     };
     
     wizard.Spells = new CreatureSpellCollection
@@ -106908,7 +106917,8 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, chaosGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, UtilityItems,    4),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -107187,7 +107197,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 11, 16)
+        new CreatureBasicAttack(10)
     };
     
     goblin.Wield(new BattleAxe());
@@ -107197,7 +107207,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -107233,7 +107243,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12)
+        new CreatureBasicAttack(11)
     };
     
     goblin.Wield(new Crossbow());
@@ -107243,7 +107253,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, upperTreasureGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    20),
-        new LootPackEntry(true, AxePotions,     0.2),
+        new LootPackEntry(true, AxePotions,     0.3),
         new LootPackEntry(true, upperTreasure,   0.63)
     ));
     
@@ -107521,6 +107531,7 @@
     draugr.AddLoot(new LootPack(
         new LootPackEntry(true, UndeadGems,       4,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, UtilityItems,    5),
         new LootPackEntry(true, upperTreasure,   0.1),
         new LootPackEntry(true, AxePotions,     0.2)
     ));
@@ -107708,6 +107719,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, UndeadGems,       2,     gemsPriceMutator), 
         new LootPackEntry(true, upperTreasureBottles,    33),
+        new LootPackEntry(true, UtilityItems,    5),
         new LootPackEntry(true, upperTreasure,   0.63),
         new LootPackEntry(true, AxePotions,     0.1)
     ));
@@ -110102,6 +110114,71 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new SmallSapphire(70000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="UtilityItems">
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new GlassWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PineWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireballOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new IceStormOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new WebOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DarknessOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new LightOrb();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Kesmai" version="0.76.0.0">
+<segment name="Kesmai" version="0.77.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -97903,7 +97903,7 @@
                 
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(5, 3, 11)
+        new CreatureBasicAttack(5)
     };
     
     troll.Wield(new Greatsword());
@@ -98012,7 +98012,7 @@
         
     wight.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6)
+        new CreatureBasicAttack(4)
     };
     
     wight.Spells = new CreatureSpellCollection()
@@ -98230,7 +98230,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1)
+        new LootPackEntry(true, dungeon3Potions,    0.2)
     ));
     
     return troll;
@@ -98278,7 +98278,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1)
+        new LootPackEntry(true, dungeon3Potions,    0.2)
     ));
     
     return hobgoblin;
@@ -98326,7 +98326,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1),
+        new LootPackEntry(true, dungeon3Potions,    0.2),
 
         new LootPackEntry(true, (from, container) => new ThrowingHammer(), 16)
     ));
@@ -98376,7 +98376,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1),
+        new LootPackEntry(true, dungeon3Potions,    0.2),
         
         new LootPackEntry(true, (from, container) => new Shuriken(), 11)
     ));
@@ -98424,7 +98424,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1),
+        new LootPackEntry(true, dungeon3Potions,    0.2),
         
         new LootPackEntry(true, (from, container) => new LeatherGauntlets(), 7.5)
     ));
@@ -98472,7 +98472,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1)
+        new LootPackEntry(true, dungeon3Potions,    0.2)
     ));
     
     return goblin;
@@ -98531,7 +98531,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1)
+        new LootPackEntry(true, dungeon3Potions,    0.2)
     ));
     
     return orc;
@@ -98589,7 +98589,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    50),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1),
+        new LootPackEntry(true, dungeon3Potions,    0.2),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.0),
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.5)
     ));
@@ -98654,7 +98654,7 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33), 
         new LootPackEntry(true, dungeon3Treasure,   0.6), 
         new LootPackEntry(true, dungeon3Rings,      0.6), 
-        new LootPackEntry(true, dungeon3Potions,    0.1),
+        new LootPackEntry(true, dungeon3Potions,    0.2),
         
         new LootPackEntry(true, (from, container) => new FieryRuby(1200u), 100.0)
     ));
@@ -98692,7 +98692,7 @@ return orc;
         
     wraith.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(7)
+        new CreatureBasicAttack(6)
     };
     
     wraith.Spells = new CreatureSpellCollection()
@@ -98710,7 +98710,8 @@ return orc;
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1),
+        new LootPackEntry(true, utilityItems,   2),
+        new LootPackEntry(true, dungeon3Potions,    0.2),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.0)
         //new LootPackEntry(true, (from, container) => new SnakeStaff(), 1.6)
     ));
@@ -98750,7 +98751,7 @@ return orc;
         
     wight.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(7),
+        new CreatureBasicAttack(6),
     };
     
     wight.Spells =  new CreatureSpellCollection()
@@ -98767,8 +98768,9 @@ return orc;
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, dungeon3Treasure,   0.6),
+        new LootPackEntry(true, utilityItems,   2),
         new LootPackEntry(true, dungeon3Rings,      0.6),
-        new LootPackEntry(true, dungeon3Potions,    0.1)
+        new LootPackEntry(true, dungeon3Potions,    0.2)
     ));
     
     return wight;
@@ -98816,7 +98818,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
 
         new LootPackEntry(true, (from, container) => new ThrowingHammer(), 16.67)
     ));
@@ -98866,7 +98868,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
 
         new LootPackEntry(true, (from, container) => new Shuriken(), 11.11)
     ));
@@ -98927,7 +98929,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon3Potions,    0.3)
     ));
     
     return orc;
@@ -98973,7 +98975,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon3Potions,    0.3)
     ));
     
     return troll;
@@ -99019,7 +99021,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon3Potions,    0.3)
     ));
     
     return hobgoblin;
@@ -99075,7 +99077,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         
         new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14)
     ));
@@ -99141,7 +99143,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.6), 
         new LootPackEntry(true, dungeon4Rings,      0.6), 
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         
         new LootPackEntry(true, (from, container) => new FieryRuby(1200u), 100.0)
     ));
@@ -99200,7 +99202,8 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, utilityItems,   3),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6)
     ));
     
@@ -99260,7 +99263,8 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, utilityItems,   3),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6)
     ));
     
@@ -99320,7 +99324,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2)
+        new LootPackEntry(true, dungeon3Potions,    0.3)
     ));
     
     return ghoul;
@@ -99385,7 +99389,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    50),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new SteelGauntlets(), 6.67),
         new LootPackEntry(true, (from, container) => new IronRod(), 6.67)
@@ -99443,7 +99447,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u), 10.0)
     ));
@@ -99500,7 +99504,7 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u), 10.0)
     ));
@@ -99569,7 +99573,8 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, utilityItems,   3),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u),    10.0),
         new LootPackEntry(true, (from, container) => new RedRunesRobe(),        10.0)
@@ -99641,7 +99646,8 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, utilityItems,   3),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new PearDiamond(1500u),    10.0),
         new LootPackEntry(true, (from, container) => new RedRunesRobe(),        10.0)
@@ -99737,10 +99743,10 @@ return orc;
             new CreatureAttack(5,     1, 4,   "The wolf rakes you with its claws."), 50 
         }, 
         {
-            new CreatureAttack(7,     2, 5,  "The wolf sinks its teeth into you."),  30 
+            new CreatureAttack(5,     2, 5,  "The wolf sinks its teeth into you."),  30 
         }, 
         {
-            new CreatureAttack(7,     3, 6,  "The wolf lunges at you."),             20 
+            new CreatureAttack(6,     3, 6,  "The wolf lunges at you."),             20 
         }, 
     };
         
@@ -99900,7 +99906,7 @@ return orc;
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(5, 1, 5)
+        new CreatureBasicAttack(4)
     };
     
     orc.Wield(new Longsword());
@@ -99949,7 +99955,7 @@ return orc;
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(3)
+        new CreatureBasicAttack(4)
     };
     
     orc.Wield(new Crossbow());
@@ -99999,7 +100005,7 @@ return orc;
         
     wraith.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(7)
+        new CreatureBasicAttack(6)
     };
     
     wraith.Spells = new CreatureSpellCollection()
@@ -100016,7 +100022,7 @@ return orc;
         new LootPackEntry(true, dungeon3Gems,       25,     gemsPriceMutator),
         new LootPackEntry(true, dungeon3Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
-        
+        new LootPackEntry(true, utilityItems,   1),        
         new LootPackEntry(true, (from, container) => new IronOre(),         1.6)
         //new LootPackEntry(true, (from, container) => new SnakeStaff(),    1.6),
     ));
@@ -100057,7 +100063,7 @@ return orc;
         
     wight.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(6)
+        new CreatureBasicAttack(4)
     };
     
     wight.Spells = new CreatureSpellCollection()
@@ -100074,7 +100080,7 @@ return orc;
         new LootPackEntry(true, dungeon3Gems,       33,     gemsPriceMutator),
         new LootPackEntry(true, dungeon2Bottles,    33),
         new LootPackEntry(true, surfaceTreasure,    0.6),
-        
+        new LootPackEntry(true, utilityItems,   1),        
         new LootPackEntry(true, (from, container) => new IronOre(),     1.6)
     ));
     
@@ -100262,8 +100268,9 @@ return orc;
         new LootPackEntry(true, ydnacTreasure,      100),
         
         new LootPackEntry(true, (from, container) => new ClearBalm(),           50),
-        new LootPackEntry(true, (from, container) => new Diamond(1500u),        100,    gemsPriceMutator),
-        new LootPackEntry(true, (from, container) => new PearDiamond(1500u),    100,    gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new Diamond(3500u),        100,    gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(4500u),    100,    gemsPriceMutator),
+        new LootPackEntry(true, utilityItems,   50),
         new LootPackEntry(true, (from, container) => new StarsRobe(),           100)
     ));
     
@@ -100382,7 +100389,7 @@ return orc;
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, dungeon4Gems,       50.0,   gemsPriceMutator), 
         new LootPackEntry(true, dungeon4Bottles,    50.0),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6),
         new LootPackEntry(true, (from, container) => new ReturningHammer(),     33.33)
     ));
@@ -100445,7 +100452,8 @@ return orc;
         new LootPackEntry(true, dungeon4Bottles,    33),
         new LootPackEntry(true, dungeon4Treasure,   0.63),
         new LootPackEntry(true, dungeon4Rings,      0.63),
-        new LootPackEntry(true, dungeon3Potions,    0.2),
+        new LootPackEntry(true, utilityItems,   3),
+        new LootPackEntry(true, dungeon3Potions,    0.3),
         new LootPackEntry(true, (from, container) => new Yttril(), 1.6)
     ));
     
@@ -103178,7 +103186,7 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -103306,6 +103314,71 @@ else
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new FireProtectionAmulet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="utilityItems">
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DarknessOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new WebOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new LightOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireballOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new IceStormOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PineWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new GlassWand();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75926,8 +75926,8 @@
     };
     
     presence.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new WaveRobe(),    100)
-        new LootPackEntry(true, UtilityTreasures,    5),
+        new LootPackEntry(true, (from, container) => new WaveRobe(),    100),
+        new LootPackEntry(true, UtilityTreasures,    5)
     ));
     
     return presence;

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75236,7 +75236,7 @@
         
     wraith.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 8, 15),
+        new CreatureBasicAttack(9),
     };
     
     wraith.Spells = new CreatureSpellCollection()
@@ -75259,7 +75259,8 @@
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, UtilityTreasures,    3),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75332,7 +75333,8 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, UtilityTreasures,    3),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75399,7 +75401,8 @@
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, UtilityTreasures,    3),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75439,7 +75442,7 @@
     
     spectre.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 10, 16),
+        new CreatureBasicAttack(10),
     };
     
     spectre.Spells = new CreatureSpellCollection()
@@ -75462,7 +75465,8 @@
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, UtilityTreasures,    2),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75502,7 +75506,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(10, 7, 15)
+        new CreatureBasicAttack(9)
     };
     
     hobgoblin.Wield(new Longsword());
@@ -75512,7 +75516,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75572,7 +75576,8 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, UtilityTreasures,    2),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
     
@@ -75615,7 +75620,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(10, 7, 13)
+        new CreatureBasicAttack(9)
     };
     
     fighter.Wield(new Longsword());
@@ -75625,7 +75630,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)        
     ));
     
@@ -75787,7 +75792,7 @@
     powerTroll.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new WingedHelm(),         40.0),
         new LootPackEntry(true, (from, container) => new PearDiamond(1200u),         40.0),
-        new LootPackEntry(true, LengPotions,    0.05),
+        new LootPackEntry(true, LengPotions,    5),
         new LootPackEntry(true, (from, container) => new Diamond(1500u),         50.0)
     ));
     
@@ -75922,6 +75927,7 @@
     
     presence.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new WaveRobe(),    100)
+        new LootPackEntry(true, UtilityTreasures,    5),
     ));
     
     return presence;
@@ -76076,7 +76082,7 @@
    ninja.AddGold(500);
    ninja.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, LengPotions,    0.3),
         new LootPackEntry(true, MausBottles,    20)
    ));
        
@@ -76429,7 +76435,7 @@
         
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(13, 8, 16)
+        new CreatureBasicAttack(12)
     };
     
     fighter.Wield(new Longsword());
@@ -76439,7 +76445,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -76534,7 +76540,7 @@
         
     lich.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 15, 25)
+        new CreatureBasicAttack(11)
     };
     
     lich.Spells = new CreatureSpellCollection()
@@ -76550,7 +76556,8 @@
     lich.AddLoot(new LootPack(
         new LootPackEntry(true, MinotaurGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, UtilityTreasures,    5),
+        new LootPackEntry(true, LengPotions,    0.3),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
     
@@ -76592,7 +76599,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11)
+        new CreatureBasicAttack(12)
     };
     
     fighter.Wield(new Longbow());
@@ -76602,7 +76609,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -76667,7 +76674,7 @@
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, MinotaurGems,       50,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, LengPotions,    0.3),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
     
@@ -76793,7 +76800,7 @@
     griffin.AddLoot(new LootPack(
         
         new LootPackEntry(true, (from, container) => new OchreEgg(), 25.0),  
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, LengPotions,    0.4),
         new LootPackEntry(true, (from, container) => new GriffinSkull(), 10),
         new LootPackEntry(true, MinotaurTreasures,  0.63)
     ));
@@ -77042,7 +77049,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11), 
+        new CreatureBasicAttack(13), 
     };
     
     fighter.Wield(new FineCrossbow());
@@ -77052,7 +77059,7 @@
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20), 
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, LengPotions,    0.4),
         new LootPackEntry(true, MinotaurTreasures,  0.63)
     ));
     
@@ -77095,7 +77102,7 @@
     
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(13, 25, 40) 
+        new CreatureBasicAttack(14) 
     };
     
     fighter.Wield(new Longsword());
@@ -77104,7 +77111,7 @@
     fighter.AddGold(750);
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator),  
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, LengPotions,    0.4),
         new LootPackEntry(true, MausBottles,    20),
         new LootPackEntry(true, MinotaurTreasures,  0.63)
         
@@ -77151,7 +77158,7 @@
     
     thaum.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 25, 40)
+        new CreatureBasicAttack(14)
     };
     
     thaum.Spells = new CreatureSpellCollection()
@@ -77173,7 +77180,8 @@
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20), 
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, UtilityTreasures,    4),
+        new LootPackEntry(true, LengPotions,    0.4),
         new LootPackEntry(true, MinotaurTreasures,  0.63)
     ));
     
@@ -77219,7 +77227,7 @@
     centaur.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77337,7 +77345,7 @@
     };
     duck.AddGold(5000);
     duck.AddLoot(new LootPack(
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    5),
         new LootPackEntry(true, (from, container) => new OchreEgg(), 100.0)  /* TODO: add another piece of minor loot just added egg because it made sense*/
     ));
         
@@ -77373,7 +77381,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 9, 15)
+        new CreatureBasicAttack(12)
     };
     
     orc.Wield(new ShortSword());
@@ -77383,7 +77391,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77439,7 +77447,7 @@
     wolf.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
         
@@ -77474,7 +77482,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(13, 11, 17)
+        new CreatureBasicAttack(13)
     };
     
     troll.Wield(new Greatsword());
@@ -77484,7 +77492,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77579,7 +77587,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, CliffTreasures,    0.63)
     ));
     
@@ -77642,7 +77650,7 @@
     manticora.AddLoot(new LootPack(
         new LootPackEntry(true, MinotaurGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.2),
+        new LootPackEntry(true, LengPotions,    0.3),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
     
@@ -77697,6 +77705,7 @@
     wight.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
+        new LootPackEntry(true, UtilityTreasures,    1),
         new LootPackEntry(true, LengPotions,    0.05),
         new LootPackEntry(true, MausTreasure,  0.63)
     ));
@@ -77817,7 +77826,8 @@
     mummy.AddLoot(new LootPack(
         new LootPackEntry(true, MausGems,       40,     gemsPriceMutator), 
         new LootPackEntry(true, MausBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.1),
+        new LootPackEntry(true, UtilityTreasures,    3),
+        new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MausTreasure,  0.63)
         
     ));
@@ -77973,7 +77983,7 @@
     seaserpent.AddLoot(new LootPack(
         new LootPackEntry(true, CliffGems,       50,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
-        new LootPackEntry(true, LengPotions,    0.3),
+        new LootPackEntry(true, LengPotions,    0.4),
         new LootPackEntry(true, CliffTreasures,    3)
     ));
     
@@ -78030,6 +78040,7 @@
         new LootPackEntry(true, (from, container) => new SilverGreatAxe(),        100),
         new LootPackEntry(true, MinotaurGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, CliffBottles,    20),
+        new LootPackEntry(true, UtilityTreasures,    6),
         new LootPackEntry(true, LengPotions,    0.2),
         new LootPackEntry(true, MinotaurTreasures,    0.63)
     ));
@@ -79901,6 +79912,80 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new DexterityRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="UtilityTreasures">
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DarknessOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new LightOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DemonWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BirchWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireballOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new IceStormOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new WebOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new HickoryWand();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -86945,7 +86945,7 @@
     
     troll.Attacks = new CreatureAttackCollection
     {
-        new CreatureAttack(7)
+        new CreatureBasicAttack(7)
     };
 
     troll.Wield(new Greatsword());

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -86800,7 +86800,7 @@
     
     kobold.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(7)
+        new CreatureBasicAttack(6)
     };
 
     kobold.Wield(new SteelMace());
@@ -86896,7 +86896,7 @@
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(8)
+        new CreatureBasicAttack(6)
     };
 
     orc.Wield(new Crossbow());
@@ -86945,7 +86945,7 @@
     
     troll.Attacks = new CreatureAttackCollection
     {
-        new CreatureAttack(6, 5, 15)
+        new CreatureAttack(7)
     };
 
     troll.Wield(new Greatsword());
@@ -87421,6 +87421,7 @@
             new LootPackEntry(true, dungeon2Gems, 25.0, gemsPriceMutator), 
             new LootPackEntry(true, dungeon2Bottles, 33.0), 
             new LootPackEntry(true, dungeon2Treasure, 0.63), 
+            new LootPackEntry(true, dungeon3Wands, 2), 
             new LootPackEntry(true, dungeon2Rings, 0.63), 
             new LootPackEntry(true, oakvaelPotions, 0.05)
             //new LootPackEntry(true, &poak_wands, 5.0), 
@@ -87460,7 +87461,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 9, 16)
+        new CreatureBasicAttack(9)
     };
 
     hobgoblin.Wield(new Longsword());
@@ -87473,7 +87474,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return hobgoblin;
@@ -87509,7 +87510,7 @@
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 8, 13)
+        new CreatureBasicAttack(9)
     };
 
     orc.Wield(new Longsword());
@@ -87522,7 +87523,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return orc;
@@ -87571,7 +87572,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return orc;
@@ -87631,7 +87632,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return orc;
@@ -87665,7 +87666,7 @@
     
     troll.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(9, 10, 17)
+        new CreatureBasicAttack(10)
     };
 
     troll.Wield(new Greatsword());
@@ -87678,7 +87679,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return troll;
@@ -87747,7 +87748,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return thaum;
@@ -87812,9 +87813,10 @@
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0, gemsPriceMutator), 
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
+            new LootPackEntry(true, dungeon3Wands, 2), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
             //new LootPackEntry(true, &poak_wands, 5.0)
         ));
 
@@ -87951,7 +87953,8 @@
         new LootPack(
             new LootPackEntry(true, dungeon3Gems, 25.0, gemsPriceMutator), 
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
-            new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14)
+            new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14), 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return gargoyle;
@@ -88093,7 +88096,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2) 
+            new LootPackEntry(true, oakvaelPotions, 0.3) 
         ));
     
     return serpent;
@@ -88143,7 +88146,7 @@
             new LootPackEntry(true, dungeon3Bottles, 33.0), 
             new LootPackEntry(true, dungeon3Treasure, 0.63), 
             new LootPackEntry(true, dungeon3Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.1) 
+            new LootPackEntry(true, oakvaelPotions, 0.2) 
         ));
 
     return pescalanor;
@@ -88210,7 +88213,8 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14)
+            new LootPackEntry(true, (from, container) => new SilverDagger(), 7.14), 
+            new LootPackEntry(true, oakvaelPotions, 0.3) 
         ));
 
     return gargoyle;
@@ -88277,7 +88281,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return minotaur;
@@ -88311,7 +88315,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11, 12, 19)
+        new CreatureBasicAttack(11)
     };
 
     hobgoblin.Wield(new Longsword());
@@ -88324,7 +88328,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return hobgoblin;
@@ -88362,7 +88366,7 @@
     
     troll.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(12, 13, 20)
+        new CreatureBasicAttack(12)
     };
 
     troll.Wield(new Greatsword());
@@ -88375,7 +88379,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return troll;
@@ -88411,7 +88415,7 @@
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(11, 11, 16)
+        new CreatureBasicAttack(11)
     };
 
     orc.Wield(new Longsword());
@@ -88424,7 +88428,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return orc;
@@ -88473,7 +88477,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return orc;
@@ -88542,9 +88546,10 @@
         new LootPack(
             new LootPackEntry(true, dungeon4Gems, 25.0, gemsPriceMutator), 
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
+            new LootPackEntry(true, dungeon3Wands, 3), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return thaum;
@@ -88610,8 +88615,9 @@
             new LootPackEntry(true, dungeon4Gems, 25.0, gemsPriceMutator), 
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
+            new LootPackEntry(true, dungeon3Wands, 3), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
             //new LootPackEntry(true, &poak_wands, 5.0), 
             //new LootPackEntry(true, &poak_books, 0.63),
         ));
@@ -88726,7 +88732,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return drizilu;
@@ -88779,7 +88785,7 @@
             new LootPackEntry(true, dungeon4Bottles, 33.0), 
             new LootPackEntry(true, dungeon4Treasure, 0.63), 
             new LootPackEntry(true, dungeon4Rings, 0.63), 
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return glamuzu;
@@ -88816,7 +88822,7 @@
     
     banshee.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(14, 11, 25)
+        new CreatureBasicAttack(14)
     };
     
     banshee.Spells = new CreatureSpellCollection()
@@ -88834,7 +88840,7 @@
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return banshee;
@@ -88888,8 +88894,9 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
+            new LootPackEntry(true, dungeon5Wands, 1), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return banshee;
@@ -88926,7 +88933,7 @@
     
     wraith.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(14, 15, 20),
+        new CreatureBasicAttack(14),
     };
     
     wraith.Spells = new CreatureSpellCollection()
@@ -88947,8 +88954,9 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return wraith;
@@ -89016,9 +89024,10 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5SpellOrbs, 5.0),
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2) 
+            new LootPackEntry(true, oakvaelPotions, 0.3) 
         ));
 
     return wizard;
@@ -89083,9 +89092,10 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5SpellOrbs, 5.0),
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return thaum;
@@ -89143,7 +89153,7 @@
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
     ));
 
     return ghoul;
@@ -89203,8 +89213,9 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
             //new LootPackEntry(true, &poak_wands, 5.0)
         ));
 
@@ -89244,7 +89255,7 @@
     
     wight.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(14, 20, 25)
+        new CreatureBasicAttack(14)
     };
         
     wight.Spells = new CreatureSpellCollection()
@@ -89262,8 +89273,9 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return wight;
@@ -89330,8 +89342,9 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2),
+            new LootPackEntry(true, oakvaelPotions, 0.3),
             new LootPackEntry(true, (from, container) => new RedRunesRobe(), 5.0) 
     ));
 
@@ -89370,7 +89383,7 @@
     
     stalker.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(15, 20, 30)
+        new CreatureBasicAttack(15)
     };
 
     stalker.Wield(new Spear());    
@@ -89381,8 +89394,9 @@
             new LootPackEntry(true, dungeon5Bottles, 33.0), 
             new LootPackEntry(true, dungeon5Gems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, dungeon5Treasure, 0.63), 
+            new LootPackEntry(true, dungeon5Wands, 2), 
             new LootPackEntry(true, dungeon5Rings, 0.63),
-            new LootPackEntry(true, oakvaelPotions, 0.2)
+            new LootPackEntry(true, oakvaelPotions, 0.3)
         ));
 
     return stalker;
@@ -89864,7 +89878,7 @@
     
     centaur.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(17, 30, 45)
+        new CreatureBasicAttack(17)
     };
         
     centaur.Wield(new WarHammer());
@@ -89912,7 +89926,7 @@
     
     dryad.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(16, 25, 35)
+        new CreatureBasicAttack(16)
     };
     
     dryad.Spells = new CreatureSpellCollection()
@@ -89930,6 +89944,7 @@
         new LootPack(
             new LootPackEntry(true, dungeon5Bottles, 60.0), 
             new LootPackEntry(true, groveGems, 25.0, gemsPriceMutator),
+            new LootPackEntry(true, dungeon5Wands, 4), 
             new LootPackEntry(true, groveTreasure, 0.63)
         ));
     
@@ -92908,6 +92923,64 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new SmallTopaz(40000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="dungeon5Wands">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new OakWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BirchWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DemonWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="dungeon3Wands">
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PineWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new GlassWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new HickoryWand();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100110,7 +100110,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 10, 18)
+        new CreatureBasicAttack(12)
     };
     
     orc.Wield(new Longsword());
@@ -100120,7 +100120,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
 
     ));
@@ -100186,7 +100186,7 @@
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       33,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UKPotions,    0.3), 
         new LootPackEntry(true, UpperTreasure,    1.0)
     ));
     
@@ -100241,7 +100241,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       33,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UpperTreasure,    2.0)
     ));
     
@@ -100280,7 +100280,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 12, 18)
+        new CreatureBasicAttack(12)
     };
     
     troll.Wield(new Greatsword());
@@ -100290,7 +100290,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UKPotions,    0.3), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100338,7 +100338,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UKPotions,    0.3), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100391,8 +100391,9 @@
     hobgoblin.AddGold(550);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, lowerUtilityItems,    4),
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100428,7 +100429,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(13, 12, 20)
+        new CreatureBasicAttack(13)
     };
     
     hobgoblin.Wield(new Longsword());
@@ -100438,7 +100439,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100490,7 +100491,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100528,7 +100529,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(13, 10, 18)
+        new CreatureBasicAttack(13)
     };
         
     troll.Wield(new Greatsword());
@@ -100538,7 +100539,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100580,7 +100581,7 @@
     
     trollguard.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(15, 20, 28)
+        new CreatureBasicAttack(15)
     };
     
     trollguard.Wield(new Halberd());
@@ -100590,7 +100591,7 @@
     trollguard.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       15,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UKPotions,    0.3), 
         new LootPackEntry(true, UpperTreasure,    0.63)
         ));
     
@@ -100627,7 +100628,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(13, 13, 19)
+        new CreatureBasicAttack(13)
     };
     
     hobgoblin.Wield(new Longsword());
@@ -100637,7 +100638,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, speedygems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100689,8 +100690,9 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, upperUtilityItems,    2),
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -100728,7 +100730,7 @@
         
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 12, 18)
+        new CreatureBasicAttack(10)
     };
     
     troll.Spells = new CreatureSpellCollection()
@@ -100743,8 +100745,9 @@
     troll.AddGold(250);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, upperUtilityItems,    2),
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -100782,7 +100785,7 @@
             
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 13, 22)
+        new CreatureBasicAttack(13)
     };
     
     troll.Spells = new CreatureSpellCollection()
@@ -100797,8 +100800,9 @@
     troll.AddGold(380);
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, lowerUtilityItems,    4),
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100853,8 +100857,9 @@
     orc.AddGold(350);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, GenericBottles,    25),
+        new LootPackEntry(true, upperUtilityItems,    2),
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -100891,7 +100896,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 7, 15)
+        new CreatureBasicAttack(12)
     };
     
     goblin.Spells = new CreatureSpellCollection()
@@ -100909,8 +100914,9 @@
     goblin.AddGold(120);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
-        new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, upperUtilityItems,    2),
+        new LootPackEntry(true, UKPotions,    0.3), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -100964,7 +100970,8 @@
     banshee.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, undeadBottles,    15), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, undeadUtilityItems,    3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -101028,7 +101035,7 @@
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       33,     gemsPriceMutator), 
         new LootPackEntry(true, undeadBottles,    50), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -101071,7 +101078,7 @@
     
     skeleton.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(14, 11, 20)
+        new CreatureBasicAttack(14)
     };
     
     skeleton.Wield(new Spear());
@@ -101082,7 +101089,7 @@
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, undeadBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -101123,7 +101130,7 @@
     
     spectre.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(14, 20, 30)
+        new CreatureBasicAttack(14)
     };
     
     spectre.Spells = new CreatureSpellCollection()
@@ -101142,7 +101149,8 @@
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, undeadBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, undeadUtilityItems,    3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -101206,7 +101214,8 @@
     mummy.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       33,     gemsPriceMutator), 
         new LootPackEntry(true, undeadBottles,    50), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, undeadUtilityItems,    3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -101303,7 +101312,7 @@
     knight.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, yasnakiBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
@@ -101342,7 +101351,7 @@
         
     lich.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(11, 20, 25)
+        new CreatureBasicAttack(14)
     };
     
     lich.Spells = new CreatureSpellCollection()
@@ -101358,7 +101367,8 @@
     lich.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, undeadBottles,    50), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, undeadUtilityItems,    3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -101470,7 +101480,8 @@
     martialartist.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       25,     gemsPriceMutator), 
         new LootPackEntry(true, yasnakiBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, undeadUtilityItems,    4), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
@@ -101533,8 +101544,9 @@
     wizard.AddGold(650);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       33,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, yasnakiBottles,    33),
+        new LootPackEntry(true, undeadUtilityItems,    4), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
@@ -101593,8 +101605,9 @@
     thaum.AddGold(750);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, yasnakiGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, yasnakiBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, yasnakiBottles,    33),
+        new LootPackEntry(true, undeadUtilityItems,    4), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, yasnakiTreasure,    0.63)
     ));
     
@@ -101652,7 +101665,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 10, 16)
+        new CreatureBasicAttack(12)
     };
     
     goblin.Wield(new BattleAxe());
@@ -101662,7 +101675,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, drop12gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.2), 
+        new LootPackEntry(true, UKPotions,    0.3), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -101697,7 +101710,7 @@
     
     goblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 10, 16)
+        new CreatureBasicAttack(10)
     };
     
     goblin.Wield(new BattleAxe());
@@ -101707,7 +101720,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -101754,7 +101767,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -101790,7 +101803,7 @@
     
     troll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(11, 10, 15)
+        new CreatureBasicAttack(11)
     };
     
     troll.Wield(new Greatsword());
@@ -101800,7 +101813,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -101837,7 +101850,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10, 10, 15)
+        new CreatureBasicAttack(10)
     };
     
     orc.Wield(new Longsword());
@@ -101847,7 +101860,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     return orc;
@@ -101891,7 +101904,7 @@
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -102080,7 +102093,7 @@
     
     hobgoblin.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(11, 10, 18)
+        new CreatureBasicAttack(11)
     };
     
     hobgoblin.Wield(new Longsword());
@@ -102090,7 +102103,7 @@
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, tunnelSewerGems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    25), 
-        new LootPackEntry(true, UKPotions,    0.1), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.3)
     ));
     
@@ -102142,7 +102155,7 @@
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -102183,7 +102196,7 @@
     
     stalker.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(15, 20, 30)
+        new CreatureBasicAttack(15)
     };
     
     stalker.Spells = new CreatureSpellCollection(100)
@@ -102197,8 +102210,9 @@
     stalker.AddGold(650);
     stalker.AddLoot(new LootPack(
         new LootPackEntry(true, udGems,       25,     gemsPriceMutator), 
-        new LootPackEntry(true, undeadBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.3), 
+        new LootPackEntry(true, undeadBottles,    33),
+        new LootPackEntry(true, undeadUtilityItems,    3), 
+        new LootPackEntry(true, UKPotions,    0.4), 
         new LootPackEntry(true, UndeadTreasure,    0.63)
     ));
     
@@ -102251,7 +102265,7 @@
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, speedygems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
-        new LootPackEntry(true, UKPotions,    0.25), 
+        new LootPackEntry(true, UKPotions,    0.35), 
         new LootPackEntry(true, UpperTreasure,    0.63)
     ));
     
@@ -104494,6 +104508,147 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new BlueStaffRaiseDead();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="upperUtilityItems">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new GlassWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new PineWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new WebOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireballOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new IceStormOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="lowerUtilityItems">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SteelWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new HickoryWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DarknessOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new IceStormOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireballOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="undeadUtilityItems">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SteelWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DemonWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BirchWand();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DarknessOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new HickoryWand();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -103488,7 +103488,7 @@
       <entry entity="uk100200Mino" size="1" minimum="3" maximum="3" />
       <entry entity="uk100200Troll" size="3" minimum="6" maximum="6" />
       <entry entity="uk100200Archer" size="3" minimum="7" maximum="7" />
-      <entry entity="uk100GoblinMage" size="4" minimum="4" maximum="4" />
+      <entry entity="uk100GoblinMage" size="4" minimum="1" maximum="1" />
       <entry entity="uk100Goblin" size="3" minimum="6" maximum="6" />
       <entry entity="uk100MaGoblin" size="1" minimum="2" maximum="2" />
       <bounds region="5">


### PR DESCRIPTION
Big balance push as well - changing monsters to just attack values, very few specific damage ranges so we can balance easier off of that. Was a change that I should have been made since week 1 but it's here now.

Increased potion drops by .1% universally based on potion scarcity feedback.