### PR TITLE
Update Kesmai.mapproj

### DIFF
--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -107,7 +107,7 @@
         var lesserPrice = (int)(item.BasePrice * 1);
         var higherPrice = (int)(item.BasePrice * 0.4);
         
-        item.Price = Utility.RandomBetween(-lesserPrice, higherPrice);
+        item.Price = Utility.RandomBetween(lesserPrice, higherPrice);
     }
     
     public static void gemsPriceMutatorHigh(MobileEntity entity, Container source, ItemEntity item)
@@ -96543,9 +96543,9 @@
     
     kobold.AddGold(20);
     kobold.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       1,     gemsPriceMutatorAboveAverage),
+        new LootPackEntry(true, kesmai12Gems,       6,     gemsPriceMutatorAboveAverage),
         new LootPackEntry(true, dungeon1Bottles,    20),
-        new LootPackEntry(true, dungeon1Treasure,   1.63)
+        new LootPackEntry(true, dungeon1Treasure,   2)
     ));
     
     return kobold;
@@ -96593,9 +96593,9 @@
             
     orc.AddGold(42);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       1,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       6,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon1Bottles,    20),
-        new LootPackEntry(true, dungeon1Treasure,   1.5),
+        new LootPackEntry(true, dungeon1Treasure,   2),
         new LootPackEntry(true, (from, container) => new ThrowingHammer(), 16)
     ));
     
@@ -96648,9 +96648,9 @@
             
     orc.AddGold(42);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       1,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       6,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon1Bottles,    20),
-        new LootPackEntry(true, dungeon1Treasure,   1.5)
+        new LootPackEntry(true, dungeon1Treasure,   2)
     ));
     
     return orc;
@@ -96695,9 +96695,9 @@
     
     skeleton.AddGold(30);
     skeleton.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       1,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       6,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon1Bottles,    20),
-        new LootPackEntry(true, dungeon1Treasure,   1.5)
+        new LootPackEntry(true, dungeon1Treasure,   2)
     ));
     
     return skeleton;
@@ -96742,9 +96742,9 @@
             
     skeleton.AddGold(30);
     skeleton.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       1,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       6,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon1Bottles,    20),
-        new LootPackEntry(true, dungeon1Treasure,   1.5)
+        new LootPackEntry(true, dungeon1Treasure,   2)
     ));
     
     return skeleton;
@@ -96803,9 +96803,9 @@
             
     wyvern.AddGold(42);
     wyvern.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       1,     gemsPriceMutator),
+        new LootPackEntry(true, kesmai12Gems,       6,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon1Bottles,    20),
-        new LootPackEntry(true, dungeon1Treasure,   1.50)
+        new LootPackEntry(true, dungeon1Treasure,   2)
     ));
     
     return wyvern;
@@ -96869,7 +96869,7 @@
         
         new LootPackEntry(true, (from, container) => new ClearBalm(),               100.0),
         new LootPackEntry(true, (from, container) => new RamSkull(),                100.0),
-        new LootPackEntry(true, (from, container) => new IronOre(),                  5.0),
+        new LootPackEntry(true, (from, container) => new Yttril(),                  33.0),
         new LootPackEntry(true, kesmaiwideGems,       100,     gemsPriceMutatorHigh),
         new LootPackEntry(true, (from, container) => new FireProtectionAmulet(),    20.0)
     ));
@@ -97768,12 +97768,12 @@
             
     goblin.AddGold(42);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorMedium),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorMedium),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.37),
-        new LootPackEntry(true, dungeon2Rings,      0.37),
+        new LootPackEntry(true, dungeon2Treasure,   0.74),
+        new LootPackEntry(true, dungeon2Rings,      0.74),
         new LootPackEntry(true, (from, container) => new LeatherGauntlets(), 7.5),
-        new LootPackEntry(true, utilityItems,   0.37)
+        new LootPackEntry(true, utilityItems,   0.74)
     ));
     
     return goblin;
@@ -97817,12 +97817,12 @@
             
     goblin.AddGold(42);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorMedium),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorMedium),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.37),
-        new LootPackEntry(true, dungeon2Rings,      0.37),
+        new LootPackEntry(true, dungeon2Treasure,   0.74),
+        new LootPackEntry(true, dungeon2Rings,      0.74),
         new LootPackEntry(true, (from, container) => new LeatherGauntlets(), 7.5),
-        new LootPackEntry(true, utilityItems,   0.37)
+        new LootPackEntry(true, utilityItems,   0.74)
     ));
     
     return goblin;
@@ -97868,10 +97868,10 @@
             
     orc.AddGold(49);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.5),
-        new LootPackEntry(true, dungeon2Rings,      0.5),
+        new LootPackEntry(true, dungeon2Treasure,   1),
+        new LootPackEntry(true, dungeon2Rings,      1),
         new LootPackEntry(true, (from, container) => new ThrowingHammer(), 16),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
@@ -97917,10 +97917,10 @@
             
     orc.AddGold(49);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.5),
-        new LootPackEntry(true, dungeon2Rings,      0.5),
+        new LootPackEntry(true, dungeon2Treasure,   1),
+        new LootPackEntry(true, dungeon2Rings,      1),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
     
@@ -97967,10 +97967,10 @@
             
     skeleton.AddGold(42);
     skeleton.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.5),
-        new LootPackEntry(true, dungeon2Rings,      0.5),
+        new LootPackEntry(true, dungeon2Treasure,   1),
+        new LootPackEntry(true, dungeon2Rings,      1),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
     
@@ -98018,9 +98018,9 @@
     troll.AddGold(56);
     troll.AddLoot(
         new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorAboveAverage),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorAboveAverage),
             new LootPackEntry(true, dungeon2Bottles,    20),
-            new LootPackEntry(true, dungeon2Treasure,   0.55),
+            new LootPackEntry(true, dungeon2Treasure,   1.1),
         new LootPackEntry(true, utilityItems,   0.55)
         ));
     
@@ -98079,10 +98079,10 @@
             
     wyvern.AddGold(49);
     wyvern.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.5),
-        new LootPackEntry(true, dungeon2Rings,      0.5),
+        new LootPackEntry(true, dungeon2Treasure,   1),
+        new LootPackEntry(true, dungeon2Rings,      1),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
     
@@ -98137,10 +98137,10 @@
 
     wight.AddGold(42);
     wight.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.5),
-        new LootPackEntry(true, dungeon2Rings,      0.5),
+        new LootPackEntry(true, dungeon2Treasure,   1),
+        new LootPackEntry(true, dungeon2Rings,      1),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
     
@@ -98195,10 +98195,10 @@
             
     orc.AddGold(49);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorNormal),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon2Bottles,    20),
-        new LootPackEntry(true, dungeon2Treasure,   0.5),
-        new LootPackEntry(true, dungeon2Rings,      0.5),
+        new LootPackEntry(true, dungeon2Treasure,   1),
+        new LootPackEntry(true, dungeon2Rings,      1),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
     
@@ -98244,9 +98244,9 @@ return orc;
     enragedTroll.AddGold(56);
     enragedTroll.AddLoot(
         new LootPack(
-        new LootPackEntry(true, kesmaiwideGems,       2,     gemsPriceMutatorAboveAverage),
+        new LootPackEntry(true, kesmai12Gems,       12,     gemsPriceMutatorAboveAverage),
             new LootPackEntry(true, dungeon2Bottles,    20),
-            new LootPackEntry(true, dungeon2Treasure,   0.55)
+            new LootPackEntry(true, dungeon2Treasure,   1.1)
         ));
                 
     return enragedTroll;
@@ -98343,8 +98343,8 @@ return orc;
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorAboveAverage),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.55),
-        new LootPackEntry(true, dungeon3Rings,      0.55),
+        new LootPackEntry(true, dungeon3Treasure,   1.1),
+        new LootPackEntry(true, dungeon3Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5)
@@ -98393,8 +98393,8 @@ return orc;
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.5),
-        new LootPackEntry(true, dungeon3Rings,      0.5),
+        new LootPackEntry(true, dungeon3Treasure,   1),
+        new LootPackEntry(true, dungeon3Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5)
@@ -98443,8 +98443,8 @@ return orc;
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.5),
-        new LootPackEntry(true, dungeon3Rings,      0.5),
+        new LootPackEntry(true, dungeon3Treasure,   1),
+        new LootPackEntry(true, dungeon3Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5)
@@ -98493,8 +98493,8 @@ return orc;
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.5),
-        new LootPackEntry(true, dungeon3Rings,      0.5),
+        new LootPackEntry(true, dungeon3Treasure,   1),
+        new LootPackEntry(true, dungeon3Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5)
@@ -98541,9 +98541,9 @@ return orc;
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorMedium),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.37),
-        new LootPackEntry(true, dungeon3Rings,      0.37),
-        new LootPackEntry(true, dungeon3Potions,    0.37),
+        new LootPackEntry(true, dungeon3Treasure,   0.74),
+        new LootPackEntry(true, dungeon3Rings,      0.74),
+        new LootPackEntry(true, dungeon3Potions,    0.74),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.37)
     ));
@@ -98589,9 +98589,9 @@ return orc;
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorMedium),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.37),
-        new LootPackEntry(true, dungeon3Rings,      0.37),
-        new LootPackEntry(true, dungeon3Potions,    0.37),
+        new LootPackEntry(true, dungeon3Treasure,   0.74),
+        new LootPackEntry(true, dungeon3Rings,      0.74),
+        new LootPackEntry(true, dungeon3Potions,    0.74),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5)
     ));
@@ -98650,8 +98650,8 @@ return orc;
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.5),
-        new LootPackEntry(true, dungeon3Rings,      0.5),
+        new LootPackEntry(true, dungeon3Treasure,   1),
+        new LootPackEntry(true, dungeon3Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5),
@@ -98711,11 +98711,11 @@ return orc;
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.25),
-        new LootPackEntry(true, dungeon3Rings,      0.25),
-        new LootPackEntry(true, dungeon3Potions,    0.25),
+        new LootPackEntry(true, dungeon3Treasure,   0.5),
+        new LootPackEntry(true, dungeon3Rings,      0.5),
+        new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
-        new LootPackEntry(true, (from, container) => new SilverDagger(), 15),
+        new LootPackEntry(true, (from, container) => new SilverDagger(), 7),
         new LootPackEntry(true, utilityItems,   0.25)
     ));
 
@@ -98776,10 +98776,10 @@ return orc;
     };
     
     salamander.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new FieryRuby(1500u), 100.0),
+        new LootPackEntry(true, (from, container) => new FieryRuby(700u), 100.0),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.5),
-        new LootPackEntry(true, dungeon3Rings,      0.5),
+        new LootPackEntry(true, dungeon3Treasure,   1),
+        new LootPackEntry(true, dungeon3Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5)
@@ -98834,8 +98834,8 @@ return orc;
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.55),
-        new LootPackEntry(true, dungeon3Rings,      0.55),
+        new LootPackEntry(true, dungeon3Treasure,   1.1),
+        new LootPackEntry(true, dungeon3Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5),
@@ -98893,8 +98893,8 @@ return orc;
     wight.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon3Bottles,    20),
-        new LootPackEntry(true, dungeon3Treasure,   0.55),
-        new LootPackEntry(true, dungeon3Rings,      0.55),
+        new LootPackEntry(true, dungeon3Treasure,   1.1),
+        new LootPackEntry(true, dungeon3Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 0.5),
         new LootPackEntry(true, utilityItems,   0.5),
@@ -98944,8 +98944,8 @@ return orc;
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.5),
-        new LootPackEntry(true, dungeon4Rings,      0.5),
+        new LootPackEntry(true, dungeon4Treasure,   1),
+        new LootPackEntry(true, dungeon4Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -98994,8 +98994,8 @@ return orc;
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.5),
-        new LootPackEntry(true, dungeon4Rings,      0.5),
+        new LootPackEntry(true, dungeon4Treasure,   1),
+        new LootPackEntry(true, dungeon4Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99055,8 +99055,8 @@ return orc;
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.5),
-        new LootPackEntry(true, dungeon4Rings,      0.5),
+        new LootPackEntry(true, dungeon4Treasure,   1),
+        new LootPackEntry(true, dungeon4Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99103,8 +99103,8 @@ return orc;
     troll.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99151,8 +99151,8 @@ return orc;
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.5),
-        new LootPackEntry(true, dungeon4Rings,      0.5),
+        new LootPackEntry(true, dungeon4Treasure,   1),
+        new LootPackEntry(true, dungeon4Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99209,11 +99209,11 @@ return orc;
     gargoyle.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.25),
-        new LootPackEntry(true, dungeon4Rings,      0.25),
+        new LootPackEntry(true, dungeon4Treasure,   0.5),
+        new LootPackEntry(true, dungeon4Rings,      0.5),
         new LootPackEntry(true, dungeon3Potions,    0.25),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
-        new LootPackEntry(true, (from, container) => new SilverDagger(), 15),
+        new LootPackEntry(true, (from, container) => new SilverDagger(), 7),
         new LootPackEntry(true, utilityItems,   1)
     ));
     
@@ -99274,10 +99274,10 @@ return orc;
     };
 
     salamander.AddLoot(new LootPack(
-        new LootPackEntry(true, (from, container) => new FieryRuby(1800u), 100.0),
+        new LootPackEntry(true, (from, container) => new FieryRuby(800u), 100.0),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.5),
-        new LootPackEntry(true, dungeon4Rings,      0.5),
+        new LootPackEntry(true, dungeon4Treasure,   1),
+        new LootPackEntry(true, dungeon4Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99335,12 +99335,13 @@ return orc;
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1),
-        new LootPackEntry(true, (from, container) => new BirchWand(), 1)
+        new LootPackEntry(true, (from, container) => new BirchWand(), 1),
+        new LootPackEntry(true, (from, container) => new YouthPotion(), 1)
     ));
     
     return wraith;
@@ -99397,12 +99398,13 @@ return orc;
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       4,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1),
-        new LootPackEntry(true, (from, container) => new BirchWand(), 1)
+        new LootPackEntry(true, (from, container) => new BirchWand(), 1),
+        new LootPackEntry(true, (from, container) => new YouthPotion(), 1)
     ));
     
     return spectre;
@@ -99459,8 +99461,8 @@ return orc;
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       16,     gemsPriceMutatorHigh),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.63),
-        new LootPackEntry(true, dungeon4Rings,      0.63),
+        new LootPackEntry(true, dungeon4Treasure,   1.26),
+        new LootPackEntry(true, dungeon4Rings,      1.26),
         new LootPackEntry(true, dungeon3Potions,    0.63),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99526,8 +99528,8 @@ return orc;
     minotaur.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorHigh),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.63),
-        new LootPackEntry(true, dungeon4Rings,      0.63),
+        new LootPackEntry(true, dungeon4Treasure,   1.26),
+        new LootPackEntry(true, dungeon4Rings,      1.26),
         new LootPackEntry(true, dungeon3Potions,    0.63),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, (from, container) => new IronRod(), 10),
@@ -99585,8 +99587,8 @@ return orc;
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorAboveAverage),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99642,8 +99644,8 @@ return orc;
     fighter.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorAboveAverage),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, utilityItems,   1)
@@ -99711,8 +99713,8 @@ return orc;
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorAboveAverage),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, (from, container) => new RedRunesRobe(),        10.0),
@@ -99784,8 +99786,8 @@ return orc;
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorAboveAverage),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.55),
-        new LootPackEntry(true, dungeon4Rings,      0.55),
+        new LootPackEntry(true, dungeon4Treasure,   1.1),
+        new LootPackEntry(true, dungeon4Rings,      1.1),
         new LootPackEntry(true, dungeon3Potions,    0.55),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, (from, container) => new RedRunesRobe(),        10.0),
@@ -100535,8 +100537,8 @@ return orc;
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       16,     gemsPriceMutatorHigh),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.63),
-        new LootPackEntry(true, dungeon4Rings,      0.63),
+        new LootPackEntry(true, dungeon4Treasure,   1.26),
+        new LootPackEntry(true, dungeon4Rings,      1.26),
         new LootPackEntry(true, dungeon3Potions,    0.63),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
         new LootPackEntry(true, (from, container) => new ReturningHammer(), 33),
@@ -100599,11 +100601,12 @@ return orc;
     wraith.AddLoot(new LootPack(
         new LootPackEntry(true, kesmaiwideGems,       8,     gemsPriceMutatorNormal),
         new LootPackEntry(true, dungeon4Bottles,    20),
-        new LootPackEntry(true, dungeon4Treasure,   0.5),
-        new LootPackEntry(true, dungeon4Rings,      0.5),
+        new LootPackEntry(true, dungeon4Treasure,   1),
+        new LootPackEntry(true, dungeon4Rings,      1),
         new LootPackEntry(true, dungeon3Potions,    0.5),
         new LootPackEntry(true, (from, container) => new Yttril(), 1),
-        new LootPackEntry(true, utilityItems,   1)
+        new LootPackEntry(true, utilityItems,   1),
+        new LootPackEntry(true, (from, container) => new YouthPotion(), 1)
     ));
     
     return wraith;
@@ -103589,6 +103592,15 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new YouthPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
     </treasure>
     <treasure name="dungeon2Treasure">
       <entry weight="2">
@@ -103712,15 +103724,6 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="8">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new YouthPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="dungeon2Rings">
       <entry weight="2">
@@ -103752,7 +103755,7 @@ else
       </entry>
     </treasure>
     <treasure name="dungeon3Rings">
-      <entry weight="2">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -103761,7 +103764,7 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -103770,7 +103773,7 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -103788,7 +103791,7 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="2">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -103808,7 +103811,7 @@ else
       </entry>
     </treasure>
     <treasure name="dungeon4Rings">
-      <entry weight="2">
+      <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -103835,15 +103838,6 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new VermeilRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
       <entry weight="1">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
@@ -103858,15 +103852,6 @@ else
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new BlindResistanceRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new WeakDexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -104131,6 +104116,44 @@ else
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new Diamond(10000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="kesmai12Gems">
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SmallRuby(250u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SmallTopaz(500u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SmallAmethyst(1000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new Diamond(1700u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
Divided kes gems up, -1 and 2 now have a 6 and 12 percent chance to drop accordingly, and gems are worth 6 times less. Can be adjusted easily based on feedback / numbers.

Youth Potions are now in the bottle genre same as MRPs.

Undead on -4 have youth pots at a 1% rate in their loot pool.

Treasure has been doubled in Kesmai, strength rings are rarer.