### PR TITLE
OL Staff Rebalance

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Staves/EbonyStaff.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Staves/EbonyStaff.cs
@@ -26,7 +26,10 @@ namespace Kesmai.Server.Items
 		public override int MaximumDamage => 8;
 
 		/// <inheritdoc />
-		public override int BaseArmorBonus => 4;
+		public override int BaseArmorBonus => 5;
+
+		        /// <inheritdoc />
+        public override int ProjectileProtection  => 3;
 
 		/// <inheritdoc />
 		public override WeaponFlags Flags => WeaponFlags.TwoHanded | WeaponFlags.Bashing | WeaponFlags.Lawful;


### PR DESCRIPTION
Adjusted OL staff defensive stats to be more in balance with class scaling:  
+1 tick additional BaseArmorBonus (bringing the total to 5)
+3 Projectile Protection added to be in line with the new wand


Prior to this change, a MU with 24 combat adds, +2 Dex, Super Icies, and 18.5 skill only has 1730 DR whereas an 18 MA with 9th Dan (15 Skill), CGs, and +2 Dex already reaches this level.