### PR TITLE
World forge

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Entity.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Entity.cs
@@ -37,6 +37,29 @@ namespace Kesmai.WorldForge
 			get => _scripts;
 			set => SetProperty(ref _scripts, value);
 		}
+
+		public int? XP
+        {
+			get
+            {
+				var xpPattern = new System.Text.RegularExpressions.Regex("Experience\\s*=\\s*(\\d+)\\s*,", System.Text.RegularExpressions.RegexOptions.Multiline);
+				var matches = xpPattern.Matches(this.Scripts[0].Blocks[1]);
+				if (matches.Count == 1 && int.TryParse(matches.First().Groups[1].Value, out var xp))
+					return xp;
+				return null;
+            }
+        }
+		public int? HP
+        {
+			get
+			{
+				var hpPattern = new System.Text.RegularExpressions.Regex("MaxHealth\\s*=\\s*(\\d+)\\s*,", System.Text.RegularExpressions.RegexOptions.Multiline);
+				var matches = hpPattern.Matches(this.Scripts[0].Blocks[1]);
+				if (matches.Count == 1 && int.TryParse(matches.First().Groups[1].Value, out var hp))
+					return hp;
+				return null;
+			}
+		}
 		
 		public Entity()
 		{

--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Spawner.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Spawner.cs
@@ -235,6 +235,11 @@ namespace Kesmai.WorldForge
 	public class RegionSpawner : Spawner
 	{
 		private int _region;
+
+		private double _averageMobs;
+		private int? _totalXP;
+		private int? _totalHP;
+		private int _openFloortiles;
 		
 		public int Region
 		{
@@ -282,76 +287,130 @@ namespace Kesmai.WorldForge
 			}
 		}
 
-		public int OpenFloorTiles
-		{
-			get
+		public void CalculateStats()
+        {
+			//Calculate Open Floor Tiles by finding all tiles that have a floor type component and not a structural component.
+			_openFloortiles = 0;
+			var segmentRequest = WeakReferenceMessenger.Default.Send<GetActiveSegmentRequestMessage>();
+			var segment = segmentRequest.Response;
+			var region = segment.GetRegion(_region);
+			if (region is not null)
 			{
-				var segmentRequest = WeakReferenceMessenger.Default.Send<GetActiveSegmentRequestMessage>();
-				var segment = segmentRequest.Response;
-				var region = segment.GetRegion(_region);
-				if (region is null)
-					return 0;
-
-				IEnumerable<SegmentTile> includedTiles = Enumerable.Empty<SegmentTile>() ;
+				IEnumerable<SegmentTile> includedTiles = Enumerable.Empty<SegmentTile>();
 				foreach (var rect in Inclusions)
-                {
+				{
 					var rectTiles = region.GetTiles(t => rect.ToRectangle().Contains(t.X, t.Y) &&
 									   t.Components.Any(floor => floor is Models.FloorComponent || floor is Models.IceComponent || floor is Models.WaterComponent) &&
 									   !t.Components.Any(notfloor => notfloor is Models.WallComponent || notfloor is Models.ObstructionComponent));
 					includedTiles = includedTiles.Union(rectTiles);
-                }
+				}
 				foreach (var rect in Exclusions)
-                {
-					if (rect is { Left: 0, Right: 0, Width: 0, Height: 0 })
+				{
+					if (rect is { Left: 0, Right: 0, Top: 0, Bottom: 0 })
 						continue;
-					includedTiles = includedTiles.Where(t => ! rect.ToRectangle().Contains(t.X, t.Y));
+					includedTiles = includedTiles.Where(t => !rect.ToRectangle().Contains(t.X, t.Y));
 				}
 
-				return includedTiles.Count();
+				_openFloortiles = includedTiles.Count();
+
+				//Calculate stats that require itterating through entities: Average mobs, total xp, total hp, density.
+				_averageMobs = 0;
+				_totalXP = 0;
+				_totalHP = 0;
+				if (Entries.Count != 0)
+				{
+					double averageEntry = 0;
+					double averageXP = 0;
+					double averageHP = 0;
+					int minimumMobs = 0;
+					int minimumXP = 0;
+					int minimumHP = 0;
+					int minimumSlots = 0;
+					int maximumMobs = 0;
+					int maximumXP = 0;
+					int maximumHP = 0;
+					int maximumSlots = 0;
+					foreach (var entry in Entries.Where(e=>e.Entity.HP is not null && e.Entity.XP is not null))
+					{
+						averageEntry += entry.Size;
+						averageHP += entry.Size * (int)entry.Entity.HP;
+						averageXP += entry.Size * (int)entry.Entity.XP;
+						minimumMobs += entry.Minimum * entry.Size;
+						minimumHP += entry.Minimum * entry.Size * (int)entry.Entity.HP;
+						minimumXP += entry.Minimum * entry.Size * (int)entry.Entity.XP;
+						minimumSlots += entry.Minimum;
+						maximumMobs += entry.Maximum * entry.Size;
+						maximumHP += entry.Maximum * entry.Size * (int)entry.Entity.HP;
+						maximumXP += entry.Maximum * entry.Size * (int)entry.Entity.XP;
+						maximumSlots += entry.Maximum ==0 ? Maximum : entry.Maximum;
+
+					}
+					averageEntry = averageEntry / Entries.Count();
+					averageHP = averageHP / Entries.Count();
+					averageXP = averageXP / Entries.Count();
+
+					//For spawners that have a maximum of 0 or a Maximum higher than the alotted entries, there is no cap on mobs, and all entries will spawn their maximum
+					if (Maximum == 0 || Maximum>=maximumSlots)
+					{
+						_averageMobs = maximumMobs;
+						_totalHP = maximumHP;
+						_totalXP = maximumXP;
+					}
+					//For spawners that have fewer slots available than needed to fill the minimums, average mobs is just slots times our average size.
+					else if (Maximum < minimumSlots)
+					{
+						_averageMobs = averageEntry * Maximum;
+						_totalHP = (int)(averageHP * Maximum);
+						_totalXP = (int)(averageXP * Maximum);
+					}
+					//For other spawners, we need to first fill the minimums, then add remaining slots * our average.
+					else
+					{
+						_averageMobs = minimumMobs + (Maximum - minimumSlots) * averageEntry;
+						_totalHP = (int)(minimumHP + (Maximum - minimumSlots) * averageHP);
+						_totalXP = (int)(minimumXP + (Maximum - minimumSlots) * averageXP);
+					}
+				}
+				//If any of the entities referenced have a null for HP or XP, invalidate that calculation
+				if (Entries.Any(e => e.Entity.HP is null))
+					_totalHP = null;
+				if (Entries.Any(e => e.Entity.XP is null))
+					_totalXP = null;
+				//If the Spawner has a 0 Maximum AND any of the entities also have a 0 maximum. I think this spawner will spawn without cap. Show as broken
+				if (Maximum == 0 && Entries.Any(e => e.Maximum == 0))
+                {
+					_averageMobs = 0;
+					_totalHP = null;
+					_totalXP = null;
+                }
 			}
 		}
+		public int OpenFloorTiles
+		{
+			get => _openFloortiles;
+		}
 
-		public Double AverageMobs
+		public double AverageMobs
+        {
+			get => _averageMobs;
+        }
+
+		public double Density
         {
             get
             {
-				//For a new spawner or an empty one, there is no mob count.
-				if (Entries.Count() == 0)
-					return 0.0;
-				
-				//Get some stats based on each entry. What's the average size, how many slots are used and how many mobs generated to hit the minimums.
-				Double averageEntry = 0;
-				int minimumMobs = 0;
-				int minimumSlots = 0;
-				int maximumMobs = 0;
-				foreach (var entry in Entries)
-                {
-					averageEntry += entry.Size;
-					minimumMobs += entry.Minimum * entry.Size;
-					minimumSlots += entry.Minimum;
-					maximumMobs += entry.Maximum * entry.Size;
-                }
-				averageEntry = averageEntry / Entries.Count();
-
-				//For spawners that have a maximum of 0, there is no cap on mobs, and all entries will spawn their maximum
-				if (Maximum == 0)
-					return maximumMobs;
-
-				//For spawners that have fewer slots available than needed to fill the minimums, average mobs is just slots times our average size.
-				if (Maximum < minimumSlots)
-					return averageEntry * Maximum;
-
-				//For other spawners, we need to first fill the minimums, then add remaining slots * our average.
-				return minimumMobs + (Maximum - minimumSlots) * averageEntry;
+				return _averageMobs / _openFloortiles;
             }
         }
 
-		public Double Density
+		public int? TotalXP
         {
-            get
-            {
-				return AverageMobs / OpenFloorTiles;
-            }
+			get => _totalXP;
+        }
+
+		public int? TotalHP
+        {
+			get => _totalHP;
         }
 
 		public override XElement GetXElement()

--- a/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
@@ -288,8 +288,20 @@ namespace Kesmai.WorldForge.Editor
 						break;
 					}
 				case "Treasure": //Ctrl-T
-					//todo: Try to identify a targeted Treasure. Can I inspect a script panel and check to see if a word under the cursor matches any treasure definitions.
+					String targetTreasure = null;
+					if (ActiveDocument is EntitiesViewModel e)
+                    {
+						var treasureRequest = WeakReferenceMessenger.Default.Send<EntitiesDocument.GetCurrentScriptSelection>();
+						if (treasureRequest.HasReceivedResponse)
+							targetTreasure = treasureRequest.Response;
+                    }
 					ActiveDocument = Documents.Where(d => d is TreasuresViewModel).FirstOrDefault() as TreasuresViewModel;
+					if (targetTreasure is not null)
+                    {
+						var targetTreasureObject = (ActiveDocument as TreasuresViewModel).Treasures.Where(t => t.Name == targetTreasure).FirstOrDefault();
+						if (targetTreasureObject is not null)
+							(ActiveDocument as TreasuresViewModel).SelectedTreasure = targetTreasureObject;
+                    }
 					break;
 				case "Location": //Ctrl-L
 					{

--- a/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
@@ -279,9 +279,13 @@ namespace Kesmai.WorldForge.Editor
 				case "Entity": //Ctrl-E
 					{
 						Entity target = null;
-						var entityRequest = WeakReferenceMessenger.Default.Send<SpawnsDocument.GetActiveEntity>();
-						if (entityRequest.HasReceivedResponse) 
-							target = entityRequest.Response;
+						//There's probably a better way to do this. but I can't search one up. Can I send a more generic message and have both documents register for it but decline to respond if they are not active?
+						var spawnEntityRequest = WeakReferenceMessenger.Default.Send<SpawnsDocument.GetActiveEntity>();
+						var treasureEntityRequest = WeakReferenceMessenger.Default.Send<TreasuresDocument.GetActiveEntity>();
+						if (spawnEntityRequest.HasReceivedResponse && spawnEntityRequest.Response != null) 
+							target = spawnEntityRequest.Response;
+						if (treasureEntityRequest.HasReceivedResponse && treasureEntityRequest.Response != null)
+							target = treasureEntityRequest.Response;
 						ActiveDocument = Documents.Where(d => d is EntitiesViewModel).FirstOrDefault() as EntitiesViewModel;
 						if (target is not null)
 							(ActiveDocument as EntitiesViewModel).SelectedEntity = target;

--- a/Source/Kesmai.WorldForge/Editor/Tools/ArrowTool.cs
+++ b/Source/Kesmai.WorldForge/Editor/Tools/ArrowTool.cs
@@ -204,9 +204,8 @@ namespace Kesmai.WorldForge
 
 					if (tile != null)
 					{
-						var componentWindow = new ComponentsWindow(region, tile);
+						var componentWindow = new ComponentsWindow(region, tile, graphicsScreen);
 
-						componentWindow.Closed += (o, args) => { tile.UpdateTerrain(); };
 						componentWindow.Show(graphicsScreen.UI);
 						componentWindow.Center();
 					}

--- a/Source/Kesmai.WorldForge/Editor/Tools/PaintTool.cs
+++ b/Source/Kesmai.WorldForge/Editor/Tools/PaintTool.cs
@@ -1,15 +1,23 @@
+using System;
 using System.Linq;
 using System.Windows.Input;
 using CommonServiceLocator;
 using DigitalRune.Game.Input;
+using DigitalRune.Graphics;
 using Kesmai.WorldForge.Editor;
 using Kesmai.WorldForge.Models;
 using Microsoft.Xna.Framework.Input;
+using DigitalRune.Game.UI;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 
 namespace Kesmai.WorldForge
 {
 	public class PaintTool : Tool
 	{
+		private bool _isShiftDown;
+		private bool _isAltDown;
+
 		public PaintTool() : base("Paint", "Editor-Icon-Paint")
 		{
 		}
@@ -30,6 +38,10 @@ namespace Kesmai.WorldForge
 
 			if (!inputService.IsKeyboardHandled)
 			{
+
+				_isShiftDown = inputService.IsDown(Keys.LeftShift) || inputService.IsDown(Keys.RightShift);
+				_isAltDown = inputService.IsDown(Keys.LeftAlt) || inputService.IsDown(Keys.RightAlt);
+
 				if (inputService.IsReleased(Keys.Escape))
 				{
 					presenter.SelectTool(default(Tool));
@@ -42,8 +54,6 @@ namespace Kesmai.WorldForge
 			if (!selection.Any())
 				return;
 
-			var append = (inputService.IsDown(Keys.RightShift) || inputService.IsDown(Keys.LeftShift));
-			
 			if (inputService.IsReleased(MouseButtons.Left) && selection.IsSelected(cx, cy, region))
 			{
 				var component = presenter.SelectedComponent;
@@ -51,6 +61,13 @@ namespace Kesmai.WorldForge
 				if (component != null)
 				{
 					var componentType = component.GetType();
+					var floorTypes = new List<String>() {
+							"FloorComponent",
+							"WaterComponent",
+							"IceComponent",
+							"SkyComponent"
+						};
+					IEnumerable<TerrainComponent> similar = Enumerable.Empty<TerrainComponent>();
 
 					foreach (var area in selection)
 					{
@@ -62,13 +79,30 @@ namespace Kesmai.WorldForge
 							if (selectedTile == null)
 								region.SetTile(x, y, selectedTile = new SegmentTile(x, y));
 
-							if (!append)
-							{
-								var similar = selectedTile.GetComponents<TerrainComponent>(c => c.GetType().IsAssignableFrom(componentType));
+							// Shift = Append; Alt = Replace
+							// if not shift and not alt, then clobber like components.
+							// if Shift, then there are no like components to clobber
+							// if Alt, then all components get clobbered.
+							// Alt wins in the case of shift+alt
 
-								foreach (var similarComponent in similar)
-									selectedTile.RemoveComponent(similarComponent);
+							if (!_isShiftDown && !_isAltDown) //not appending and not replacing.
+							{
+									if (floorTypes.Contains(componentType.Name))
+									{
+										similar = selectedTile.GetComponents<TerrainComponent>(c => c is FloorComponent || c is WaterComponent || c is IceComponent || c is SkyComponent);
+									}
+									else
+									{
+										similar = selectedTile.GetComponents<TerrainComponent>(c => c.GetType().IsAssignableFrom(componentType));
+									}
 							}
+							if (_isAltDown) // replacing
+                            {
+									similar = selectedTile.GetComponents<TerrainComponent>();
+							}
+
+							foreach (var similarComponent in similar)
+								selectedTile.RemoveComponent(similarComponent);
 
 							selectedTile.Components.Add(component.Clone());
 							selectedTile.UpdateTerrain();
@@ -89,6 +123,35 @@ namespace Kesmai.WorldForge
 		public override void OnDeactivate()
 		{
 			base.OnDeactivate();
+		}
+
+		public override void OnRender(RenderContext context)
+		{
+			base.OnRender(context);
+
+			var graphicsService = context.GraphicsService;
+			var spriteBatch = graphicsService.GetSpriteBatch();
+
+			var presentationTarget = context.GetPresentationTarget();
+
+			var worldScreen = presentationTarget.WorldScreen;
+			var uiScreen = worldScreen.UI;
+			var renderer = uiScreen.Renderer;
+			var spriteFont = renderer.GetFont("Tahoma14Bold");
+
+			var text = String.Empty;
+
+			if (_isShiftDown)
+				text = "Append";
+			if (_isAltDown)
+				text = "Replace";
+
+			var position = (Vector2)_position + new Vector2(10.0f, -10.0f);
+
+			spriteBatch.DrawString(spriteFont, text, position + new Vector2(1f, 1f),
+				Color.Black);
+			spriteBatch.DrawString(spriteFont, text, position,
+				Color.Yellow);
 		}
 	}
 }

--- a/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
+++ b/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
@@ -498,6 +498,8 @@ namespace Kesmai.WorldForge
 								{
 									var currentFilter = _presenter.SelectedFilter;
 									var tile = region.GetTile(x,y);
+									if (tile is null)
+										continue;
 									var validComponents = tile.Components.Where(c => currentFilter.IsValid(c)).ToArray();
 									foreach (var component in validComponents){
 										tile.RemoveComponent(component);

--- a/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
+++ b/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
@@ -645,7 +645,7 @@ namespace Kesmai.WorldForge
 									var spriteBounds = originalBounds;
 
 									if (sprite.Offset != Vector2F.Zero)
-										spriteBounds.Offset(sprite.Offset.X, sprite.Offset.Y);
+										spriteBounds.Offset((int)Math.Floor(sprite.Offset.X * _zoomFactor), (int)Math.Floor(sprite.Offset.Y * _zoomFactor));
 
 									spritebatch.Draw(sprite.Texture, spriteBounds.Location.ToVector2(),null,  render.Color, 0, Vector2.Zero, _zoomFactor, SpriteEffects.None, 0f);
 								}

--- a/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
+++ b/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
@@ -495,9 +495,17 @@ namespace Kesmai.WorldForge
 						{
 							for (var x = area.Left; x < area.Right; x++)
 								for (var y = area.Top; y < area.Bottom; y++)
-									region.DeleteTile(x, y);
-						}
+								{
+									var currentFilter = _presenter.SelectedFilter;
+									var tile = region.GetTile(x,y);
+									var validComponents = tile.Components.Where(c => currentFilter.IsValid(c)).ToArray();
+									foreach (var component in validComponents){
+										tile.RemoveComponent(component);
+									}
+								}
 
+						}
+						_invalidateRender = true;
 						inputService.IsKeyboardHandled = true;
 					}
 				}

--- a/Source/Kesmai.WorldForge/Game/UI/Controls/PropertyGrid/CheckComboBoxPropertyEditor.cs
+++ b/Source/Kesmai.WorldForge/Game/UI/Controls/PropertyGrid/CheckComboBoxPropertyEditor.cs
@@ -63,8 +63,9 @@ namespace Kesmai.WorldForge.Windows
 			{
 				var propertyInfo = parent.PropertyInfo;
 				var source = parent.Source;
+				var propValue = propertyInfo.GetValue(source);
 
-				if (propertyInfo.GetValue(source) is IList values)
+				if (propValue is IList values)
 				{
 					foreach (var value in values)
 					{
@@ -74,6 +75,12 @@ namespace Kesmai.WorldForge.Windows
 							_comboBoxButton.SelectedItems.Add(item);
 					}
 				}
+				if (propValue is Direction dir)
+                {
+					var item = sources.FirstOrDefault(i => (Direction)i.Value == dir);
+					if (item != null)
+						_comboBoxButton.SelectedItems.Add(item);
+                }
 			}
 
 			Children.Add(_comboBoxButton);
@@ -87,8 +94,9 @@ namespace Kesmai.WorldForge.Windows
 			{
 				var propertyInfo = _parent.PropertyInfo;
 				var source = _parent.Source;
+				var propValue = propertyInfo.GetValue(source);
 
-				if (propertyInfo.GetValue(source) is IList values)
+				if (propValue is IList values)
 				{
 					foreach (var newItem in e.NewItems)
 					{
@@ -103,6 +111,15 @@ namespace Kesmai.WorldForge.Windows
 					}
 					
 					propertyInfo.SetValue(source, values, null);
+				}
+
+				if (propValue is Direction dir)
+                {
+					foreach (var newItem in e.NewItems)
+					{
+						if (newItem is Item item)
+							propertyInfo.SetValue(source, (Direction)item.Value, null);
+					}
 				}
 			}
 		}

--- a/Source/Kesmai.WorldForge/Game/UI/Windows/ComponentsWindow.cs
+++ b/Source/Kesmai.WorldForge/Game/UI/Windows/ComponentsWindow.cs
@@ -116,6 +116,28 @@ namespace Kesmai.WorldForge.Windows
 				
 				foreach (var button in SelectedItem.Component.GetInspectorActions())
 					_actionsPanel.Children.Add(button);
+
+				var deleteButton = new Button()
+				{
+					Content = new TextBlock()
+					{
+						Foreground = Color.OrangeRed,
+						Shadow = Color.Black,
+
+						Font = "Tahoma14Bold",
+						Text = "Delete",
+
+						Margin = new Vector4F(3, 3, 3, 3)
+					}
+				};
+
+				deleteButton.Click += (o, args) =>
+				{
+					_tile.RemoveComponent(SelectedItem.Component);
+					OnLoad();
+					//todo: onLoad() causes the component window to refresh,  showing the component is removed, but I can't figure out how to get a reference to the current world render from here to invalidate it.
+				};
+				_actionsPanel.Children.Add(deleteButton);
 			}
 		}
 

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -31,7 +31,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="*"></RowDefinition>
-                <RowDefinition Height="64"></RowDefinition>
+                <RowDefinition Height="114"></RowDefinition>
                 <RowDefinition Height="200"></RowDefinition>
             </Grid.RowDefinitions>
             
@@ -72,9 +72,12 @@
             <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                      SelectedObject="{Binding SelectedEntity}"
                                      AutoGenerateItems="False"
+                                     SortDirection="{x:Null}"
                                      DisableAnimationOnObjectSelection="True">
                 <syncfusion:PropertyGrid.Items>
                     <syncfusion:PropertyGridItem PropertyName="Name" />
+                    <syncfusion:PropertyGridItem PropertyName="XP" />
+                    <syncfusion:PropertyGridItem PropertyName="HP" />
                 </syncfusion:PropertyGrid.Items>
             </syncfusion:PropertyGrid>
             <StackPanel Grid.Row="3" Margin="0,3,0,0">

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -56,6 +56,7 @@
             </ToolBar>
             
             <ListBox Width="300" Grid.Row="1"
+                        x:Name="_entityList"
                         ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
                         SelectedItem="{Binding SelectedEntity, Mode=TwoWay}"
                         SelectionMode="Single">

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -113,7 +113,7 @@
                 </TabControl.ItemTemplate>
                 <TabControl.ContentTemplate>
                     <DataTemplate>
-                        <scripting:ScriptEditor Script="{Binding}" IsEnabled="{Binding IsEnabled}" />
+                        <scripting:ScriptEditor Script="{Binding}" IsEnabled="{Binding IsEnabled}" x:Name="_editor"/>
                     </DataTemplate>
                 </TabControl.ContentTemplate>
             </TabControl>

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -77,10 +77,19 @@
                     <syncfusion:PropertyGridItem PropertyName="Name" />
                 </syncfusion:PropertyGrid.Items>
             </syncfusion:PropertyGrid>
-            <ListBox Grid.Row="3" Margin="0,3,0,0"
-                      x:Name="_spawnersList"
-                      ItemsSource="{Binding RelatedSpawners}">
-            </ListBox>
+            <StackPanel Grid.Row="3" Margin="0,3,0,0">
+                <TextBlock Margin="7,0,0,0" FontWeight="Bold">Spawns In</TextBlock>
+                <ListBox
+                    BorderBrush="White"
+                    x:Name="_spawnersList"
+                    ItemsSource="{Binding RelatedSpawners}">
+                    <ListBox.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Jump to Spawn Definition" Command="{Binding JumpSpawnerCommand}"/>
+                        </ContextMenu>
+                    </ListBox.ContextMenu>
+                </ListBox>
+            </StackPanel>
         </Grid>
         
         <Border Margin="2" Grid.Column="1"

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -55,20 +55,18 @@
                 </ToolBar.Items>
             </ToolBar>
             
-            <ScrollViewer Grid.Row="1">
-                <ListBox Width="300"
-                         ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
-                         SelectedItem="{Binding SelectedEntity, Mode=TwoWay}"
-                         SelectionMode="Single">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-                               <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-            </ScrollViewer>
+            <ListBox Width="300" Grid.Row="1"
+                        ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
+                        SelectedItem="{Binding SelectedEntity, Mode=TwoWay}"
+                        SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+                            <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
             
             <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                      SelectedObject="{Binding SelectedEntity}"

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
@@ -78,6 +78,7 @@ namespace Kesmai.WorldForge.UI.Documents
 			private void OnEntityChanged(EntitiesDocument recipient, EntitiesViewModel.SelectedEntityChangedMessage message)
 		{
 			_scriptsTabControl.SelectedIndex = 0;
+			_entityList.ScrollIntoView(_entityList.SelectedItem);
 		}
 	}
 

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
@@ -149,6 +149,7 @@ namespace Kesmai.WorldForge.UI.Documents
 		public RelayCommand AddEntityCommand { get; set; }
 		public RelayCommand<Entity> RemoveEntityCommand { get; set; }
 		public RelayCommand<Entity> CopyEntityCommand { get; set; }
+		public RelayCommand JumpSpawnerCommand { get; set; }
 
 		public EntitiesViewModel(Segment segment)
 		{
@@ -164,8 +165,27 @@ namespace Kesmai.WorldForge.UI.Documents
 				(entity) => (SelectedEntity != null));
 			CopyEntityCommand.DependsOn(() => SelectedEntity);
 
-			
+			JumpSpawnerCommand = new RelayCommand(JumpSpawner);
 
+		}
+
+		public void JumpSpawner()
+		{
+			var spawnRequest = WeakReferenceMessenger.Default.Send<EntitiesDocument.GetSelectedSpawner>();
+			var spawn = spawnRequest.Response;
+			var presenter = ServiceLocator.Current.GetInstance<ApplicationPresenter>();
+			if (spawnRequest.HasReceivedResponse)
+			{
+				Spawner target = spawnRequest.Response;
+				var ActiveDocument = presenter.Documents.Where(d => d is SpawnsViewModel).FirstOrDefault() as SpawnsViewModel;
+				presenter.ActiveDocument = ActiveDocument;
+				if (target is LocationSpawner)
+					(ActiveDocument as SpawnsViewModel).SelectedLocationSpawner = target as LocationSpawner;
+				if (target is RegionSpawner)
+					(ActiveDocument as SpawnsViewModel).SelectedRegionSpawner = target as RegionSpawner;
+				WeakReferenceMessenger.Default.Send(target as Spawner);
+			}
+			WeakReferenceMessenger.Default.Send(spawn as Spawner);
 		}
 
 		public void AddEntity()

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
@@ -50,6 +50,10 @@ namespace Kesmai.WorldForge.UI.Documents
 		public class GetSelectedSpawner : RequestMessage<Spawner>
 		{
 		}
+		public class GetCurrentScriptSelection : RequestMessage<String>
+		{
+		}
+
 		public EntitiesDocument()
 		{
 			InitializeComponent();
@@ -63,6 +67,9 @@ namespace Kesmai.WorldForge.UI.Documents
 
 			WeakReferenceMessenger.Default.Register<EntitiesDocument, GetSelectedSpawner>(this,
 					(r, m) => m.Reply(_spawnersList.SelectedItem as Spawner));
+
+			WeakReferenceMessenger.Default.Register<EntitiesDocument, GetCurrentScriptSelection>(this,
+				(r, m) => m.Reply(GetScriptSelection()));
 		}
 
 		private void ChangeEntity(Entity entity)
@@ -79,6 +86,18 @@ namespace Kesmai.WorldForge.UI.Documents
 		{
 			_scriptsTabControl.SelectedIndex = 0;
 			_entityList.ScrollIntoView(_entityList.SelectedItem);
+		}
+
+		public String GetScriptSelection ()
+        {
+			if (_scriptsTabControl.HasItems)
+			{
+				ContentPresenter cp = _scriptsTabControl.Template.FindName("PART_SelectedContentHost", _scriptsTabControl) as ContentPresenter;
+				ScriptEditor editor = _scriptsTabControl.ContentTemplate.FindName("_editor", cp) as ScriptEditor;
+				return editor.SelectedText;
+			} else 
+				return null;
+
 		}
 	}
 

--- a/Source/Kesmai.WorldForge/UI/Documents/LocationsDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/LocationsDocument.xaml
@@ -55,40 +55,38 @@
                 </ToolBar.Items>
             </ToolBar>
             
-            <ScrollViewer Grid.Row="1">
-                <ListBox Width="300" 
-                         ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
-                         SelectedItem="{Binding SelectedLocation, Mode=TwoWay}"
-                         SelectionMode="Single">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal" 
-                                        VerticalAlignment="Center">
-                                <TextBlock FontWeight="Bold" x:Name="locationName" Text="{Binding Name}" Margin="3" />
-                                <TextBlock FontStyle="Italic" x:Name="locationPoint" TextAlignment="Right" Margin="3">
-                                    <TextBlock.Text>
-                                        <MultiBinding StringFormat="X: {0} Y: {1} Region: {2}">
-                                            <Binding Path="X" />
-                                            <Binding Path="Y" />
-                                            <Binding Path="Region" />
-                                        </MultiBinding>
-                                    </TextBlock.Text>
-                                </TextBlock>
-                            </StackPanel>
+            <ListBox Width="300" Grid.Row="1"
+                        ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
+                        SelectedItem="{Binding SelectedLocation, Mode=TwoWay}"
+                        SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" 
+                                    VerticalAlignment="Center">
+                            <TextBlock FontWeight="Bold" x:Name="locationName" Text="{Binding Name}" Margin="3" />
+                            <TextBlock FontStyle="Italic" x:Name="locationPoint" TextAlignment="Right" Margin="3">
+                                <TextBlock.Text>
+                                    <MultiBinding StringFormat="X: {0} Y: {1} Region: {2}">
+                                        <Binding Path="X" />
+                                        <Binding Path="Y" />
+                                        <Binding Path="Region" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
+                        </StackPanel>
                         
-                            <DataTemplate.Triggers>
-                                <DataTrigger Binding="{Binding IsReserved}" Value="True">
-                                    <Setter TargetName="locationName" Property="Foreground" Value="DodgerBlue"/>
-                                </DataTrigger>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsReserved}" Value="True">
+                                <Setter TargetName="locationName" Property="Foreground" Value="DodgerBlue"/>
+                            </DataTrigger>
                                 
-                                <DataTrigger Binding="{Binding Region}" Value="0">
-                                    <Setter TargetName="locationPoint" Property="Foreground" Value="Red"/>
-                                </DataTrigger>
-                            </DataTemplate.Triggers>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-            </ScrollViewer>
+                            <DataTrigger Binding="{Binding Region}" Value="0">
+                                <Setter TargetName="locationPoint" Property="Foreground" Value="Red"/>
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
             
             <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                      SelectedObject="{Binding SelectedLocation}"

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
@@ -172,7 +172,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"></RowDefinition>
                         <RowDefinition Height="*"></RowDefinition>
-                        <RowDefinition Height="244"></RowDefinition>
+                        <RowDefinition Height="295"></RowDefinition>
                         <RowDefinition Height="120"></RowDefinition>
                         <RowDefinition Height="120"></RowDefinition>
                     </Grid.RowDefinitions>
@@ -219,6 +219,8 @@
                             <syncfusion:PropertyGridItem PropertyName="Density" IsReadOnly="True" />
                             <syncfusion:PropertyGridItem PropertyName="AverageMobs" IsReadOnly="True" />
                             <syncfusion:PropertyGridItem PropertyName="OpenFloorTiles" IsReadOnly="True" />
+                            <syncfusion:PropertyGridItem PropertyName="TotalHP" IsReadOnly="True" />
+                            <syncfusion:PropertyGridItem PropertyName="TotalXP" IsReadOnly="True" />
                         </syncfusion:PropertyGrid.Items>
                     </syncfusion:PropertyGrid>
                     

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
@@ -61,6 +61,7 @@
                     </ToolBar>
 
                     <ListBox Width="300" Grid.Row="1"
+                                x:Name="_locationSpawnerList"
                                 ItemsSource="{Binding Source={StaticResource collectionViewSourceLocation}}" 
                                 SelectedItem="{Binding SelectedLocationSpawner, Mode=TwoWay}"
                                 SelectionMode="Single"
@@ -191,6 +192,7 @@
                     </ToolBar>
                     
                     <ListBox Width="300" Grid.Row="1"
+                                x:Name="_regionSpawnerList"
                                 ItemsSource="{Binding Source={StaticResource collectionViewSourceRegion}}" 
                                 SelectedItem="{Binding SelectedRegionSpawner, Mode=TwoWay}"
                                 SelectedIndex="0">

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
@@ -59,23 +59,21 @@
                             </Button>
                         </ToolBar.Items>
                     </ToolBar>
-                    
-                    <ScrollViewer Grid.Row="1">
-                        <ListBox Width="300"
-                                 ItemsSource="{Binding Source={StaticResource collectionViewSourceLocation}}" 
-                                 SelectedItem="{Binding SelectedLocationSpawner, Mode=TwoWay}"
-                                 SelectionMode="Single"
-                                 SelectedIndex="0">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </ScrollViewer>
-                    
+
+                    <ListBox Width="300" Grid.Row="1"
+                                ItemsSource="{Binding Source={StaticResource collectionViewSourceLocation}}" 
+                                SelectedItem="{Binding SelectedLocationSpawner, Mode=TwoWay}"
+                                SelectionMode="Single"
+                                SelectedIndex="0">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
                     <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                              SelectedObject="{Binding SelectedLocationSpawner}"
                                              SortDirection="{x:Null}"
@@ -192,20 +190,18 @@
                         </ToolBar.Items>
                     </ToolBar>
                     
-                    <ScrollViewer Grid.Row="1">
-                        <ListBox Width="300"
-                                 ItemsSource="{Binding Source={StaticResource collectionViewSourceRegion}}" 
-                                 SelectedItem="{Binding SelectedRegionSpawner, Mode=TwoWay}"
-                                 SelectedIndex="0">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </ScrollViewer>
+                    <ListBox Width="300" Grid.Row="1"
+                                ItemsSource="{Binding Source={StaticResource collectionViewSourceRegion}}" 
+                                SelectedItem="{Binding SelectedRegionSpawner, Mode=TwoWay}"
+                                SelectedIndex="0">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                     
                     <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                              SelectedObject="{Binding SelectedRegionSpawner}"

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
@@ -70,6 +70,7 @@ namespace Kesmai.WorldForge.UI.Documents
 				_locationPresenter.Region = segment.GetRegion(spawn.Region);
 				_locationPresenter.SetLocation(spawn);
 			}
+			_locationSpawnerList.ScrollIntoView(_locationSpawnerList.SelectedItem);
 		}
 
 		private void OnRegionSpawnerChanged(SpawnsDocument recipient, SpawnsViewModel.SelectedRegionSpawnerChangedMessage message)
@@ -85,6 +86,7 @@ namespace Kesmai.WorldForge.UI.Documents
 				_regionPresenter.Region = segment.GetRegion(spawn.Region);
 				_regionPresenter.SetLocation(spawn);
 			}
+			_regionSpawnerList.ScrollIntoView(_regionSpawnerList.SelectedItem);
 		}
 
 	}

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
@@ -44,6 +44,9 @@ namespace Kesmai.WorldForge.UI.Documents
 		public Entity GetSelectedEntity()
 		{
 			SpawnEntry entry = null;
+			var presenter = ServiceLocator.Current.GetInstance<ApplicationPresenter>();
+			if (presenter.ActiveDocument is not SpawnsViewModel)
+				return null;
 			if (_typeSelector.SelectedIndex == 0)
 			{
 				entry = _locationEntities.SelectedItem as SpawnEntry;

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml.cs
@@ -138,7 +138,10 @@ namespace Kesmai.WorldForge.UI.Documents
 				SetProperty(ref _selectedRegionSpawner, value, true);
 
 				if (value != null)
+				{
 					WeakReferenceMessenger.Default.Send(new SelectedRegionSpawnerChangedMessage(value));
+					value.CalculateStats();
+				}
 			}
 		}
 

--- a/Source/Kesmai.WorldForge/UI/Documents/SubregionDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SubregionDocument.xaml
@@ -51,18 +51,16 @@
                 </ToolBar.Items>
             </ToolBar>
             
-            <ScrollViewer Grid.Row="1">
-                <ListBox Width="300" 
-                         ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
-                         SelectedItem="{Binding SelectedSubregion, Mode=TwoWay}"
-                         SelectionMode="Single">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-            </ScrollViewer>
+            <ListBox Width="300" Grid.Row="1"
+                        ItemsSource="{Binding Source={StaticResource collectionViewSource}}"
+                        SelectedItem="{Binding SelectedSubregion, Mode=TwoWay}"
+                        SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
             
             <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                      SelectedObject="{Binding SelectedSubregion}"

--- a/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml
@@ -34,7 +34,8 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="*"></RowDefinition>
-                <RowDefinition Height="200"></RowDefinition>
+                <RowDefinition Height="64"></RowDefinition>
+                <RowDefinition Height="78"></RowDefinition>
                 <RowDefinition Height="200"></RowDefinition>
             </Grid.RowDefinitions>
             
@@ -88,6 +89,20 @@
                          VerticalScrollBarVisibility="Visible"
                          Text="{Binding SelectedTreasure.Notes, UpdateSourceTrigger=PropertyChanged}"/>
             </GroupBox>
+
+            <StackPanel Grid.Row="4" Margin="0,3,0,0">
+                <TextBlock Margin="7,0,0,0" FontWeight="Bold">Dropped By</TextBlock>
+                <ListBox                    
+                    BorderBrush="White"
+                    x:Name="_entitiesList"
+                    ItemsSource="{Binding RelatedEntities}">
+                    <ListBox.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Jump to Entity Definition" Command="{Binding JumpEntityCommand}"/>
+                        </ContextMenu>
+                    </ListBox.ContextMenu>
+                </ListBox>
+            </StackPanel>
         </Grid>
         
         <Border Margin="2" Grid.Column="1"

--- a/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml
@@ -59,6 +59,7 @@
             </ToolBar>
             
             <ListBox Width="300" Grid.Row="1"
+                        x:Name="_treasuresList"
                         ItemsSource="{Binding Source={StaticResource collectionViewSourceTreasures}}" 
                         SelectedItem="{Binding SelectedTreasure}"
                         SelectionMode="Single">

--- a/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml
@@ -58,20 +58,18 @@
                 </ToolBar.Items>
             </ToolBar>
             
-            <ScrollViewer Grid.Row="1">
-                <ListBox Width="300"
-                         ItemsSource="{Binding Source={StaticResource collectionViewSourceTreasures}}" 
-                         SelectedItem="{Binding SelectedTreasure}"
-                         SelectionMode="Single">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-            </ScrollViewer>
+            <ListBox Width="300" Grid.Row="1"
+                        ItemsSource="{Binding Source={StaticResource collectionViewSourceTreasures}}" 
+                        SelectedItem="{Binding SelectedTreasure}"
+                        SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock FontWeight="Bold" Text="{Binding Name}" Margin="3" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
             
             <syncfusion:PropertyGrid Grid.Row="2" Margin="0,3,0,0"
                                      SelectedObject="{Binding SelectedTreasure}"

--- a/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/TreasuresDocument.xaml.cs
@@ -7,6 +7,7 @@ using Kesmai.WorldForge.Scripting;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Mvvm.Messaging;
+using Microsoft.Toolkit.Mvvm.Messaging.Messages;
 
 namespace Kesmai.WorldForge.UI.Documents
 {
@@ -24,11 +25,20 @@ namespace Kesmai.WorldForge.UI.Documents
 		public TreasuresDocument()
 		{
 			InitializeComponent();
+
+			WeakReferenceMessenger.Default
+				.Register<TreasuresDocument, TreasuresViewModel.SelectedTreasureChangedMessage>(this, (r, m) => { _treasuresList.ScrollIntoView(_treasuresList.SelectedItem); });
 		}
 	}
 
 	public class TreasuresViewModel : ObservableRecipient
 	{
+		public class SelectedTreasureChangedMessage : ValueChangedMessage<SegmentTreasure>
+		{
+			public SelectedTreasureChangedMessage(SegmentTreasure value) : base(value)
+			{
+			}
+		}
 		public string Name => "(Treasures)";
 		
 		private Segment _segment;
@@ -43,7 +53,13 @@ namespace Kesmai.WorldForge.UI.Documents
 		public SegmentTreasure SelectedTreasure
 		{
 			get => _selectedTreasure;
-			set => SetProperty(ref _selectedTreasure, value, true);
+			set
+			{
+				SetProperty(ref _selectedTreasure, value, true);
+
+				if (value != null)
+					WeakReferenceMessenger.Default.Send(new SelectedTreasureChangedMessage(value));
+			}
 		}
 		
 		public TreasureEntry SelectedTreasureEntry


### PR DESCRIPTION
Enhancements:
* Paint tool now behaves like Draw tool in that a painted floor-type component will overwrite other floor-type components. Append instead with Shift. Paint ONLY the selected component and clobber all existing components with ALT.
* When using the delete hotkey, Only currently visible components are deleted from the selected tile. Filter to floors to remove floor-type components, etc.
* When pasting from the clipboard, the behavior is changed if the target selection is more than 1x1. Old behavior, or if the target selection is 1x1: whole clipboard is pasted in starting with the top left tile as the current selection. New behavior if the target selection is larger than 1x1: the clipboard is tiled horizontally and vertically to fill the selected space. Clipboard tiles that extend beyond the selection are not applied.
* Tile Component Editor (double click a tile) now has a delete action button to remove a specific component without removing all other components.
* Counter property editor now reads and writes accessDirection. This is a bit of a workaround. Only the LAST entry selected will be saved to the mapproj. The editor does not show that previous values are cleared unless you close the component editor or navigate to another component on the tile and back.
* When editing components, changes to color, static IDs and other properties are periodically rendered on the world screen. Previously, the editor had to be closed and the world moved to trigger a new render.
* Using the Ctrl-T hotkey to jump to the Treasures tab will now jump directly to a Treasure definition if coming from the Entities tab if the currently selected text matches a Treasure name.
* When jumping to Entities, Spawns or Treasures, the list will scroll to bring the destination entry into view.
* Treasures Document has a listing showing all Entities using that Treasure name. This is not code interpretation, but simple string matching. An Entity with a comment containing the Treasure name will still appear in the list.
* On the Entities, Spawns and Treasures documents, the lists of related objects have a right-click context menu that will jump directly to that record in the related tab.

Fixes:
* Lists for Entities, Spawns, Locations, Subregions, Treasures all now correctly receive mouse scroll input
* A few sprites (ones that were not 100x100 and had offsets, will now render correctly when zooming in and out. Thanks Midgit.

Entity, Spawn, Treasure, and Location hotkeys only jump to a specific entry if the tab has already been loaded. The Documents don't initialize and register themselves for the event I send until the user opens them manually once. If anyone knows how to force them to initialize on segment load, please let me know. My Google-fu has failed me.