### PR TITLE
WorldForge 1/28

### DIFF
--- a/Source/Kesmai.WorldForge/UI/ApplicationWindow.xaml
+++ b/Source/Kesmai.WorldForge/UI/ApplicationWindow.xaml
@@ -209,7 +209,7 @@
                         </LayoutDocumentPane>
                     </LayoutDocumentPaneGroup>
                     
-                    <LayoutAnchorablePane FloatingWidth="365" DockWidth="365" DockMinWidth="365">
+                    <LayoutAnchorablePane FloatingWidth="365" DockWidth="365" DockMinWidth="365" >
                         <LayoutAnchorable x:Name="_componentsWindow" Title="Components" ContentId="component">
                                 <ui:ComponentsPanel Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" 
                                                     OpacityMask="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
@@ -231,6 +231,7 @@
             <DockingManager.LayoutItemContainerStyle>
                 <Style TargetType="{x:Type LayoutItem}" >
                     <Setter Property="Title" Value="{Binding Model.Name}" />
+                    <Setter Property="CanClose" Value="False" />
                 </Style>
             </DockingManager.LayoutItemContainerStyle>
            

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -138,7 +138,17 @@
                 </TabControl.ItemTemplate>
                 <TabControl.ContentTemplate>
                     <DataTemplate>
-                        <scripting:ScriptEditor Script="{Binding}" IsEnabled="{Binding IsEnabled}" x:Name="_editor"/>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"></RowDefinition>
+                                <RowDefinition Height="72"></RowDefinition>
+                            </Grid.RowDefinitions>
+                            <scripting:ScriptEditor Script="{Binding}" IsEnabled="{Binding IsEnabled}" x:Name="_editor" Grid.Row="0"/>
+                            <Border Grid.Row="1" Margin="2" Padding="2"
+                                BorderBrush="Black" BorderThickness="1">
+                                <TextBlock Text="Here are some issues" x:Name="_scriptIssues" />
+                            </Border>
+                        </Grid>
                     </DataTemplate>
                 </TabControl.ContentTemplate>
             </TabControl>

--- a/Source/Kesmai.WorldForge/UI/Windows/WhatsNewWindow.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Windows/WhatsNewWindow.xaml.cs
@@ -29,6 +29,17 @@ $@"
 <h3>=== {Core.Version} ===</h3>
 <strong>Enhancements:</strong>
 <ul>
+<li>When saving a segment, all script sections are checked for correct syntax. Mismatched brackets or missing semicolons should be called out here. If prompted that there are syntax errors, choosing not to continue will abort the save action and jump to the script with an issue.</li>
+</ul>
+<br/>
+<strong>Fixes:</strong>
+<ul>
+<li>Removed a crash when selecting a treeComponent if the data sent from the server does not define a live\dead sprite pair</li>
+</ul>
+</br>
+<h3>=== 0.87.0.0 ===</h3>
+<strong>Enhancements:</strong>
+<ul>
 <li>Added a Help Menu with a ""What's New"" window and a link to the WoldForge article on the wiki.</li>
 <li>Added a calculated 'Threat' metric to Entities. This (m,r) notation shows skill levels in melee and ranged damage respectively. Threat does not take into account the weapon used or any custom damage ranges, only skill. Magic skill levels are doubled. This threat metric, as well as HP and XP is now presented in the datagrid for Spawners.</li>
 <li>Component Editor has two new buttons for reordering components. This generally has no effect on gameplay, but certain components can layer.</li>


### PR DESCRIPTION
Enhancements:
* When saving a segment, all script sections are checked for correct syntax. Mismatched brackets or missing semicolons should be called out here. If prompted that there are syntax errors, choosing not to continue will abort the save action and jump to the script with an issue.
* Removed close option from Region Tabs. Resolves #1219