### PR TITLE
Search for experience assignment from syntax tree.

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Entity.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Entity.cs
@@ -56,8 +56,7 @@ namespace Kesmai.WorldForge
 				/* Create a syntax tree for analysis. */
 				var syntaxTree = CSharpSyntaxTree.ParseText(onSpawnScript.Blocks[1]);
 				var syntaxRoot = syntaxTree.GetCompilationUnitRoot();
-				var allNodes = syntaxRoot.DescendantNodes().Where(n => n is AssignmentExpressionSyntax assignmentSyntax);
-				
+
 				/* Find a node that is an assignment, where the left identifier is "Experience" */
 				var experienceAssignment = syntaxRoot
 					.DescendantNodes().LastOrDefault(


### PR DESCRIPTION
For @yarrim as a concept on how to search through a SyntaxTree of a particular script block. This might catch issues where experience is assigned twice, or in a way that the regex fails.