### PR TITLE
Leng Bridge Troll Can Charge Now

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75821,6 +75821,7 @@
         MaxHealth = 250, Health = 250,
         BaseDodge = 13,
         HideDetection = 23,
+        CanCharge = 1,
 
         Experience = 10500,
         

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Leng" version="0.86.0.0">
+<segment name="Leng" version="0.87.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -74909,6 +74909,11 @@
     <subregion name="Sandylair" type="Lair" region="10">
       <rectangles>
         <rectangle left="33" top="2" right="39" bottom="5" />
+      </rectangles>
+    </subregion>
+    <subregion name="priestTemple" type="Town" region="254">
+      <rectangles>
+        <rectangle left="0" top="0" right="5" bottom="7" />
       </rectangles>
     </subregion>
   </subregions>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75821,7 +75821,7 @@
         MaxHealth = 250, Health = 250,
         BaseDodge = 13,
         HideDetection = 23,
-        CanCharge = 1,
+        CanCharge = true,
 
         Experience = 10500,
         

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75815,7 +75815,7 @@
         <block><![CDATA[]]></block>
         <block><![CDATA[
 
-    //Prone 100% chance might need to be toned down but he moves 2 and doesn't charge so I thought it would be fun.
+    //Prone 100% and Charge now. Let's up the fun.
     var bridgeTroll = new ElderTroll()
     {
         MaxHealth = 250, Health = 250,

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -195,7 +195,7 @@
             BaseDodge = 10;
     
             Experience = 50;
-            Movement = 1;
+            Movement = 3;
     
             Alignment = Alignment.Lawful;
 			

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/WeakStrengthRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/WeakStrengthRing.cs
@@ -18,7 +18,7 @@ namespace Kesmai.Server.Items
 		/// </summary>
 		public override int Weight => 20;
 
-		public override int StrengthBonus => 3;
+		public override int StrengthBonus => 1;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="WeakStrengthRing"/> class.


### PR DESCRIPTION
The leng bridge troll needed some flair. Keep the Bridge Troll to be 2 hex movement, but make sure he can charge. He can only melee, so could easily be outran by adventures still, unless of course in sand.. muhahaha. 