### PR TITLE
Added Hide Detection to Various Lands

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104995,7 +104995,6 @@
     {
         MaxHealth = 1000, Health = 1000,
         BaseDodge = 21,
-        HideDetection = 25,
         Experience = 19000,
         
         HideDetection = 21,

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -103539,7 +103539,7 @@
         MaxHealth = 68, Health = 68,
         MaxMana = 17, Mana = 17,
         BaseDodge = 12,
-        
+        HideDetection = 22, 
         Experience = 1700,
     };
         
@@ -103595,7 +103595,7 @@
     {
         MaxHealth = 50, Health = 50,
         BaseDodge = 11,
-                
+        HideDetection = 22,         
         Experience = 900,
     };
     
@@ -103652,7 +103652,7 @@
     {
         MaxHealth = 40, Health = 40,
         BaseDodge = 10,
-                
+        HideDetection = 22,         
         Experience = 800,
                 
         Movement = 2,
@@ -103699,7 +103699,7 @@
     {
         MaxHealth = 36, Health = 36,
         BaseDodge = 10,
-                
+        HideDetection = 22,        
         Experience = 900,
     };
     
@@ -103745,7 +103745,7 @@
     {
         MaxHealth = 35, Health = 35,
         BaseDodge = 10,
-                
+        HideDetection = 22,         
         Experience = 925,
         
         CanFlee = true,
@@ -103793,7 +103793,7 @@
     {
         MaxHealth = 45, Health = 45,
         BaseDodge = 12,
-                
+        HideDetection = 22,         
         Experience = 1300,
                 
         Movement = 2,
@@ -103843,7 +103843,7 @@
     {
         MaxHealth = 36, Health = 36,
         BaseDodge = 10,
-                
+        HideDetection = 22,         
         Experience = 900,
     };
     
@@ -103889,7 +103889,7 @@
     {
         MaxHealth = 82, Health = 82,
         BaseDodge = 10,
-                
+        HideDetection = 22,        
         Experience = 1525,
                 
         Movement = 2,
@@ -103950,7 +103950,7 @@
         MaxHealth = 36, Health = 36,
         MaxMana = 16, Mana = 16,
         BaseDodge = 9,
-                
+        HideDetection = 22,         
         Experience = 900,
     };
     
@@ -104006,7 +104006,7 @@
     {
         MaxHealth = 45, Health = 45,
         BaseDodge = 13,
-                
+        HideDetection = 23,        
         Experience = 1900,
     };
     
@@ -104051,7 +104051,7 @@
     {
         MaxHealth = 70, Health = 70,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 2700,
                 
         Movement = 2,
@@ -104102,7 +104102,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 110, Health = 110,
         BaseDodge = 11,
     
@@ -104157,7 +104157,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 35 : 49), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 100, Health = 100,
         BaseDodge = 13,
     
@@ -104207,7 +104207,7 @@
     {
         MaxHealth = 50, Health = 50,
         BaseDodge = 10,
-                
+        HideDetection = 23,        
         Experience = 2050,
         
         CanFlee = true,
@@ -104254,7 +104254,7 @@
     {
         MaxHealth = 107, Health = 107,
         BaseDodge = 12,
-                
+        HideDetection = 23,        
         Experience = 2625,
                 
         Movement = 2,
@@ -104314,7 +104314,7 @@
     {
         MaxHealth = 55, Health = 55,
         BaseDodge = 10,
-                
+        HideDetection = 23,        
         Experience = 2200,
     };
     
@@ -104371,7 +104371,7 @@
         MaxHealth = 68, Health = 68,
         MaxMana = 17, Mana = 17,
         BaseDodge = 11,
-        
+        HideDetection = 23,
         Experience = 2600,
     };
         
@@ -104427,7 +104427,7 @@
         MaxHealth = 40, Health = 40,
         MaxMana = 16, Mana = 16,
         BaseDodge = 12,
-                
+        HideDetection = 23,        
         Experience = 1725,
     };
     
@@ -104484,7 +104484,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 110, Health = 110,
         BaseDodge = 12,
     
@@ -104536,7 +104536,7 @@
     {
         MaxHealth = 40, Health = 40,
         BaseDodge = 12,
-                
+        HideDetection = 23,        
         Experience = 1800,
     };
     
@@ -104581,7 +104581,7 @@
     {
         MaxHealth = 59, Health = 59,
         BaseDodge = 13,
-    
+        HideDetection = 23,
         Experience = 2950,
     };
     
@@ -104626,7 +104626,7 @@
     {
         MaxHealth = 100, Health = 100,
         BaseDodge = 14,
-                
+        HideDetection = 23,        
         Experience = 4500,
         BasePenetration = ShieldPenetration.Medium,
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
@@ -104708,7 +104708,7 @@
         /* He is protection from magic, all spell damage reduced by 50% */
         MagicProtection = 50,
         
-        HideDetection = 21,
+        HideDetection = 24,
     };
     
     wolf.AddStatus(new NightVisionStatus(wolf));
@@ -104763,7 +104763,7 @@
     {
         MaxHealth = 200, Health = 200,
         BaseDodge = 13,
-    
+        HideDetection = 23,
         Experience = 5500,
         BasePenetration = ShieldPenetration.Light,
         VisibilityDistance = 1,
@@ -104829,7 +104829,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 110, Health = 110,
         BaseDodge = 11,
     
@@ -104882,7 +104882,7 @@
     {
         MaxHealth = 120, Health = 120,
         BaseDodge = 13,
-    
+        HideDetection = 23,
         Experience = 5200,
         BasePenetration = ShieldPenetration.Medium,
         Immunity = CreatureImmunity.Web
@@ -104931,7 +104931,7 @@
     {
         MaxHealth = 70, Health = 70,
         BaseDodge = 11,
-        
+        HideDetection = 23,
         Experience = 3800,
         
         Movement = 2,
@@ -104995,7 +104995,7 @@
     {
         MaxHealth = 1000, Health = 1000,
         BaseDodge = 21,
-    
+        HideDetection = 25,
         Experience = 19000,
         
         HideDetection = 21,
@@ -105073,7 +105073,7 @@
     {
         MaxHealth = 32, Health = 32,
         BaseDodge = 12,
-                
+        HideDetection = 23,        
         Experience = 500,
     };
     
@@ -105126,7 +105126,7 @@
     {
         MaxHealth = 55, Health = 55,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 2800,
         BasePenetration = ShieldPenetration.Light,
     };
@@ -105174,7 +105174,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 120, Health = 120,
         BaseDodge = 13,
     
@@ -105228,7 +105228,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
     
@@ -105280,7 +105280,7 @@
     {
         MaxHealth = 175, Health = 175,
         BaseDodge = 13,
-                
+        HideDetection = 23,        
         Experience = 5525,
                 
         BasePenetration = ShieldPenetration.Light,
@@ -105340,7 +105340,7 @@
     {
         MaxHealth = 65, Health = 65,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 2800,    
     };
     
@@ -105386,7 +105386,7 @@
         MaxHealth = 50, Health = 50,
         MaxMana = 16, Mana = 16,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 2800,
     };
     
@@ -105441,7 +105441,7 @@
     {
         MaxHealth = 72, Health = 72,
         BaseDodge = 11,
-    
+        HideDetection = 23,
         Experience = 3800,
     };
     
@@ -105488,7 +105488,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 35 : 49), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 160, Health = 160,
         BaseDodge = 13,
     
@@ -105538,7 +105538,7 @@
     {
         MaxHealth = 175, Health = 175,
         BaseDodge = 15,
-    
+        HideDetection = 23,
         Experience = 6000,
         BasePenetration = ShieldPenetration.Medium,
         Immunity = CreatureImmunity.Web
@@ -105587,7 +105587,7 @@
     {
         MaxHealth = 80, Health = 80,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 3100,
         
         CanFlee = true,
@@ -105636,7 +105636,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
     
@@ -105688,7 +105688,7 @@
     {
         MaxHealth = 100, Health = 100,
         BaseDodge = 12,
-                
+        HideDetection = 23,        
         Experience = 4200,
                 
         Movement = 2,
@@ -105737,7 +105737,7 @@
     {
         MaxHealth = 65, Health = 65,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 3700,
     };
     
@@ -105794,7 +105794,7 @@
         MaxHealth = 89, Health = 89,
         MaxMana = 17, Mana = 17,
         BaseDodge = 11,
-        
+        HideDetection = 23,
         Experience = 4500,
     };
         
@@ -105849,7 +105849,7 @@
     {
         MaxHealth = 70, Health = 70,
         BaseDodge = 11,
-        
+        HideDetection = 23,
         Experience = 4300,
         
         Movement = 2,
@@ -105912,7 +105912,7 @@
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 11,
-                
+        HideDetection = 23,        
         Experience = 5500,
                 
         BasePenetration = ShieldPenetration.VeryLight,
@@ -105971,7 +105971,7 @@
     {
         MaxHealth = 300, Health = 300,
         BaseDodge = 13,
-                
+        HideDetection = 23,        
         Experience = 9000,
                 
         BasePenetration = ShieldPenetration.Medium,
@@ -106043,7 +106043,7 @@
         
         /*HideDetection = Thief Detection. Hide Detection of 25 means a thief level 15 with 10 magic can hide from him 100% of the time. Lower thieves will blink
         or be totally visible. Formula is as written above: Experience level + Magic Level on thief.*/
-        HideDetection = 25,
+        HideDetection = 26,
         
         //Showing all the Can tags: Only CanStrikeCriticall is necessary here as Drake() variable can fly and charge, but adding them for documentation.
         
@@ -106701,7 +106701,7 @@
         MaxHealth = 89, Health = 89,
         MaxMana = 5, Mana = 5,
         BaseDodge = 12,
-        
+        HideDetection = 23,
         Experience = 3800,
         
         VisibilityDistance = 1,
@@ -106759,7 +106759,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 37 : 38), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 105, Health = 105,
         MaxMana = 16, Mana = 16,
         BaseDodge = 12,
@@ -106834,7 +106834,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 16 : 48), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 110, Health = 110,
         MaxMana = 23, Mana = 23,
         BaseDodge = 13,
@@ -106899,7 +106899,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 37 : 38), IsFemale = female,
-            
+        HideDetection = 23,    
         MaxHealth = 100, Health = 100,
         MaxMana = 16, Mana = 16,
         BaseDodge = 13,
@@ -107145,7 +107145,7 @@
         MaxHealth = 200, Health = 200,
         BaseDodge = 14,
         MaxMana = 50, Mana = 50,
-    
+        HideDetection = 23,
         Experience = 9000,
         VisibilityDistance = 1,
         
@@ -107207,7 +107207,7 @@
         MaxHealth = 55, Health = 55,
         BaseDodge = 13,
         Alignment = Alignment.Evil,
-                
+        HideDetection = 23,        
         Experience = 3800,
         BasePenetration = ShieldPenetration.Light,
     };
@@ -107256,6 +107256,7 @@
         Alignment = Alignment.Evil,
         Experience = 3800,
         BasePenetration = ShieldPenetration.Medium,
+        HideDetection = 23,
     };
     
     goblin.Attacks = new CreatureAttackCollection()

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -74841,7 +74841,7 @@
     {
         MaxHealth = 90, Health = 90,
         BaseDodge = 10,
-
+        HideDetection = 23,   
         Experience = 3100,
 
         Movement = 2,
@@ -75248,7 +75248,7 @@
         MaxHealth = 100, Health = 100,
         MaxMana = 31, Mana = 31,
         BaseDodge = 12,
-        
+        HideDetection = 23,   
         Experience = 3200,
     };
         
@@ -75308,7 +75308,7 @@
     {
         Name = "Thrall",
         Body = (isFemale ? 37 : 38), IsFemale = isFemale,
-            
+        HideDetection = 23,    
         MaxHealth = 110, Health = 110,
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
@@ -75381,7 +75381,7 @@
     {
         Name = "Thrall",
         Body = 38,
-            
+        HideDetection = 23,       
         MaxHealth = 110, Health = 110,
         MaxMana = 31, Mana = 31,
         BaseDodge = 13,
@@ -75450,7 +75450,7 @@
         MaxHealth = 100, Health = 100,
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
-    
+        HideDetection = 23,   
         Experience = 6500,
     
         VisibilityDistance = 1,
@@ -75513,7 +75513,7 @@
     {
         MaxHealth = 90, Health = 90,
         BaseDodge = 11,
-    
+        HideDetection = 23,   
         Experience = 2300,
         BasePenetration = ShieldPenetration.VeryLight,
         Attacks = new CreatureAttackCollection
@@ -75564,7 +75564,7 @@
         MaxHealth = 80, Health = 80,
         MaxMana = 31, Mana = 31,
         BaseDodge = 12,
-    
+        HideDetection = 23,   
         Experience = 2600,
     
     };
@@ -75626,7 +75626,7 @@
     {
         Name = "Wretch",
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 23,       
         MaxHealth = 125, Health = 125,
         BaseDodge = 11,
         
@@ -75682,6 +75682,7 @@
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 0,
         Experience = 700,
+        HideDetection = 23,   
     };
     
     raven.Attacks = new CreatureAttackCollection
@@ -75734,6 +75735,7 @@
     {
         MaxHealth = 250, Health = 250,
         BaseDodge = 13,
+        HideDetection = 23,
 
         Experience = 10500,
         
@@ -75786,7 +75788,7 @@
     {
         MaxHealth = 750, Health = 750,
         BaseDodge = 15,
-
+        HideDetection = 23,
         Experience = 10500,
         BasePenetration = ShieldPenetration.Medium,
         
@@ -75843,7 +75845,7 @@
         Experience = 11500,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 1,
-        
+        HideDetection = 23,   
         Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
                    CreatureImmunity.Projectile | CreatureImmunity.Poison | CreatureImmunity.Web,
         Weakness = CreatureWeakness.BlueGlowing,
@@ -75908,7 +75910,7 @@
         MaxHealth = 250, Health = 250,
         MaxMana = 50, Mana = 50,
         BaseDodge = 14,
-    
+        HideDetection = 23,   
         Experience = 12000,
     
         VisibilityDistance = 0,
@@ -75975,7 +75977,7 @@
         Name = "Shidosha",
         MaxHealth = 3000, Health = 3000,
         BaseDodge = 28,
-        HideDetection = 24,
+        HideDetection = 28,
         Experience = 32000,
         
         VisibilityDistance = 0,
@@ -76054,7 +76056,7 @@
     {
         MaxHealth = 250, Health = 250,
         BaseDodge = 20,
-    
+        HideDetection = 26,
         Experience = 6000,
        
         CanJumpkick = true,
@@ -76130,7 +76132,7 @@
     {
         MaxHealth = 3000, Health = 3000,
         BaseDodge = 18,
-        HideDetection = 22,
+        HideDetection = 26,
         Experience = 40000,
         
         CanStrikeCritically = false,
@@ -76294,7 +76296,7 @@
         BaseDodge = 25,
         
         Alignment = Alignment.Chaotic,
-        HideDetection = 27,
+        HideDetection = 28,
         Experience = 85000,
         
         CanFly = true,
@@ -76381,7 +76383,8 @@
     {
         MaxHealth = 300, Health = 300,
         BaseDodge = 15,
-                
+        HideDetection = 26,
+        
         Experience = 11000,
     };
     griffin.AddStatus(new NightVisionStatus(griffin));
@@ -76445,6 +76448,7 @@
             
         MaxHealth = 125, Health = 125,
         BaseDodge = 13,
+        HideDetection = 26,
         BasePenetration = ShieldPenetration.Light,
         Experience = 6300,
         CanSwim = true,
@@ -76492,7 +76496,7 @@
     {
         MaxHealth = 160, Health = 160,
         BaseDodge = 16,
-    
+        HideDetection = 26,
         Experience = 9500,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
@@ -76548,6 +76552,7 @@
         MaxHealth = 100, Health = 100,
         MaxMana = 19, Mana = 19,
         BaseDodge = 14,
+        HideDetection = 26,
         MagicProtection = 33,
         Experience = 9500,
         VisibilityDistance = 0,
@@ -76609,7 +76614,7 @@
             
         MaxHealth = 110, Health = 110,
         BaseDodge = 14,
-            
+        HideDetection = 26,    
         Experience = 6200,
         CanSwim = true,
     };
@@ -76656,6 +76661,7 @@
     {
         MaxHealth = 300, Health = 300,
         BaseDodge = 18,
+        HideDetection = 26,
     
         Experience = 15500,
         
@@ -76721,6 +76727,7 @@
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 16,
+        HideDetection = 28,
         
         Experience = 9025,
         
@@ -76790,6 +76797,7 @@
         VisibilityDistance = 0,
         FireProtection = 100,
         MagicProtection = 33,
+        HideDetection = 28,
     };
     griffin.AddStatus(new NightVisionStatus(griffin));
         
@@ -76848,7 +76856,7 @@
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
-                            
+        HideDetection = 23,                    
         Experience = 4700,
     };
     
@@ -76893,7 +76901,7 @@
     {
         MaxHealth = 110, Health = 110,
         BaseDodge = 14,
-    
+        HideDetection = 23,
         Experience = 2300,
     
         VisibilityDistance = 1,
@@ -76949,7 +76957,7 @@
     {
         MaxHealth = 90, Health = 90,
         BaseDodge = 11,
-    
+        HideDetection = 23,
         Experience = 2100,
         
         Immunity = CreatureImmunity.Poison,
@@ -77005,7 +77013,7 @@
     {
         MaxHealth = 35, Health = 35,
         BaseDodge = 9,
-                
+        HideDetection = 23,        
         Experience = 500,
     
         BasePenetration = ShieldPenetration.VeryLight,
@@ -77052,7 +77060,7 @@
     {
         Name = "Familiar",
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 28,    
         MaxHealth = 130, Health = 130,
         BaseDodge = 14,
         MagicProtection = 33,
@@ -77108,7 +77116,7 @@
     {
         Name = "Familiar",
         Body = (female ? 33 : 32), IsFemale = female,
-            
+        HideDetection = 28,    
         MaxHealth = 180, Health = 180,
         BaseDodge = 15,
         MagicProtection = 33,
@@ -77162,7 +77170,7 @@
     {
         Name = "Familiar",
         Body = (female ? 16 : 48), IsFemale = female,
-            
+        HideDetection = 28,    
         MaxHealth = 130, Health = 130,
         MaxMana = 23, Mana = 23,
         BaseDodge = 14,
@@ -77228,6 +77236,7 @@
     {
         MaxHealth = 178, Health = 178,
         BaseDodge = 14,
+        HideDetection = 26,
         BasePenetration = ShieldPenetration.Medium,     
         Experience = 8700,
     };
@@ -77274,7 +77283,7 @@
     {
         MaxHealth = 550, Health = 550,
         BaseDodge = 15,
-                
+        HideDetection = 26,        
         Experience = 18000,
         BasePenetration = ShieldPenetration.Light,
         CanSwim = true,
@@ -77330,7 +77339,7 @@
     {
         MaxHealth = 1000, Health = 1000,
         BaseDodge = 16,
-        HideDetection = 20,
+        HideDetection = 26,
         CanSwim = true,
         CanJumpkick = true,
         CanStrikeCritically = false,
@@ -77393,7 +77402,7 @@
         MaxHealth = 110, Health = 110,
         BaseDodge = 14,
         Experience = 6200,
-        
+        HideDetection = 26,
         CanFlee = true,
     };
     
@@ -77438,7 +77447,7 @@
     {
         MaxHealth = 105, Health = 105,
         BaseDodge = 15,
-                
+        HideDetection = 26,        
         Experience = 5900,
     };
     
@@ -77496,6 +77505,7 @@
         BaseDodge = 15,
         BasePenetration = ShieldPenetration.Light,
         Experience = 6900,
+        HideDetection = 26,
     };
     
     troll.Attacks = new CreatureAttackCollection()
@@ -77539,7 +77549,7 @@
     {
         MaxHealth = 80, Health = 80,
         BaseDodge = 14,
-                
+        HideDetection = 23,        
         Experience = 2500,
     };
     
@@ -77589,7 +77599,7 @@
         MaxHealth = 90, Health = 90,
         BaseDodge = 14,
         Experience = 5700,
-        
+        HideDetection = 26,
         CanFlee = true,
     };
     
@@ -77634,6 +77644,7 @@
     {
         MaxHealth = 220, Health = 220,
         BaseDodge = 14,
+        HideDetection = 26,
         BasePenetration = ShieldPenetration.Light,
         Experience = 11500,
         
@@ -77698,7 +77709,7 @@
         MaxHealth = 55, Health = 55,
         MaxMana = 8, Mana = 8,
         BaseDodge = 12,
-    
+        HideDetection = 23,
         Experience = 1725,
         
         CanFlee = true,
@@ -77813,7 +77824,7 @@
         MaxHealth = 145, Health = 145,
         MaxMana = 3, Mana = 3,
         BaseDodge = 13,
-    
+        HideDetection = 23,   
         Experience = 2750,
     
         Movement = 2,
@@ -77875,7 +77886,7 @@
     {
         MaxHealth = 500, Health = 500,
         BaseDodge = 18,
-
+        HideDetection = 23,
         Experience = 23000,
 
         Movement = 3,
@@ -77948,7 +77959,7 @@
     {
         MaxHealth = 800, Health = 800,
         BaseDodge = 18,
-
+        HideDetection = 23,   
         Experience = 23000,
         
         CanWalk = false,
@@ -78035,6 +78046,7 @@
         Experience = 9500,
         VisibilityDistance = 0,
         CanLoot = false,
+        HideDetection = 28,
     };
     
     lich.AddStatus(new NightVisionStatus(lich));

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -87064,7 +87064,7 @@
     {
         MaxHealth = 60, Health = 60,
         BaseDodge = 14,
-
+        HideDetection = 21,
         Experience = 2500,
 
         Movement = 2,
@@ -87113,7 +87113,7 @@
     {
         MaxHealth = 46, Health = 46,
         BaseDodge = 13,
-
+        HideDetection = 21,
         Experience = 1900,
     };
     
@@ -87160,7 +87160,7 @@
     {
         MaxHealth = 42, Health = 42,
         BaseDodge = 13,
-
+        HideDetection = 21,
         Experience = 1900,
     };
     
@@ -87209,7 +87209,7 @@
         BaseDodge = 14,
 
         Experience = 2220,
-
+        HideDetection = 21,
         Movement = 2,
 
         CanFlee = true,
@@ -87260,7 +87260,7 @@
     {
         MaxHealth = 48, Health = 48,
         BaseDodge = 13,
-
+        HideDetection = 21,
         Experience = 1900,
         
         CanFlee = true,
@@ -87309,7 +87309,7 @@
     {
         MaxHealth = 40, Health = 40,
         BaseDodge = 13,
-
+        HideDetection = 21,
         Experience = 1955,
 
         CanFlee = true,
@@ -87359,7 +87359,7 @@
         MaxHealth = 40, Health = 40,
         MaxMana = 12, Mana = 12,
         BaseDodge = 13,
-
+        HideDetection = 21,
         Experience = 1925,
         
         CanFlee = true,
@@ -87418,7 +87418,7 @@
         MaxHealth = 78, Health = 78,
         MaxMana = 17, Mana = 17,
         BaseDodge = 14,
-
+        HideDetection = 21,
         Experience = 2750,
 
         VisibilityDistance = 1,
@@ -87480,7 +87480,7 @@
     {
         MaxHealth = 80, Health = 80,
         BaseDodge = 15,
-
+        HideDetection = 25,
         Experience = 2500,
 
         Movement = 2,
@@ -87529,7 +87529,7 @@
     {
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
-
+        HideDetection = 25,
         Experience = 2250,
         
         CanFlee = true,
@@ -87578,7 +87578,7 @@
     {
         MaxHealth = 63, Health = 63,
         BaseDodge = 14,
-
+        HideDetection = 25,
         Experience = 2300,
         
         CanFlee = true,
@@ -87628,7 +87628,7 @@
         MaxHealth = 63, Health = 63,
         MaxMana = 12, Mana = 12,
         BaseDodge = 14,
-
+        HideDetection = 25,
         Experience = 2275,
 
         CanFlee = true,
@@ -87687,7 +87687,7 @@
     {
         MaxHealth = 98, Health = 98,
         BaseDodge = 16,
-
+        HideDetection = 25,
         Experience = 3250,
     };
     
@@ -87736,7 +87736,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 16 : 48), IsFemale = female,
-        
+        HideDetection = 25,     
         MaxHealth = 120, Health = 120,
         MaxMana = 18, Mana = 18,
         BaseDodge = 15,
@@ -87805,7 +87805,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 37 : 38), IsFemale = female,
-        
+        HideDetection = 25,       
         MaxHealth = 108, Health = 108,
         MaxMana = 21, Mana = 21,
         BaseDodge = 15,
@@ -87872,7 +87872,7 @@
     {
         MaxHealth = 130, Health = 130,
         BaseDodge = 15,
-
+        HideDetection = 25,
         Experience = 5500,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
@@ -87940,7 +87940,7 @@
     {
         MaxHealth = 125, Health = 125,
         BaseDodge = 15,
-
+        HideDetection = 25,
         Experience = 2450,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
@@ -88009,7 +88009,7 @@
     {
         MaxHealth = 71, Health = 71,
         BaseDodge = 15,
-
+        HideDetection = 25,
         Experience = 1325,
         FireProtection = 100,
 
@@ -88070,7 +88070,7 @@
     {
         MaxHealth = 500, Health = 500,
         BaseDodge = 18,
-
+        HideDetection = 25,
         Experience = 15000,
 
         Movement = 2,
@@ -88153,7 +88153,7 @@
         Name = "Pescalanor",
         MaxHealth = 120, Health = 120,
         BaseDodge = 16,
-
+        HideDetection = 25,
         Experience = 6000,
 
         CanWalk = false,
@@ -88202,7 +88202,7 @@
     {
         MaxHealth = 130, Health = 130,
         BaseDodge = 17,
-
+        HideDetection = 26,
         Experience = 3500,
 
         Movement = 2,
@@ -88384,7 +88384,7 @@
     {
         MaxHealth = 110, Health = 110,
         BaseDodge = 18,
-
+        HideDetection = 26,
         Experience = 4400,
 
         Movement = 2,
@@ -88535,7 +88535,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 16 : 48), IsFemale = female,
-        
+        HideDetection = 26,    
         MaxHealth = 130, Health = 130,
         MaxMana = 18, Mana = 18,
         BaseDodge = 17,
@@ -88607,7 +88607,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 37 : 38), IsFemale = female,
-        
+        HideDetection = 26,     
         MaxHealth = 123, Health = 123,
         MaxMana = 21, Mana = 21,
         BaseDodge = 17,
@@ -88675,7 +88675,7 @@
     {
         MaxHealth = 80, Health = 80,
         BaseDodge = 17,
-
+        HideDetection = 26,
         Experience = 4450,
         FireProtection = 100,
 
@@ -88736,7 +88736,7 @@
     {
         Name = "Drizilu",
         Body = 32,
-        
+        HideDetection = 26,    
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
         BasePenetration = ShieldPenetration.Medium,
@@ -88789,7 +88789,7 @@
     {
         Name = "Glamuzu",
         Body = 32,
-        
+        HideDetection = 26,
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
         BasePenetration = ShieldPenetration.Medium,
@@ -88843,7 +88843,7 @@
         MaxHealth = 120, Health = 120,
         MaxMana = 5, Mana = 5,
         BaseDodge = 18,
-
+        HideDetection = 26,
         Experience = 5075,
     };
     
@@ -88898,7 +88898,7 @@
         MaxHealth = 120, Health = 120,
         MaxMana = 11, Mana = 11,
         BaseDodge = 18,
-
+        HideDetection = 26,
         Experience = 5475,
     };
     
@@ -88954,7 +88954,7 @@
         MaxHealth = 150, Health = 150,
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
-
+        HideDetection = 26,
         Experience = 6300,
     };
     
@@ -89015,7 +89015,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 37 : 38), IsFemale = female,
-        
+        HideDetection = 26,       
         MaxHealth = 150, Health = 150,
         MaxMana = 25, Mana = 25,
         BaseDodge = 19,
@@ -89086,7 +89086,7 @@
     {
         Name = _names.Random(),
         Body = (female ? 16 : 48), IsFemale = female,
-        
+        HideDetection = 26,       
         MaxHealth = 165, Health = 165,
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
@@ -89152,7 +89152,7 @@
     {
         MaxHealth = 180, Health = 180,
         BaseDodge = 19,
-
+        HideDetection = 26,
         Experience = 6200,
 
         Movement = 2,
@@ -89211,7 +89211,7 @@
         MaxHealth = 145, Health = 145,
         MaxMana = 18, Mana = 18,
         BaseDodge = 19,
-
+        HideDetection = 26,
         Experience = 8300,
 
         VisibilityDistance = 1,
@@ -89274,7 +89274,7 @@
         MaxHealth = 120, Health = 120,
         MaxMana = 10, Mana = 10,
         BaseDodge = 18,
-
+        HideDetection = 26,
         Experience = 5500,
 
         CanFlee = true,
@@ -89333,7 +89333,7 @@
         MaxHealth = 165, Health = 165,
         MaxMana = 21, Mana = 21,
         BaseDodge = 19,
-
+        HideDetection = 26,
         Experience = 9575,
 
         VisibilityDistance = 1,
@@ -89404,7 +89404,7 @@
         BaseDodge = 18,
 
         Experience = 6700,
-
+        HideDetection = 26,
         VisibilityDistance = 1,
     };
     
@@ -89456,7 +89456,7 @@
         
         MaxHealth = 600, Health = 600, /* Based on 4 Death casts to kill at level 16 magic. */
         BaseDodge = 20,
-        
+        HideDetection = 26,       
         Experience = 25000,
         
         BasePenetration = ShieldPenetration.Heavy,
@@ -89521,7 +89521,7 @@
         
         MaxHealth = 600, Health = 600,
         BaseDodge = 20,
-        
+        HideDetection = 26,     
         Experience = 25000,
         
         BasePenetration = ShieldPenetration.Heavy,

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -99406,7 +99406,8 @@
         BaseDodge = 12,
         BasePenetration = ShieldPenetration.Light,
         Experience = 2500,
-    
+        HideDetection = 25,
+        
         Movement = 2,
         
         LightningResistance = 100,
@@ -99467,6 +99468,7 @@
         Body = 177,
         MaxHealth = 70, Health = 70,
         BaseDodge = 12,
+        HideDetection = 25,
                 
         Experience = 2500,
         BasePenetration = ShieldPenetration.Light,
@@ -99530,6 +99532,7 @@
         Body = 178,
         MaxHealth = 70, Health = 70,
         BaseDodge = 12,
+        HideDetection = 25,
                 
         Experience = 2500,
     
@@ -99593,6 +99596,7 @@
         Body = 65,
         MaxHealth = 70, Health = 70,
         BaseDodge = 12,
+        HideDetection = 25,
                 
         Experience = 2500,
     
@@ -99659,7 +99663,7 @@
         BaseDodge = 19,
     
         Alignment = Alignment.Chaotic,
-        HideDetection = 24,
+        HideDetection = 26,
         Experience = 42000,
         
         CanFly = true,
@@ -99744,7 +99748,7 @@
         Name = "Carfel",
         MaxHealth = 2000, Health = 2000,
         BaseDodge = 21,
-        HideDetection = 27,
+        HideDetection = 28,
         Alignment = Alignment.Evil,
         
         Experience = 32000,
@@ -99810,7 +99814,7 @@
     {
         MaxHealth = 800, Health = 800,
         BaseDodge = 15,
-    
+        HideDetection = 28,
         Experience = 18000,
         BasePenetration = ShieldPenetration.Medium,
         
@@ -99935,7 +99939,7 @@
         Experience = 27000,
         CanWalk = false,
         Immunity = CreatureImmunity.Poison,
-            
+        HideDetection = 28,    
         VisibilityDistance = 0,
     };
     
@@ -99994,7 +99998,7 @@
         Body = 163,
         MaxHealth = 2500, Health = 2500,
         BaseDodge = 21,
-        HideDetection = 25,
+        HideDetection = 28,
         Experience = 39000,
        
         CanCharge = true,
@@ -100052,7 +100056,7 @@
     
         MaxHealth = 5000, Health = 5000,
         BaseDodge = 15,
-    
+        HideDetection = 30,
         Experience = 69000,
         
         BasePenetration = ShieldPenetration.VeryHeavy,
@@ -100120,7 +100124,7 @@
     {
         MaxHealth = 130, Health = 130,
         BaseDodge = 12,
-                
+        HideDetection = 25,            
         Experience = 5200,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
@@ -100168,7 +100172,7 @@
     {
         MaxHealth = 200, Health = 200,
         BaseDodge = 16,
-    
+        HideDetection = 25, 
         Experience = 10500,
     
         CanCharge = true,
@@ -100233,7 +100237,7 @@
     {
         MaxHealth = 200, Health = 200,
         BaseDodge = 18,
-                
+        HideDetection = 25,           
         Experience = 12000,
         BasePenetration = ShieldPenetration.Medium,
         CanStrikeCritically = false,
@@ -100289,7 +100293,7 @@
     {
         MaxHealth = 145, Health = 145,
         BaseDodge = 13,
-                
+        HideDetection = 25,            
         Experience = 6400,
                 
         Movement = 3,
@@ -100337,7 +100341,7 @@
     {
         MaxHealth = 100, Health = 100,
         BaseDodge = 12,
-                
+        HideDetection = 25,              
         Experience = 5600,
         
         CanFlee = true,
@@ -100389,7 +100393,7 @@
         BasePenetration = ShieldPenetration.Light,
         Experience = 6700,
         LightningResistance = 100,
-    
+        HideDetection = 25, 
     };
     
     hobgoblin.Attacks = new CreatureAttackCollection()
@@ -100440,7 +100444,7 @@
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
-    
+        HideDetection = 25,
         Experience = 6600,
         BasePenetration = ShieldPenetration.Medium,
     };
@@ -100489,7 +100493,7 @@
     {
         MaxHealth = 135, Health = 135,
         BaseDodge = 13,
-                
+        HideDetection = 25,           
         Experience = 6400,
         BasePenetration = ShieldPenetration.Medium,
         Movement = 3,
@@ -100538,7 +100542,7 @@
     {
         MaxHealth = 175, Health = 175,
         BaseDodge = 14,
-                
+        HideDetection = 25,           
         Experience = 6800,
                 
         Movement = 3,
@@ -100587,7 +100591,7 @@
         Name = "Elite.Guard",
         MaxHealth = 300, Health = 300,
         BaseDodge = 15,
-            
+        HideDetection = 29,    
         Experience = 11000,
         
         CanCharge = true,
@@ -100639,7 +100643,7 @@
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
-    
+        HideDetection = 25,
         Experience = 7500,
         BasePenetration = ShieldPenetration.Medium,
     };
@@ -100688,7 +100692,7 @@
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.VeryLight,
         Experience = 2300,
-    
+        HideDetection = 25,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -100741,7 +100745,7 @@
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.VeryLight,
         Experience = 2600,
-        
+        HideDetection = 25,  
         MaxMana = 21, Mana = 21,
             
     };
@@ -100794,7 +100798,7 @@
     {
         MaxHealth = 130, Health = 130,
         BaseDodge = 12,
-    
+        HideDetection = 25,
         Experience = 6800,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 31, Mana = 31,
@@ -100850,7 +100854,7 @@
         MaxHealth = 90, Health = 90,
         MaxMana = 21, Mana = 21,
         BaseDodge = 11,
-    
+        HideDetection = 25,
         Experience = 2300,
         BasePenetration = ShieldPenetration.VeryLight,
     };
@@ -100910,6 +100914,7 @@
         BasePenetration = ShieldPenetration.VeryLight,        
         Experience = 5800,
         FireProtection = 100,
+        HideDetection = 25,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -100963,7 +100968,7 @@
     {
         MaxHealth = 120, Health = 120,
         BaseDodge = 13,
-    
+        HideDetection = 28,
         Experience = 7200,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 21, Mana = 21,
@@ -101022,7 +101027,7 @@
         Experience = 9000,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 0,
-            
+        HideDetection = 28,    
         FireProtection = 50,
         IceProtection = 50,
         DeathResistance = 100,
@@ -101082,7 +101087,7 @@
     {
         MaxHealth = 150, Health = 150,
         BaseDodge = 14,
-
+        HideDetection = 28,
         Experience = 6800,
         BasePenetration = ShieldPenetration.Light,
         Movement = 3,
@@ -101137,7 +101142,7 @@
         MaxHealth = 150, Health = 150,
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
-    
+        HideDetection = 28, 
         Experience = 8500,
         BasePenetration = ShieldPenetration.Light,
         VisibilityDistance = 1,
@@ -101198,7 +101203,7 @@
         Name = "mummy",
         MaxHealth = 350, Health = 350,
         BaseDodge = 15,
-        HideDetection = 26,
+        HideDetection = 28,
         Experience = 19000,
     
         BasePenetration = ShieldPenetration.Heavy,
@@ -101263,7 +101268,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 12,
         MaxMana = 10, Mana = 10,
-    
+        HideDetection = 28,
         Experience = 2725,
         
     };
@@ -101313,7 +101318,7 @@
         Name = "Yasnaki.Knight",
         MaxHealth = 230, Health = 230,
         BaseDodge = 14,
-                
+        HideDetection = 28,        
         Experience = 10500,
         BasePenetration = ShieldPenetration.Medium,
     };
@@ -101360,6 +101365,7 @@
         MaxHealth = 120, Health = 120,
         MaxMana = 19, Mana = 19,
         BaseDodge = 14,
+        HideDetection = 28,
         BasePenetration = ShieldPenetration.Light,
         Experience = 12000,
         VisibilityDistance = 0,
@@ -101421,6 +101427,7 @@
         CanWalk = false,
         CanCharge = true,   
         Experience = 7000,
+        HideDetection = 25,
         
         Immunity = CreatureImmunity.Poison, 
             
@@ -101483,7 +101490,7 @@
             
         MaxHealth = 260, Health = 260,
         BaseDodge = 16,
-    
+        HideDetection = 28,
         Experience = 10550,
         BasePenetration = ShieldPenetration.Heavy,
         CanJumpkick = true,
@@ -101528,7 +101535,7 @@
     {
         Name = "Yasnaki.Wizard",
         Body = 37,
-            
+        HideDetection = 28,      
         MaxHealth = 150, Health = 150,
         MaxMana = 31, Mana = 31,
         BaseDodge = 14,
@@ -101596,7 +101603,7 @@
         Body = 48,
         MaxHealth = 130, Health = 130,
         BaseDodge = 11,
-    
+        HideDetection = 28,
         Experience = 9500,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 31, Mana = 31,
@@ -101676,7 +101683,7 @@
     {
         MaxHealth = 130, Health = 130,
         BaseDodge = 12,
-                
+        HideDetection = 25,            
         Experience = 5700,
         BasePenetration = ShieldPenetration.Light,
     };
@@ -101723,7 +101730,8 @@
         MaxHealth = 80, Health = 80,
         BaseDodge = 10,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 2200,    
+        Experience = 2200,  
+        HideDetection = 25,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -101769,7 +101777,7 @@
         BaseDodge = 11,
         BasePenetration = ShieldPenetration.Light,
         Experience = 2200,
-        
+        HideDetection = 25, 
         CanFlee = true,
     };
     
@@ -101814,7 +101822,7 @@
     {
         MaxHealth = 110, Health = 110,
         BaseDodge = 12,
-                
+        HideDetection = 25,        
         Experience = 2600,
         BasePenetration = ShieldPenetration.Light,
     };
@@ -101860,7 +101868,7 @@
     {
         MaxHealth = 80, Health = 80,
         BaseDodge = 11,
-                
+        HideDetection = 25,         
         Experience = 2100,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
@@ -101908,7 +101916,9 @@
         BaseDodge = 10,
         BasePenetration = ShieldPenetration.Light,       
         Experience = 2200,
+        HideDetection = 25,
     };
+    
     
     goblin.Attacks = new CreatureAttackCollection()
     {
@@ -102104,7 +102114,7 @@
     {
         MaxHealth = 90, Health = 90,
         BaseDodge = 14,
-    
+        HideDetection = 25,
         Experience = 2600,
         BasePenetration = ShieldPenetration.Medium,
     };
@@ -102153,7 +102163,7 @@
     {
         MaxHealth = 80, Health = 80,
         BaseDodge = 14,
-                
+        HideDetection = 25,        
         Experience = 2700,
         BasePenetration = ShieldPenetration.Medium,
         Movement = 3,
@@ -102203,7 +102213,7 @@
         MaxHealth = 200, Health = 200,
         MaxMana = 17, Mana = 17,
         BaseDodge = 20,
-    
+        HideDetection = 28,  
         Experience = 14500,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 1,
@@ -102262,7 +102272,7 @@
         BaseDodge = 14,
         BasePenetration = ShieldPenetration.VeryLight,
         Experience = 6000,
-    
+        HideDetection = 25,
     };
     
     orc.Attacks = new CreatureAttackCollection()


### PR DESCRIPTION
Added hide detection attributes to all the mobs in Axe, Leng, Oak and UK. I left Kesmai alone, and the surface/easy areas of all the other lands. I based these detection levels on a chart I had from the original GS version of the game. Obviously they can be tweaked, but it'll make it more challenging than it is right now to get a level 3 thief rdaggers, doom bow, etc... 