### PR TITLE
Tether Entities to their spawn areas.

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -106981,6 +106981,8 @@
         MaxMana = 30, Mana = 30,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
 
     peacekeeper.Attacks = new CreatureAttackCollection
@@ -107092,6 +107094,8 @@
         Experience = 50,
         
         Alignment = Alignment.Lawful,
+        
+        IsTethered = true,
     };
     
     griffin.Home = new RectangleBounds()
@@ -107381,7 +107385,10 @@
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
-	return new Alia();
+	return new Alia()
+	{
+	   IsTethered = true,
+	};
 ]]></block>
         <block><![CDATA[]]></block>
       </script>

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -97264,6 +97264,8 @@
         MaxHealth = 110, Health = 110,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
 
     peacekeeper.Attacks = new CreatureAttackCollection()
@@ -97313,6 +97315,8 @@
         MaxMana = 30, Mana = 30,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
 
     peacekeeper.Attacks = new CreatureAttackCollection()
@@ -97360,6 +97364,8 @@
         MaxHealth = 130, Health = 130,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
     
     peacekeeper.Attacks = new CreatureAttackCollection()
@@ -97442,6 +97448,8 @@
         Experience = 50,
         
         Alignment = Alignment.Lawful,
+        
+        IsTethered = true,
     };
 
     crocodile.Home = new RectangleBounds()
@@ -97498,6 +97506,8 @@
         CanSwim = true,
 
         Alignment = Alignment.Lawful,
+        
+        IsTethered = true,
     };
     
     dog.Home = new RectangleBounds()
@@ -97589,6 +97599,8 @@
         Experience = 50,
     
         Alignment = Alignment.Lawful,
+        
+        IsTethered = true,
     };
     
     shark.AddImmunity(typeof(Whirlwind));
@@ -100924,6 +100936,8 @@ else
         MaxHealth = 130, Health = 130,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
     
     sheriff.Attacks = new CreatureAttackCollection()

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -76070,6 +76070,7 @@
         BasePenetration = ShieldPenetration.Medium,
         CanLoot = false,
 
+        IsTethered = true,
     };
     
     ninja.AddStatus(new NightVisionStatus(ninja));
@@ -77781,6 +77782,8 @@
         MaxMana = 30, Mana = 30,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
 
     peacekeeper.Attacks = new CreatureAttackCollection

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -94139,6 +94139,8 @@
         BaseDodge = 12,
 
         Experience = 50,
+        
+        IsTethered = true,
     };
     sheriff.Home = new RectangleBounds()
     {
@@ -94331,6 +94333,8 @@
         BaseDodge = 15,
         BasePenetration = ShieldPenetration.Light,
         Experience = 50,
+        
+        IsTethered = true,
     };
     
     peyton.Attacks = new CreatureAttackCollection
@@ -94371,6 +94375,8 @@
         BaseDodge = 15,
 
         Experience = 50,
+        
+        IsTethered = true,
     };
     
     karin.Attacks = new CreatureAttackCollection

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -99375,6 +99375,8 @@
 	   
 	   Experience = 50,
 	   BasePenetration = ShieldPenetration.Medium,
+	   
+	   IsTethered = true,
 	   Home = new RectangleBounds()
        {
             new Rectangle2D(7, 2, 13, 14, 1)
@@ -99429,6 +99431,8 @@
        
        Experience = 50,
        BasePenetration = ShieldPenetration.Medium,
+       
+       IsTethered = true,
        Home = new RectangleBounds()
        {
             new Rectangle2D(7, 2, 13, 14, 1)
@@ -102052,6 +102056,8 @@
         MaxMana = 30, Mana = 30,
         
         Experience = 50,
+        
+        IsTethered = true,
     };
 
     peacekeeper.Attacks = new CreatureAttackCollection()


### PR DESCRIPTION
This PR tethers certain entities, specifically bosses, to their spawn region. Some changes will be added on the server to support  `IsTethered`.  I did the OG lands @zrikzlok may have to tag bosses he deems necessary to tether on Bloodlands.