### PR TITLE
shield change proposal

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/LightningShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/LightningShield.cs
@@ -19,10 +19,10 @@ namespace Kesmai.Server.Items
 		public override int Category => 1;
 		
 		/// <inheritdoc />
-		public override int BaseArmorBonus => 1;
+		public override int BaseArmorBonus => 2;
 
 		/// <inheritdoc />
-		public override int ProjectileProtection => 2;
+		public override int ProjectileProtection => 4;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="LightningShield"/> class.

--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/PlatedShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/PlatedShield.cs
@@ -21,7 +21,7 @@ namespace Kesmai.Server.Items
 		public override int BaseArmorBonus => 1;
 
 		/// <inheritdoc />
-		public override int ProjectileProtection => 1;
+		public override int ProjectileProtection => 2;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PlatedShield"/> class.

--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/SteelShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/SteelShield.cs
@@ -21,7 +21,7 @@ namespace Kesmai.Server.Items
 		public override int BaseArmorBonus => 1;
 
 		/// <inheritdoc />
-		public override int ProjectileProtection => 2;
+		public override int ProjectileProtection => 3;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SteelShield"/> class.

--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/WoodenShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/WoodenShield.cs
@@ -22,6 +22,9 @@ namespace Kesmai.Server.Items
 		/// </summary>
 		public override int BaseArmorBonus => 1;
 
+
+		public override int ProjectileProtection => 1;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="WoodenShield"/> class.
 		/// </summary>


### PR DESCRIPTION
Proposal to make shields a little better and more useful:

- Set wooden shield to +1 projectile protection
- Set Plated shield to +2 projectile protection
- Set steel shield to +3 projectile protection
- Set lightning shield armor bonus to 2, and +4 projectile protection.

These changes would help everyone using shields.. and would pair well with the new caster wand to give casters more survivability. 

They would provide a boost to the mace/shield combo for knights, but wouldn't over power any of the other weapons. 