### PR TITLE
Armor class changes

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104845,7 +104845,7 @@
     var wolf = new Wolf()
     {
         MaxHealth = 119, Health = 119,
-        BaseDodge = 20,
+        BaseDodge = 21,
         HideDetection = 23,        
         Experience = 3583,
         BasePenetration = ShieldPenetration.Medium,
@@ -104909,7 +104909,7 @@
         <block><![CDATA[
     var wolf = new Wolf()
     {
-        BaseDodge = 30,
+        BaseDodge = 25,
         MaxHealth = 550, Health = 550,
 
         Experience = 12383,
@@ -104988,7 +104988,7 @@
     var rockworm = new Rockwyrm()
     {
         MaxHealth = 100, Health = 100,
-        BaseDodge = 20,
+        BaseDodge = 21,
         HideDetection = 23,
         Experience = 3740,
         BasePenetration = ShieldPenetration.Light,
@@ -105726,7 +105726,7 @@
         Body = (female ? 35 : 49), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 110, Health = 110,
-        BaseDodge = 25,
+        BaseDodge = 24,
     
         Experience = 5262,
     
@@ -106217,7 +106217,7 @@
     var bear = new Bear()
     {
         MaxHealth = 200, Health = 200,
-        BaseDodge = 25,
+        BaseDodge = 23,
         HideDetection = 23,        
         Experience = 10319,
         FireProtection = 30,
@@ -106418,7 +106418,7 @@
     var dragon = new Dragon()
     {
         MaxHealth = 4200, Health = 4200,
-        BaseDodge = 35,
+        BaseDodge = 32,
         Body = 135,
         Experience = 213980,
         
@@ -106511,7 +106511,7 @@
     var yeti = new Yeti()
     {
         MaxHealth = 3600, Health = 3600,
-        BaseDodge = 31,
+        BaseDodge = 30,
     
         Experience = 148600,
         HideDetection = 27,
@@ -106559,7 +106559,7 @@
     yeti.Spells = new CreatureSpellCollection(20.0)
     {
         new CreatureSpell<IceStormSpell>(
-            skillLevel: 21)
+            skillLevel: 30)
     };
         
    yeti.AddGold(16000);
@@ -107867,7 +107867,7 @@
         Name = "undead frost giant",
         MaxHealth = 800,
         Health = 800,
-        BaseDodge = 39,
+        BaseDodge = 31,
         HideDetection = 32,
         Mana = 7, MaxMana = 7,
         BasePenetration = ShieldPenetration.Heavy,
@@ -107929,9 +107929,9 @@
     {
         Name = "Vile Necromancer",
 
-        MaxHealth = 8000,
-        Health = 8000,
-        BaseDodge = 32,
+        MaxHealth = 9000,
+        Health = 9000,
+        BaseDodge = 31,
         HideDetection = 40,
         BasePenetration = ShieldPenetration.Heavy,
         Experience = 308140,
@@ -107950,7 +107950,7 @@
     necro.AddStatus(new NightVisionStatus(necro));
     necro.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(24, 13, 23)
+        new CreatureBasicAttack(22, 13, 23)
     };
     
     necro.Spells = new CreatureSpellCollection(10.0)

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75372,7 +75372,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="BossMinorLevel12Shidosha">
+    <entity name="BossMinorLevel14Shidosha">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -75381,10 +75381,10 @@
         Body = 245,
         Name = "shidosha",
         
-        MaxHealth = 1800, Health = 1800,
-        BaseDodge = 31,
+        MaxHealth = 2100, Health = 2100,
+        BaseDodge = 28,
 
-        Experience = 59440,
+        Experience = 85595,
 
         HideDetection = 28,
         
@@ -75409,17 +75409,17 @@
     {
         {
             new CreatureAttack(20,      20, 40,      "Shidosha hits you with a flurry of fists.",
-                                                        new AttackProneComponent(10), 
+                                                        new AttackProneComponent(5), 
                                                         new AttackStunComponent(10)),                40
         },
         {
             new CreatureAttack(20,      30, 50,     "Shidosha slams his fist into your chest.",
-                                                        new AttackProneComponent(10), 
+                                                        new AttackProneComponent(5), 
                                                         new AttackStunComponent(25)),               40
         },
         {
             new CreatureAttack(20,      40, 61,     "Shidosha knocks you back with a forceful kick.",
-                                                        new AttackProneComponent(100), 
+                                                        new AttackProneComponent(10), 
                                                         new AttackStunComponent(15)),               20
         },
     };
@@ -75431,7 +75431,7 @@
         new CreatureBlock(3, "inhuman reflexes"),
     };
         
-   shidosha.AddGold(1600);
+   shidosha.AddGold(1800);
    shidosha.AddLoot(new LootPack(
        new LootPackEntry(true, LengGems,       100,     gemsPriceMutatorVeryHigh), 
        new LootPackEntry(true, (from, container) => new Kimono(),        100),
@@ -75475,7 +75475,7 @@
     var ninja = new Ninja()
     {
         MaxHealth = 127, Health = 127,
-        BaseDodge = 26,
+        BaseDodge = 27,
         HideDetection = 29,
         Experience = 9094,
        
@@ -75500,12 +75500,12 @@
         },
         {
             new CreatureAttack(17,      13, 20,     "The ninja slams his fist into your chest.",
-                                                        new AttackProneComponent(10), 
+                                                        new AttackProneComponent(5), 
                                                         new AttackStunComponent(5)),               40
         },
         {
             new CreatureAttack(17,      15, 21,     "The ninja knocks you back with a forceful kick.",
-                                                        new AttackProneComponent(15), 
+                                                        new AttackProneComponent(5), 
                                                         new AttackStunComponent(5)),               20
         },
     };
@@ -75548,7 +75548,7 @@
     var dragon = new Dragon()
     {
         MaxHealth = 1650, Health = 1650,
-        BaseDodge = 30,
+        BaseDodge = 25,
         HideDetection = 26,
         Experience = 49532,
         
@@ -75636,7 +75636,7 @@
         Name = "vampire",
         
         MaxHealth = 4200, Health = 4200,
-        BaseDodge = 35,
+        BaseDodge = 32,
         BasePenetration = ShieldPenetration.VeryHeavy,
         Experience = 213980,
         HideDetection = 28,
@@ -75714,7 +75714,7 @@
     var drake = new Drake()
     {
         MaxHealth = 4200, Health = 4200,
-        BaseDodge = 35,
+        BaseDodge = 32,
         
         Alignment = Alignment.Chaotic,
         HideDetection = 28,
@@ -76510,7 +76510,7 @@
     var tiger = new Tiger()
     {
         MaxHealth = 600, Health = 600,
-        BaseDodge = 30,
+        BaseDodge = 25,
         HideDetection = 26,        
         Experience = 14860,
         BasePenetration = ShieldPenetration.Light,
@@ -76568,7 +76568,7 @@
     var duck = new Duck()
     {
         MaxHealth = 600, Health = 600,
-        BaseDodge = 30,
+        BaseDodge = 25,
         HideDetection = 26,
         CanSwim = true,
         CanJumpkick = true,
@@ -76949,7 +76949,7 @@
     var wyrm = new Wyrm()
     {
         MaxHealth = 650, Health = 650,
-        BaseDodge = 33,
+        BaseDodge = 26,
         HideDetection = 23,
         Experience = 17832,
         
@@ -77780,7 +77780,7 @@
     var sandwyrm = new Sandwyrm()
     {
         MaxHealth = 450, Health = 450,
-        BaseDodge = 26,
+        BaseDodge = 23,
         Experience = 11608,
         BasePenetration = ShieldPenetration.Medium,
         VisibilityDistance = 1,
@@ -78289,7 +78289,7 @@
     var powerTroll = new ElderTroll()
     {
         MaxHealth = 600, Health = 600,
-        BaseDodge = 18,
+        BaseDodge = 25,
         HideDetection = 23,
         Experience = 29700,
         BasePenetration = ShieldPenetration.Medium,
@@ -79984,7 +79984,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="BossMinorLevel12Shidosha" size="1" minimum="1" maximum="1" />
+      <entry entity="BossMinorLevel14Shidosha" size="1" minimum="1" maximum="1" />
       <entry entity="level14Ninja" size="1" minimum="1" maximum="1" />
       <bounds region="255">
         <inclusion left="1" top="1" right="5" bottom="7" />
@@ -80735,7 +80735,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new ManaPotion();
+	return new DeathResistanceRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -80762,7 +80762,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new DeathResistanceBracelet();
+	return new WeakDexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -80800,7 +80800,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new GriffinSkull();
+	return new DeathResistanceRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Leng" version="0.87.0.0">
+<segment name="Leng" version="0.90.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -80137,12 +80137,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level13Lich" size="1" minimum="3" maximum="5" />
-      <entry entity="level13Archer" size="1" minimum="6" maximum="9" />
+      <entry entity="level13Lich" size="1" minimum="2" maximum="2" />
+      <entry entity="level13Archer" size="1" minimum="6" maximum="6" />
       <entry entity="level13Hobgoblin" size="4" minimum="8" maximum="12" />
       <entry entity="level13Ghoul" size="1" minimum="5" maximum="7" />
-      <entry entity="level13Spectre" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Wraith" size="1" minimum="4" maximum="6" />
+      <entry entity="level13Spectre" size="1" minimum="3" maximum="3" />
+      <entry entity="level13Wraith" size="1" minimum="3" maximum="3" />
       <entry entity="level13Troll" size="3" minimum="3" maximum="10" />
       <bounds region="18">
         <inclusion left="3" top="6" right="20" bottom="28" />
@@ -80548,13 +80548,13 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level13Lich" size="1" minimum="3" maximum="5" />
-      <entry entity="level13Archer" size="1" minimum="6" maximum="9" />
-      <entry entity="level13Hobgoblin" size="4" minimum="8" maximum="12" />
-      <entry entity="level13Ghoul" size="1" minimum="5" maximum="7" />
-      <entry entity="level13Spectre" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Wraith" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Troll" size="3" minimum="3" maximum="10" />
+      <entry entity="level13Lich" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Archer" size="1" minimum="1" maximum="6" />
+      <entry entity="level13Hobgoblin" size="4" minimum="1" maximum="8" />
+      <entry entity="level13Ghoul" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Spectre" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Wraith" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Troll" size="3" minimum="1" maximum="10" />
       <bounds region="18">
         <inclusion left="3" top="6" right="20" bottom="26" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -80578,13 +80578,13 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level13Lich" size="1" minimum="3" maximum="5" />
-      <entry entity="level13Archer" size="1" minimum="6" maximum="9" />
-      <entry entity="level13Hobgoblin" size="4" minimum="8" maximum="12" />
-      <entry entity="level13Ghoul" size="1" minimum="5" maximum="7" />
-      <entry entity="level13Spectre" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Wraith" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Troll" size="3" minimum="3" maximum="10" />
+      <entry entity="level13Lich" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Archer" size="1" minimum="1" maximum="4" />
+      <entry entity="level13Hobgoblin" size="4" minimum="1" maximum="12" />
+      <entry entity="level13Ghoul" size="1" minimum="1" maximum="3" />
+      <entry entity="level13Spectre" size="1" minimum="1" maximum="3" />
+      <entry entity="level13Wraith" size="1" minimum="1" maximum="3" />
+      <entry entity="level13Troll" size="3" minimum="1" maximum="10" />
       <bounds region="18">
         <inclusion left="31" top="14" right="35" bottom="22" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -80608,13 +80608,13 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level13Lich" size="1" minimum="3" maximum="5" />
-      <entry entity="level13Archer" size="1" minimum="6" maximum="9" />
-      <entry entity="level13Hobgoblin" size="4" minimum="8" maximum="12" />
-      <entry entity="level13Ghoul" size="1" minimum="5" maximum="7" />
-      <entry entity="level13Spectre" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Wraith" size="1" minimum="4" maximum="6" />
-      <entry entity="level13Troll" size="3" minimum="3" maximum="10" />
+      <entry entity="level13Lich" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Archer" size="1" minimum="1" maximum="6" />
+      <entry entity="level13Hobgoblin" size="4" minimum="1" maximum="12" />
+      <entry entity="level13Ghoul" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Spectre" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Wraith" size="1" minimum="1" maximum="1" />
+      <entry entity="level13Troll" size="3" minimum="1" maximum="10" />
       <bounds region="18">
         <inclusion left="29" top="34" right="35" bottom="37" />
         <inclusion left="41" top="26" right="43" bottom="36" />
@@ -80892,7 +80892,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="2">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -80731,7 +80731,7 @@
       </entry>
     </treasure>
     <treasure name="MausTreasure">
-      <entry weight="3">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -80740,7 +80740,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="4">
+      <entry weight="6">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -80749,7 +80749,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="4">
+      <entry weight="6">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -102489,7 +102489,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new YouthPotion();
+	return new DeathResistanceBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -102666,7 +102666,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new YouthPotion();
+	return new DeathResistanceBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -102760,7 +102760,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new YouthPotion();
+	return new DeathResistanceBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -98775,17 +98775,17 @@
     {
             {
                 new CreatureAttack(16, 35, 50, "The dragon slashes you with its claws.",
-                                    new AttackProneComponent(15),
+                                    new AttackProneComponent(5),
                                     new AttackStunComponent(5)),                            30
             },
             {
                 new CreatureAttack(17, 40, 60, "The dragon smashes you with its tail.",
-                                    new AttackProneComponent(25),
+                                    new AttackProneComponent(5),
                                     new AttackStunComponent(10)),                           30
             },
             {
                 new CreatureAttack(18, 50, 70, "The dragon buffets you with its wings.",
-                                    new AttackProneComponent(35),
+                                    new AttackProneComponent(5),
                                     new AttackStunComponent(15)),                           40
             },
     };
@@ -102733,7 +102733,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongStrengthBracelet();
+	return new ShieldBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -102841,20 +102841,11 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="18">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new YouthPotion();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
       <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongShieldBracelet();
+	return new ShieldBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -102955,7 +102946,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="3">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -102964,7 +102955,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -102982,7 +102973,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -104407,12 +104407,12 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level14Banshee" size="4" minimum="2" maximum="2" />
-      <entry entity="level14Ghoul" size="1" minimum="1" maximum="1" />
-      <entry entity="level14Skeleton" size="4" minimum="2" maximum="2" />
-      <entry entity="level14Spectre" size="1" minimum="1" maximum="1" />
-      <entry entity="level14Lich" size="1" minimum="1" maximum="1" />
-      <entry entity="level14Stalker" size="1" minimum="1" maximum="1" />
+      <entry entity="level14Banshee" size="4" minimum="2" maximum="6" />
+      <entry entity="level14Ghoul" size="1" minimum="1" maximum="3" />
+      <entry entity="level14Skeleton" size="4" minimum="2" maximum="7" />
+      <entry entity="level14Spectre" size="1" minimum="1" maximum="2" />
+      <entry entity="level14Lich" size="1" minimum="1" maximum="2" />
+      <entry entity="level14Stalker" size="1" minimum="1" maximum="2" />
       <bounds region="17">
         <inclusion left="2" top="3" right="37" bottom="22" />
         <exclusion left="2" top="21" right="29" bottom="22" />

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -105416,7 +105416,7 @@
       </entry>
     </treasure>
     <treasure name="yasnakiTreasure">
-      <entry weight="5">
+      <entry weight="8">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -105425,7 +105425,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="8">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -105434,7 +105434,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="5">
+      <entry weight="8">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -105532,7 +105532,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new BlueStaffRaiseDead();
+	return new BlindFearProtectionBracelet();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -99824,7 +99824,7 @@
     {
         Name = "Drake",
         MaxHealth = 3000, Health = 3000,
-        BaseDodge = 19,
+        BaseDodge = 28,
     
         Alignment = Alignment.Chaotic,
         HideDetection = 26,
@@ -99832,6 +99832,7 @@
         
         CanFly = true,
         CanCharge = true,
+        CanStrikeCritically = false,
         
         BasePenetration = ShieldPenetration.Heavy,
 
@@ -99914,7 +99915,7 @@
         Body = 206,
         
         MaxHealth = 1800, Health = 1800,
-        BaseDodge = 31,
+        BaseDodge = 26,
         HideDetection = 28,
         Alignment = Alignment.Evil,
         
@@ -99982,7 +99983,7 @@
         Body = 147,
         
         MaxHealth = 600, Health = 600,
-        BaseDodge = 31,
+        BaseDodge = 26,
         HideDetection = 28,
         Experience = 14860,
         BasePenetration = ShieldPenetration.Medium,
@@ -100037,7 +100038,7 @@
     {
         Name = "Troll.King",
         MaxHealth = 3900, Health = 3900,
-        BaseDodge = 30,
+        BaseDodge = 28,
         Body = 133,
         
         Alignment = Alignment.Chaotic,
@@ -100065,7 +100066,7 @@
     
     trollKing.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(20, 25, 88),
+        new CreatureBasicAttack(19, 25, 88),
     };
     
     trollKing.Wield(new Greatsword());
@@ -100109,7 +100110,7 @@
         BasePenetration = ShieldPenetration.Heavy,
         Alignment = Alignment.Chaotic,
         Experience = 21398,
-        BaseDodge = 35,
+        BaseDodge = 28,
         CanWalk = false,
         Immunity = CreatureImmunity.Poison,
         HideDetection = 28,    
@@ -100170,7 +100171,7 @@
         Name = "Swordmaster",
         Body = 163,
         MaxHealth = 2100, Health = 2100,
-        BaseDodge = 31,
+        BaseDodge = 24,
         HideDetection = 28,
         Experience = 39000,
        
@@ -100230,7 +100231,7 @@
         Name = "Overlord", Alignment = Alignment.Evil,
     
         MaxHealth = 4200, Health = 4200,
-        BaseDodge = 35,
+        BaseDodge = 32,
         HideDetection = 30,
         Experience = 213980,
         
@@ -100413,7 +100414,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 179, Health = 179,
-        BaseDodge = 26,
+        BaseDodge = 25,
         HideDetection = 25,           
         Experience = 7430,
         BasePenetration = ShieldPenetration.Medium,
@@ -101640,7 +101641,7 @@
         Body = 105,
             
         MaxHealth = 150, Health = 150,
-        BaseDodge = 31,
+        BaseDodge = 28,
         HideDetection = 28,
         Experience = 10918,
         BasePenetration = ShieldPenetration.Heavy,

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Underkingdom" version="0.87.0.0">
+<segment name="Underkingdom" version="0.90.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -104407,9 +104407,9 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level14Banshee" size="4" minimum="2" maximum="6" />
+      <entry entity="level14Banshee" size="4" minimum="6" maximum="6" />
       <entry entity="level14Ghoul" size="1" minimum="1" maximum="3" />
-      <entry entity="level14Skeleton" size="4" minimum="2" maximum="7" />
+      <entry entity="level14Skeleton" size="4" minimum="7" maximum="7" />
       <entry entity="level14Spectre" size="1" minimum="1" maximum="2" />
       <entry entity="level14Lich" size="1" minimum="1" maximum="2" />
       <entry entity="level14Stalker" size="1" minimum="1" maximum="2" />
@@ -105519,11 +105519,11 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new StrongShieldBracelet();
+	return new BlueStaffRaiseDead();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
Boss and Martial Artist monster formula has been adjusted to have lower armor class. Now it's a +1 per level, higher level monsters it will be more noticeable on. (level 14 major boss Mama went from 1,750 to 1,600 defense rating for example).

Shidosha base dodge has been reduced, hit points increased slight. **Number of prones has been drastically decreased.**

Death resistance ring has been added to Leng loot tables for Maus / Cliffs.

Death Resistance Bracelet has been added to Oak loot tables from 2 - 4.

Strong shielders have been removed from OG loot tables except on vlad, mama, and Yasnaki level loot tables at a low %.

Leng Undead has had the number of potential casters spawned lowered. (4 liches can now be on the level instead of potentially 20 for example)

Yeti Ice Storm has been increased

UK Undead is now at the same population as a week ago.

