### PR TITLE
UK - UD Dex Ring

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -105540,6 +105540,15 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
+      <entry weight="2">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DexterityRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
     </treasure>
     <treasure name="UtilityItems">
       <entry weight="4">


### PR DESCRIPTION
* Added +2 Dex at 2 weight to UD treasure. This works out to 3.70% and is the lowest drop rate available there.