### PR TITLE
Minor Fix to Oak Salamanders

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -87982,7 +87982,6 @@
 
         Experience = 1325,
         FireProtection = 100,
-        CanLoot = false,
 
         Movement = 2,
     };    
@@ -88646,7 +88645,6 @@
 
         Experience = 4450,
         FireProtection = 100,
-        CanLoot = false,
 
         Movement = 2,
     };

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -87981,6 +87981,8 @@
         BaseDodge = 15,
 
         Experience = 1325,
+        FireProtection = 100,
+        CanLoot = false,
 
         Movement = 2,
     };    
@@ -88643,6 +88645,8 @@
         BaseDodge = 17,
 
         Experience = 4450,
+        FireProtection = 100,
+        CanLoot = false,
 
         Movement = 2,
     };


### PR DESCRIPTION
Changed the following:

- Made salamanders immune to fire
- Turned off their ability to loot since they are monster/creatures.