### PR TITLE
Shid changes and armor balances

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104035,7 +104035,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 43, Health = 43,
-        BaseDodge = 1413
+        BaseDodge = 13,
         HideDetection = 22,         
         Experience = 1306,
     };

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -103889,7 +103889,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 43, Health = 43,
-        BaseDodge = 14,
+        BaseDodge = 13,
         HideDetection = 22,        
         Experience = 1306,
     };
@@ -103935,7 +103935,7 @@
     var orc = new Orc()
     {
         MaxHealth = 60, Health = 60,
-        BaseDodge = 15,
+        BaseDodge = 14,
         HideDetection = 22,         
         Experience = 1679,
         
@@ -103984,7 +103984,7 @@
     var troll = new Troll()
     {
         MaxHealth = 66, Health = 66,
-        BaseDodge = 15,
+        BaseDodge = 14,
         HideDetection = 22,         
         Experience = 1804,
                 
@@ -104035,7 +104035,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 43, Health = 43,
-        BaseDodge = 14,
+        BaseDodge = 1413
         HideDetection = 22,         
         Experience = 1306,
     };
@@ -104200,7 +104200,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 57, Health = 57,
-        BaseDodge = 16,
+        BaseDodge = 15,
         HideDetection = 23,        
         Experience = 1881,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -104247,7 +104247,7 @@
     var troll = new Troll()
     {
         MaxHealth = 88, Health = 88,
-        BaseDodge = 17,
+        BaseDodge = 16,
         HideDetection = 23,        
         Experience = 2700,
         BasePenetration = ShieldPenetration.Light,
@@ -104303,7 +104303,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 88, Health = 88,
-        BaseDodge = 17,
+        BaseDodge = 15,
     
         Experience = 3045,
     
@@ -104407,7 +104407,7 @@
     var orc = new Orc()
     {
         MaxHealth = 80, Health = 80,
-        BaseDodge = 16,
+        BaseDodge = 15,
         HideDetection = 23,        
         Experience = 2418,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -104699,7 +104699,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 88, Health = 88,
-        BaseDodge = 17,
+        BaseDodge = 15,
     
         Experience = 3045,
     
@@ -104750,7 +104750,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 57, Health = 57,
-        BaseDodge = 16,
+        BaseDodge = 15,
         HideDetection = 23,        
         Experience = 1881,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -104797,7 +104797,7 @@
     var hobgoblin = new Hobgoblin()
     {
         MaxHealth = 80, Health = 80,
-        BaseDodge = 17,
+        BaseDodge = 16,
         HideDetection = 23,
         Experience = 2418,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -104988,7 +104988,7 @@
     var rockworm = new Rockwyrm()
     {
         MaxHealth = 100, Health = 100,
-        BaseDodge = 13,
+        BaseDodge = 20,
         HideDetection = 23,
         Experience = 3740,
         BasePenetration = ShieldPenetration.Light,
@@ -105056,7 +105056,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 88, Health = 88,
-        BaseDodge = 17,
+        BaseDodge = 15,
     
         Experience = 3045,
     
@@ -105351,7 +105351,7 @@
 	var goblin = new Goblin()
     {
         MaxHealth = 71, Health = 71,
-        BaseDodge = 18,
+        BaseDodge = 17,
         HideDetection = 23,        
         Experience = 2708,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -105403,7 +105403,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 121, Health = 121,
-        BaseDodge = 21,
+        BaseDodge = 19,
     
         Experience = 5262,
     
@@ -105458,7 +105458,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 121, Health = 121,
-        BaseDodge = 21,
+        BaseDodge = 19,
     
         Experience = 5262,
     
@@ -105569,7 +105569,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 71, Health = 71,
-        BaseDodge = 18,
+        BaseDodge = 17,
         HideDetection = 23,        
         Experience = 2708,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -105674,7 +105674,7 @@
     var hobgoblin = new Hobgoblin()
     {
         MaxHealth = 100, Health = 100,
-        BaseDodge = 19,
+        BaseDodge = 18,
         HideDetection = 23,
         Experience = 3482,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -105878,7 +105878,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 121, Health = 121,
-        BaseDodge = 21,
+        BaseDodge = 19,
     
         Experience = 5262,
     
@@ -105928,7 +105928,7 @@
     var troll = new Troll()
     {
         MaxHealth = 110, Health = 110,
-        BaseDodge = 20,
+        BaseDodge = 19,
         HideDetection = 23,        
         Experience = 3740,
                 
@@ -106094,7 +106094,7 @@
     var lizard = new Lizard()
     {
         MaxHealth = 71, Health = 71,
-        BaseDodge = 11,
+        BaseDodge = 18,
         HideDetection = 23,
         Experience = 3482,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -107022,7 +107022,7 @@
         HideDetection = 23,    
         MaxHealth = 105, Health = 105,
         MaxMana = 16, Mana = 16,
-        BaseDodge = 12,
+        BaseDodge = 19,
     
         Experience = 5262,
         BasePenetration = ShieldPenetration.Medium,
@@ -107098,7 +107098,7 @@
         HideDetection = 23,    
         MaxHealth = 121, Health = 121,
         MaxMana = 23, Mana = 23,
-        BaseDodge = 21,
+        BaseDodge = 19,
     
         Experience = 5262,
         BasePenetration = ShieldPenetration.Medium,
@@ -107164,7 +107164,7 @@
         HideDetection = 23,    
         MaxHealth = 100, Health = 100,
         MaxMana = 16, Mana = 16,
-        BaseDodge = 13,
+        BaseDodge = 19,
     
         Experience = 5262,
         BasePenetration = ShieldPenetration.Medium,
@@ -107471,7 +107471,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 71, Health = 71,
-        BaseDodge = 18,
+        BaseDodge = 17,
         HideDetection = 23,        
         Experience = 2708,    
         Alignment = Alignment.Evil,
@@ -107519,7 +107519,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 71, Health = 71,
-        BaseDodge = 18,
+        BaseDodge = 17,
         HideDetection = 23,        
         Experience = 2708,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -107673,7 +107673,7 @@
 
         MaxHealth = 198,
         Health = 198,
-        BaseDodge = 26,
+        BaseDodge = 23,
         HideDetection = 31,
         BasePenetration = ShieldPenetration.Medium,
         Experience = 13095,

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75372,7 +75372,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel14Shidosha">
+    <entity name="BossMinorLevel12Shidosha">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75381,10 +75381,10 @@
         Body = 245,
         Name = "shidosha",
         
-        MaxHealth = 2100, Health = 2100,
-        BaseDodge = 35,
+        MaxHealth = 1800, Health = 1800,
+        BaseDodge = 31,
 
-        Experience = 85592,
+        Experience = 59440,
 
         HideDetection = 28,
         
@@ -75418,7 +75418,7 @@
                                                         new AttackStunComponent(25)),               40
         },
         {
-            new CreatureAttack(20,      40, 69,     "Shidosha knocks you back with a forceful kick.",
+            new CreatureAttack(20,      40, 61,     "Shidosha knocks you back with a forceful kick.",
                                                         new AttackProneComponent(100), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -75431,7 +75431,7 @@
         new CreatureBlock(3, "inhuman reflexes"),
     };
         
-   shidosha.AddGold(4000);
+   shidosha.AddGold(1600);
    shidosha.AddLoot(new LootPack(
        new LootPackEntry(true, LengGems,       100,     gemsPriceMutatorVeryHigh), 
        new LootPackEntry(true, (from, container) => new Kimono(),        100),
@@ -75541,7 +75541,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel11Kosh">
+    <entity name="BossMinorLevel11Kosh">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75627,7 +75627,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel14Vlad">
+    <entity name="BossMajorLevel14Vlad">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75707,7 +75707,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel14Sparky">
+    <entity name="BossMajorLevel14Sparky">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75871,7 +75871,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
             
         MaxHealth = 121, Health = 121,
-        BaseDodge = 21,
+        BaseDodge = 19,
         HideDetection = 26,
         BasePenetration = ShieldPenetration.Light,
         Experience = 4489,
@@ -76046,7 +76046,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
             
         MaxHealth = 121, Health = 121,
-        BaseDodge = 21,
+        BaseDodge = 20,
         HideDetection = 26,    
         Experience = 4489,
         CanSwim = true,
@@ -76294,7 +76294,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 28,    
         MaxHealth = 154, Health = 154,
-        BaseDodge = 24,
+        BaseDodge = 22,
         MagicProtection = 33,
         Experience = 9094,
     
@@ -76350,7 +76350,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 28,    
         MaxHealth = 154, Health = 154,
-        BaseDodge = 24,
+        BaseDodge = 22,
         MagicProtection = 33,
         BasePenetration = ShieldPenetration.Medium,
     
@@ -76404,7 +76404,7 @@
         HideDetection = 28,    
         MaxHealth = 154, Health = 154,
         MaxMana = 23, Mana = 23,
-        BaseDodge = 14,
+        BaseDodge = 22,
         MagicProtection = 33,
         Experience = 9094,
     
@@ -76503,7 +76503,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel12Tiger">
+    <entity name="BossNotableLevel12Tiger">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76561,7 +76561,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel12DoomDuck">
+    <entity name="BossNotableLevel12DoomDuck">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -76629,7 +76629,7 @@
     var orc = new Orc()
     {
         MaxHealth = 120, Health = 120,
-        BaseDodge = 20,
+        BaseDodge = 19,
         Experience = 5015,
         HideDetection = 26,
         CanFlee = true,
@@ -76731,7 +76731,7 @@
     var troll = new Troll()
     {
         MaxHealth = 132, Health = 132,
-        BaseDodge = 22,
+        BaseDodge = 21,
         BasePenetration = ShieldPenetration.Light,
         Experience = 5386,
         HideDetection = 26,
@@ -76777,7 +76777,7 @@
     var orc = new Orc()
     {
         MaxHealth = 120, Health = 120,
-        BaseDodge = 20,
+        BaseDodge = 19,
         Experience = 5015,
         HideDetection = 26,
         CanFlee = true,
@@ -76823,7 +76823,7 @@
     var manticora = new Manticora()
     {
         MaxHealth = 220, Health = 220,
-        BaseDodge = 14,
+        BaseDodge = 19,
         HideDetection = 26,
         BasePenetration = ShieldPenetration.Light,
         Experience = 11500,
@@ -76942,7 +76942,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel13Wyrm">
+    <entity name="BossNotableLevel13Wyrm">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77243,7 +77243,7 @@
         HideDetection = 23,       
         MaxHealth = 99, Health = 99,
         MaxMana = 31, Mana = 31,
-        BaseDodge = 18,
+        BaseDodge = 17,
     
         Experience = 3654,
         
@@ -77308,7 +77308,7 @@
     var hobgoblin = new Hobgoblin()
     {
         MaxHealth = 90, Health = 90,
-        BaseDodge = 18,
+        BaseDodge = 17,
         MaxMana = 31, Mana = 31,
         HideDetection = 23,   
         Experience = 2900,
@@ -77365,7 +77365,7 @@
     var hobgoblin = new Hobgoblin()
     {
         MaxHealth = 90, Health = 90,
-        BaseDodge = 18,
+        BaseDodge = 17,
         HideDetection = 23,   
         Experience = 2900,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -77665,7 +77665,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 23,       
         MaxHealth = 100, Health = 100,
-        BaseDodge = 18,
+        BaseDodge = 16,
         
         Movement = 2,
     
@@ -77706,7 +77706,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel9Presence">
+    <entity name="BossMiniLevel9Presence">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -77773,14 +77773,14 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel9Sandy">
+    <entity name="BossNotableLevel9Sandy">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
     var sandwyrm = new Sandwyrm()
     {
-        MaxHealth = 300, Health = 300,
-        BaseDodge = 21,
+        MaxHealth = 450, Health = 450,
+        BaseDodge = 26,
         Experience = 11608,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 1,
@@ -77800,10 +77800,10 @@
     sandwyrm.Attacks = new CreatureAttackCollection
     {
         { 
-            new CreatureAttack(12,     10, 15,     "The sandwyrm rolls over you"),        70 
+            new CreatureAttack(14,     14, 15,     "The sandwyrm rolls over you"),        70 
         }, 
         {
-            new CreatureAttack(12,    12, 24,     "You've been bitten by the sandwyrm",
+            new CreatureAttack(14,    16, 30,     "You've been bitten by the sandwyrm",
                                                     new AttackPoisonComponent(8, 50)),  30 
         },
     };
@@ -77814,7 +77814,7 @@
         new CreatureBlock(4, "the toothy maw"), 
     };
     
-    sandwyrm.AddGold(1200);
+    sandwyrm.AddGold(1300);
     sandwyrm.AddLoot(new LootPack(
         new LootPackEntry(true, LengGems, 100, gemsPriceMutatorVeryHigh),
         new LootPackEntry(true, (from, container) => new StrengthRing(),       20), 
@@ -77840,7 +77840,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel9SeaSerpent">
+    <entity name="BossMiniLevel9SeaSerpent">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -78166,13 +78166,13 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel8BridgeTroll">
+    <entity name="BossMiniLevel8BridgeTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
     var bridgeTroll = new ElderTroll()
     {
-        MaxHealth = 336, Health = 336,
+        MaxHealth = 260, Health = 260,
         BaseDodge = 18,
         HideDetection = 23,
         CanCharge = true,
@@ -78282,7 +78282,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossLevel12PowerTroll">
+    <entity name="BossNotableLevel12PowerTroll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -78342,7 +78342,7 @@
     var troll = new Troll()
     {
         MaxHealth = 143, Health = 143,
-        BaseDodge = 23,
+        BaseDodge = 22,
         BasePenetration = ShieldPenetration.Light,
         Experience = 6464,
         HideDetection = 26,
@@ -78393,7 +78393,7 @@
         Body = (female ? 33 : 32), IsFemale = female,
         HideDetection = 28,    
         MaxHealth = 143, Health = 143,
-        BaseDodge = 23,
+        BaseDodge = 21,
         Experience = 7578,
     
         BasePenetration = ShieldPenetration.Medium,
@@ -78441,7 +78441,7 @@
     var hobgoblin = new Hobgoblin()
     {
         MaxHealth = 130, Health = 130,
-        BaseDodge = 18,
+        BaseDodge = 20,
         HideDetection = 22,   
         Experience = 6018,
         BasePenetration = ShieldPenetration.Light,
@@ -78667,7 +78667,7 @@
     {
         MaxHealth = 130, Health = 130,
         MaxMana = 23, Mana = 23,
-        BaseDodge = 23,
+        BaseDodge = 22,
         HideDetection = 23,   
         Experience = 7578,
     
@@ -79532,7 +79532,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel9SeaSerpent" size="1" minimum="0" maximum="0" />
+      <entry entity="BossMiniLevel9SeaSerpent" size="1" minimum="0" maximum="0" />
       <location x="43" y="32" region="10" />
     </spawn>
     <spawn type="RegionSpawner" name="mausoleumSandyPath">
@@ -79666,7 +79666,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel9Presence" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMiniLevel9Presence" size="1" minimum="1" maximum="1" />
       <bounds region="10">
         <inclusion left="33" top="9" right="39" bottom="11" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79826,7 +79826,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel14Sparky" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMajorLevel14Sparky" size="1" minimum="1" maximum="1" />
       <entry entity="level14Lich" size="1" minimum="2" maximum="2" />
       <entry entity="level14Minotaur" size="1" minimum="3" maximum="3" />
       <bounds region="43">
@@ -79852,7 +79852,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel11Kosh" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMinorLevel11Kosh" size="1" minimum="1" maximum="1" />
       <bounds region="30">
         <inclusion left="6" top="3" right="8" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -79876,7 +79876,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel14Vlad" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMajorLevel14Vlad" size="1" minimum="1" maximum="1" />
       <entry entity="level14VladSalamander" size="1" minimum="1" maximum="1" />
       <entry entity="level14VladGryph" size="1" minimum="2" maximum="2" />
       <entry entity="level14VladLich" size="1" minimum="1" maximum="1" />
@@ -79984,7 +79984,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel14Shidosha" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMinorLevel12Shidosha" size="1" minimum="1" maximum="1" />
       <entry entity="level14Ninja" size="1" minimum="1" maximum="1" />
       <bounds region="255">
         <inclusion left="1" top="1" right="5" bottom="7" />
@@ -80009,7 +80009,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel9Sandy" size="1" minimum="1" maximum="1" />
+      <entry entity="BossNotableLevel9Sandy" size="1" minimum="1" maximum="1" />
       <bounds region="10">
         <inclusion left="34" top="3" right="38" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -80033,7 +80033,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel8BridgeTroll" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMiniLevel8BridgeTroll" size="1" minimum="1" maximum="1" />
       <bounds region="1">
         <inclusion left="36" top="15" right="40" bottom="16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -80299,7 +80299,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel12PowerTroll" size="1" minimum="1" maximum="1" />
+      <entry entity="BossNotableLevel12PowerTroll" size="1" minimum="1" maximum="1" />
       <bounds region="236">
         <inclusion left="3" top="6" right="6" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -80323,8 +80323,8 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel12DoomDuck" size="1" minimum="1" maximum="1" />
-      <entry entity="BossLevel12Tiger" size="1" minimum="1" maximum="1" />
+      <entry entity="BossNotableLevel12DoomDuck" size="1" minimum="1" maximum="1" />
+      <entry entity="BossNotableLevel12Tiger" size="1" minimum="1" maximum="1" />
       <bounds region="35">
         <inclusion left="3" top="4" right="9" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -80524,7 +80524,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossLevel13Wyrm" size="1" minimum="1" maximum="1" />
+      <entry entity="BossNotableLevel13Wyrm" size="1" minimum="1" maximum="1" />
       <bounds region="18">
         <inclusion left="23" top="11" right="29" bottom="14" />
         <exclusion left="0" top="0" right="0" bottom="0" />

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -101459,7 +101459,7 @@
     var knight = new Humanoid()
     {
         Name = "Yasnaki Knight",
-        Body = 25,
+        Body = 193,
         
         MaxHealth = 167, Health = 167,
         BaseDodge = 23,

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -99596,7 +99596,7 @@
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    1), 
         new LootPackEntry(true, UpperTreasure,    0.25)
@@ -99662,7 +99662,7 @@
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    1), 
         new LootPackEntry(true, UpperTreasure,    0.25)
@@ -99728,7 +99728,7 @@
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    1), 
         new LootPackEntry(true, UpperTreasure,    0.25)
@@ -99793,7 +99793,7 @@
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
         new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    1), 
         new LootPackEntry(true, UpperTreasure,    0.25)
@@ -100316,7 +100316,7 @@
             
     orc.AddGold(119);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -100382,7 +100382,7 @@
     
     minotaur.AddGold(160);
     minotaur.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.63), 
@@ -100469,7 +100469,7 @@
     var troll = new Troll()
     {
         MaxHealth = 132, Health = 132,
-        BaseDodge = 22,
+        BaseDodge = 21,
         HideDetection = 25,        
         Experience = 5386,
         BasePenetration = ShieldPenetration.Light,
@@ -100485,7 +100485,7 @@
     
     troll.AddGold(138);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -100533,7 +100533,7 @@
             
     orc.AddGold(112);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -100589,7 +100589,7 @@
     hobgoblin.AddGold(119);
     hobgoblin.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new SteelWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -100622,7 +100622,7 @@
     var troll = new Troll()
     {
         MaxHealth = 128, Health = 128,
-        BaseDodge = 23,
+        BaseDodge = 22,
         HideDetection = 25,        
         Experience = 6464,
         BasePenetration = ShieldPenetration.Medium,
@@ -100640,7 +100640,7 @@
     
     troll.AddGold(146);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -100671,7 +100671,7 @@
     var troll = new Troll()
     {
         MaxHealth = 143, Health = 143,
-        BaseDodge = 23,
+        BaseDodge = 22,
         HideDetection = 25,           
         Experience = 6800,
         BasePenetration = ShieldPenetration.Medium,
@@ -100687,7 +100687,7 @@
     
     troll.AddGold(146);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -100719,7 +100719,7 @@
     {
         Name = "Elite Guard",
         MaxHealth = 209, Health = 209,
-        BaseDodge = 29,
+        BaseDodge = 27,
         HideDetection = 29,    
         Experience = 11000,
         
@@ -100740,7 +100740,7 @@
     
     trollguard.AddGold(216);
     trollguard.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -100772,7 +100772,7 @@
     var hobgoblin = new Hobgoblin()
     {
         MaxHealth = 130, Health = 130,
-        BaseDodge = 20,
+        BaseDodge = 21,
         HideDetection = 25,
         Experience = 6018,
         BasePenetration = ShieldPenetration.Medium,
@@ -100788,7 +100788,7 @@
     
     hobgoblin.AddGold(119);
     hobgoblin.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -100820,7 +100820,7 @@
     {
         MaxHealth = 96, Health = 96,
         MaxMana = 13, Mana = 13,
-        BaseDodge = 20,
+        BaseDodge = 21,
         BasePenetration = ShieldPenetration.VeryLight,
         Experience = 5015,
         HideDetection = 25,
@@ -100843,7 +100843,7 @@
     orc.AddGold(112);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new SteelWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -100898,7 +100898,7 @@
         
     troll.AddGold(130);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -100953,7 +100953,7 @@
         
     troll.AddGold(146);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -100985,7 +100985,7 @@
     {
         MaxHealth = 88, Health = 88,
         MaxMana = 21, Mana = 21,
-        BaseDodge = 19,
+        BaseDodge = 18,
         HideDetection = 25,
         Experience = 4179,
         BasePenetration = ShieldPenetration.VeryLight,
@@ -101011,7 +101011,7 @@
     orc.AddGold(105);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new HickoryWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -101043,7 +101043,7 @@
     {
         MaxHealth = 68, Health = 68,
         MaxMana = 16, Mana = 16,
-        BaseDodge = 11,
+        BaseDodge = 20,
         BasePenetration = ShieldPenetration.VeryLight,        
         Experience = 3900,
         FireProtection = 100,
@@ -101070,7 +101070,7 @@
     goblin.AddGold(96);
     goblin.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new HickoryWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.37), 
@@ -101126,7 +101126,7 @@
     banshee.AddGold(108);
     banshee.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new YouthPotion(), .05),
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.5), 
@@ -101192,7 +101192,7 @@
     ghoul.AddGold(154);
     ghoul.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new YouthPotion(), .1),
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.63), 
@@ -101249,7 +101249,7 @@
     skeleton.AddGold(108);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new YouthPotion(), .05),
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.5), 
@@ -101312,7 +101312,7 @@
     spectre.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new YouthPotion(), .1),
         new LootPackEntry(true, (from, container) => new OakWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.5), 
@@ -101378,7 +101378,7 @@
     mummy.AddGold(216);
     mummy.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new YouthPotion(), .1),
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorVeryHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.63), 
@@ -101462,7 +101462,7 @@
         Body = 25,
         
         MaxHealth = 167, Health = 167,
-        BaseDodge = 25,
+        BaseDodge = 23,
         HideDetection = 28,        
         Experience = 10913,
         BasePenetration = ShieldPenetration.Medium,
@@ -101478,7 +101478,7 @@
     
     knight.AddGold(162);
     knight.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       17.2,     gemsPriceMutatorAboveAverage), 
+        new LootPackEntry(true, UnderkingdomGems,       14.6,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, yasnakiTreasure,    0.55), 
@@ -101537,7 +101537,7 @@
     lich.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new YouthPotion(), .1),
         new LootPackEntry(true, (from, container) => new OakWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.63), 
@@ -101606,7 +101606,7 @@
         new LootPackEntry(true, (from, container) => new YouthPotion(),       5),
         new LootPackEntry(true, (from, container) => new ManaPotion(),       5), 
         new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    50), 
         new LootPackEntry(true, UtilityItems,    3), 
         new LootPackEntry(true, UpperTreasure,    0.63)
@@ -101666,7 +101666,7 @@
     
     martialartist.AddGold(162);
     martialartist.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       17.2,     gemsPriceMutatorAboveAverage), 
+        new LootPackEntry(true, UnderkingdomGems,       14.6,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, yasnakiTreasure,    0.55), 
@@ -101701,7 +101701,7 @@
         HideDetection = 28,      
         MaxHealth = 133, Health = 133,
         MaxMana = 31, Mana = 31,
-        BaseDodge = 25,
+        BaseDodge = 23,
         BasePenetration = ShieldPenetration.Light,
         Experience = 10918,
                     
@@ -101732,7 +101732,7 @@
     wizard.AddGold(162);
     wizard.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new GlassWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       17.2,     gemsPriceMutatorAboveAverage), 
+        new LootPackEntry(true, UnderkingdomGems,       14.6,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, yasnakiTreasure,    0.55), 
@@ -101766,7 +101766,7 @@
         Name = "Yasnaki Thaumaturge",
         Body = 191,
         MaxHealth = 133, Health = 133,
-        BaseDodge = 25,
+        BaseDodge = 23,
         HideDetection = 28,
         Experience = 10918,
         BasePenetration = ShieldPenetration.Light,
@@ -101794,7 +101794,7 @@
     thaum.AddGold(162);
     thaum.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new OakWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       17.2,     gemsPriceMutatorAboveAverage), 
+        new LootPackEntry(true, UnderkingdomGems,       14.6,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, yasnakiTreasure,    0.55), 
@@ -101825,7 +101825,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 85, Health = 85,
-        BaseDodge = 20,
+        BaseDodge = 19,
         BasePenetration = ShieldPenetration.Light,
         Experience = 3900,  
         HideDetection = 25,
@@ -101841,7 +101841,7 @@
             
     goblin.AddGold(96);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.37), 
@@ -101872,7 +101872,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 78, Health = 78,
-        BaseDodge = 19,
+        BaseDodge = 18,
         BasePenetration = ShieldPenetration.Light,
         Experience = 3250,  
         HideDetection = 25,
@@ -101888,7 +101888,7 @@
             
     goblin.AddGold(90);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.37), 
@@ -101919,7 +101919,7 @@
     var orc = new Orc()
     {
         MaxHealth = 99, Health = 99,
-        BaseDodge = 19,
+        BaseDodge = 18,
         BasePenetration = ShieldPenetration.Light,
         Experience = 4179,
         HideDetection = 25, 
@@ -101936,7 +101936,7 @@
             
     orc.AddGold(105);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -101967,7 +101967,7 @@
     var troll = new Troll()
     {
         MaxHealth = 121, Health = 121,
-        BaseDodge = 21,
+        BaseDodge = 20,
         HideDetection = 25,        
         Experience = 4489,
         BasePenetration = ShieldPenetration.Light,
@@ -101983,7 +101983,7 @@
     
     troll.AddGold(130);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -102014,7 +102014,7 @@
     var orc = new Orc()
     {
         MaxHealth = 110, Health = 110,
-        BaseDodge = 19,
+        BaseDodge = 18,
         HideDetection = 25,         
         Experience = 4179,
         BasePenetration = ShieldPenetration.Light,
@@ -102031,7 +102031,7 @@
             
     orc.AddGold(105);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -102061,7 +102061,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 70, Health = 70,
-        BaseDodge = 19,
+        BaseDodge = 18,
         BasePenetration = ShieldPenetration.Light,       
         Experience = 3250,
         HideDetection = 25,
@@ -102078,7 +102078,7 @@
             
     goblin.AddGold(90);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       8.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.37), 
@@ -102280,7 +102280,7 @@
     
     hobgoblin.AddGold(112);
     hobgoblin.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -102312,7 +102312,7 @@
     var troll = new Troll()
     {
         MaxHealth = 118, Health = 118,
-        BaseDodge = 22,
+        BaseDodge = 21,
         HideDetection = 25,        
         Experience = 5386,
         BasePenetration = ShieldPenetration.Medium,
@@ -102331,7 +102331,7 @@
     
     troll.AddGold(138);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -102388,7 +102388,7 @@
     
     stalker.AddGold(154);
     stalker.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       14.5,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomGems,       12.3,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UndeadTreasure,    0.63), 
@@ -102420,7 +102420,7 @@
     {
         MaxHealth = 104, Health = 104,
         MaxMana = 13, Mana = 13,
-        BaseDodge = 21,
+        BaseDodge = 22,
         BasePenetration = ShieldPenetration.VeryLight,
         Experience = 6018,
         HideDetection = 25,
@@ -102443,7 +102443,7 @@
     orc.AddGold(119);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, (from, container) => new SteelWand(), 1),
-        new LootPackEntry(true, UnderkingdomGems,       12.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -102540,7 +102540,7 @@
         
     troll.AddGold(138);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorAboveAverage), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.55), 
@@ -102588,7 +102588,7 @@
             
     orc.AddGold(112);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomGems,       10.2,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomGems,       8.7,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
         new LootPackEntry(true, UpperTreasure,    0.5), 
@@ -105292,20 +105292,20 @@
       </entry>
     </treasure>
     <treasure name="UnderkingdomGems">
-      <entry weight="10">
+      <entry weight="50">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new Diamond(3500u);
+	return new Diamond(6500u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="25">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StarSapphire(7500u);
+	return new StarSapphire(9500u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -105314,16 +105314,16 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new Tourmaline(32000u);
+	return new Tourmaline(100000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="3">
+      <entry weight="10">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new FlawlessSapphire(8000u);
+	return new FlawlessSapphire(13000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -99595,11 +99595,11 @@
             
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomPotions,    0.025),
+        new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
-        new LootPackEntry(true, UtilityItems,    1), 
-        new LootPackEntry(true, UpperTreasure,    0.25)
+        new LootPackEntry(true, UtilityItems,    .3), 
+        new LootPackEntry(true, UpperTreasure,    0.15)
     ));
     
     return wyvern;
@@ -99661,11 +99661,11 @@
             
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomPotions,    0.025),
+        new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
-        new LootPackEntry(true, UtilityItems,    1), 
-        new LootPackEntry(true, UpperTreasure,    0.25)
+        new LootPackEntry(true, UtilityItems,    .3), 
+        new LootPackEntry(true, UpperTreasure,    0.15)
     ));
     
     return wyvern;
@@ -99727,11 +99727,11 @@
             
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomPotions,    0.025),
+        new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
-        new LootPackEntry(true, UtilityItems,    1), 
-        new LootPackEntry(true, UpperTreasure,    0.25)
+        new LootPackEntry(true, UtilityItems,    .3), 
+        new LootPackEntry(true, UpperTreasure,    0.15)
     ));
     
     return wyvern;
@@ -99792,11 +99792,11 @@
             
     wyvern.AddGold(98);
     wyvern.AddLoot(new LootPack(
-        new LootPackEntry(true, UnderkingdomPotions,    0.05),
-        new LootPackEntry(true, UnderkingdomGems,       6,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, UnderkingdomPotions,    0.025),
+        new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
-        new LootPackEntry(true, UtilityItems,    1), 
-        new LootPackEntry(true, UpperTreasure,    0.25)
+        new LootPackEntry(true, UtilityItems,    .3), 
+        new LootPackEntry(true, UpperTreasure,    0.15)
     ));
     
     return wyvern;


### PR DESCRIPTION
Shidosha is now a level 12 instead of 14 boss - defense rating, damage and hit points have been decreased since last pull.

Armor has been universally dropped on monsters wearing armor to compensate for the values.

UK gems have become more rare to 7.2 in tunnels to 14.6 in Yasnaki depending on level.

