### PR TITLE
Disincentivize Scripting and small balance changes

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -105258,18 +105258,18 @@
     {
         {
             new CreatureAttack(13,      25, 38,      "The giant smashes you with his fist.",
-                                                        new AttackProneComponent(15), 
-                                                        new AttackStunComponent(5)),                40
+                                                        new AttackProneComponent(10), 
+                                                        new AttackStunComponent(5)),                45
         },
         {
             new CreatureAttack(14,      29, 45,     "The giant stomps on you.",
-                                                        new AttackProneComponent(25), 
-                                                        new AttackStunComponent(10)),               40
+                                                        new AttackProneComponent(15), 
+                                                        new AttackStunComponent(5)),               45
         },
         {
             new CreatureAttack(15,      34, 54,     "The giant slams you across the room.",
                                                         new AttackProneComponent(100), 
-                                                        new AttackStunComponent(15)),               20
+                                                        new AttackStunComponent(20)),               10
         },
     };
     
@@ -105286,7 +105286,7 @@
         new LootPackEntry(true, AxeGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, (from, container) => new ReturningHammer(),        100),
         new LootPackEntry(true, (from, container) => new MoonstoneRing(),        100),
-        new LootPackEntry(true, (from, container) => new PermanentIntelligencePotion(),        50)
+        new LootPackEntry(true, AxePotions,        50)
     ));
        
     return giant;
@@ -107717,7 +107717,7 @@
         new LootPackEntry(true, UndeadGems,       4.5,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, AxeBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
-        new LootPackEntry(true, upperTreasure,   0.55),
+        new LootPackEntry(true, undeadTreasure,   0.55),
         new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new YouthPotion(), 0.4)
     ));
@@ -107776,7 +107776,7 @@
         new LootPackEntry(true, UndeadGems,       4.5,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, AxeBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
-        new LootPackEntry(true, upperTreasure,   0.5),
+        new LootPackEntry(true, undeadTreasure,   0.5),
         new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new YouthPotion(), 0.4)
     ));
@@ -107847,7 +107847,7 @@
         new LootPackEntry(true, UndeadGems,       4.5,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, AxeBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
-        new LootPackEntry(true, upperTreasure,   0.5),
+        new LootPackEntry(true, undeadTreasure,   0.5),
         new LootPackEntry(true, AxePotions,     0.1),
         new LootPackEntry(true, (from, container) => new YouthPotion(), 0.4)
     ));
@@ -107912,8 +107912,8 @@
         new LootPackEntry(true, UndeadGems,       45,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, AxeBottles,    100),
         new LootPackEntry(true, UtilityItems,    1),
-        new LootPackEntry(true, upperTreasure,   0.55),
-        new LootPackEntry(true, AxePotions,     0.1),
+        new LootPackEntry(true, undeadTreasure,   5),
+        new LootPackEntry(true, AxePotions,     5),
         new LootPackEntry(true, (from, container) => new YouthPotion(), 1)
     ));
 
@@ -108044,7 +108044,7 @@
         new LootPackEntry(true, UndeadGems,       4.5,     gemsPriceMutatorAboveAverage), 
         new LootPackEntry(true, AxeBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
-        new LootPackEntry(true, upperTreasure,   0.55),
+        new LootPackEntry(true, undeadTreasure,   0.55),
         new LootPackEntry(true, AxePotions,     0.1)
     ));
     
@@ -108109,7 +108109,7 @@
         new LootPackEntry(true, UndeadGems,       4.5,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, AxeBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
-        new LootPackEntry(true, upperTreasure,   0.5),
+        new LootPackEntry(true, undeadTreasure,   0.5),
         new LootPackEntry(true, AxePotions,     0.1)
     ));
     return worg;
@@ -109678,6 +109678,8 @@
       <bounds region="12">
         <inclusion left="2" top="3" right="24" bottom="38" />
         <inclusion left="25" top="9" right="29" bottom="38" />
+        <inclusion left="20" top="-4" right="21" bottom="2" />
+        <inclusion left="22" top="-4" right="26" bottom="-2" />
         <exclusion left="2" top="9" right="3" bottom="17" />
         <exclusion left="4" top="14" right="4" bottom="21" />
         <exclusion left="2" top="29" right="4" bottom="31" />
@@ -110130,8 +110132,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Mama">
-      <minimumDelay>10800</minimumDelay>
-      <maximumDelay>21600</maximumDelay>
+      <minimumDelay>7200</minimumDelay>
+      <maximumDelay>10800</maximumDelay>
       <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -110149,7 +110151,7 @@
       </script>
       <entry entity="BossMajorLevel14Dragon" size="1" minimum="1" maximum="1" />
       <bounds region="39">
-        <inclusion left="0" top="0" right="5" bottom="8" />
+        <inclusion left="0" top="0" right="5" bottom="6" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -110509,6 +110511,53 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new FireIceProtectionRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="3">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="7">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="5">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new MoonstoneRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="undeadTreasure">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -71038,7 +71038,7 @@
       </tile>
       <tile x="11" y="25">
         <component type="FloorComponent">
-          <ground>112523</ground>
+          <ground>23</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Leng" version="0.90.0.0">
+<segment name="Leng" version="0.92.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -70804,6 +70804,10 @@
         <component type="FloorComponent">
           <ground>16</ground>
         </component>
+        <component type="ObstructionComponent">
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
       </tile>
       <tile x="9" y="24">
         <component type="FloorComponent">
@@ -70813,6 +70817,10 @@
       <tile x="10" y="24">
         <component type="FloorComponent">
           <ground>16</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
         </component>
       </tile>
       <tile x="11" y="24">
@@ -71003,6 +71011,7 @@
           <wall>159</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="25">
@@ -71024,16 +71033,18 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="25">
         <component type="FloorComponent">
-          <ground>23</ground>
+          <ground>112523</ground>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="25">
@@ -71237,6 +71248,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="26">
@@ -79606,8 +79618,8 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9ConcWiz" size="1" minimum="5" maximum="5" />
-      <entry entity="level9FireWiz" size="1" minimum="6" maximum="6" />
+      <entry entity="level9ConcWiz" size="1" minimum="2" maximum="2" />
+      <entry entity="level9FireWiz" size="1" minimum="8" maximum="8" />
       <entry entity="level9Wraith" size="1" minimum="3" maximum="3" />
       <entry entity="level9WretchFighter" size="3" minimum="7" maximum="7" />
       <entry entity="level9Spectre" size="1" minimum="3" maximum="3" />
@@ -79825,10 +79837,9 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="BossMajorLevel14Sparky" size="1" minimum="1" maximum="1" />
-      <entry entity="level14Lich" size="1" minimum="2" maximum="2" />
-      <entry entity="level14Minotaur" size="1" minimum="3" maximum="3" />
       <bounds region="43">
         <inclusion left="28" top="3" right="31" bottom="8" />
+        <inclusion left="20" top="5" right="27" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -80275,8 +80286,8 @@
       <entry entity="level14Lich" size="1" minimum="2" maximum="2" />
       <entry entity="level14Minotaur" size="2" minimum="2" maximum="2" />
       <bounds region="43">
-        <inclusion left="8" top="2" right="18" bottom="9" />
-        <exclusion left="8" top="6" right="12" bottom="9" />
+        <inclusion left="5" top="2" right="18" bottom="9" />
+        <exclusion left="6" top="6" right="12" bottom="9" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="BossLevel12PowerTroll">
@@ -80352,9 +80363,9 @@
       <entry entity="level12Troll" size="3" minimum="10" maximum="10" />
       <entry entity="level12OrcArcher" size="3" minimum="5" maximum="5" />
       <bounds region="35">
-        <inclusion left="1" top="9" right="24" bottom="27" />
-        <exclusion left="8" top="25" right="11" bottom="27" />
-        <exclusion left="17" top="9" right="24" bottom="12" />
+        <inclusion left="1" top="9" right="8" bottom="27" />
+        <inclusion left="9" top="9" right="10" bottom="25" />
+        <inclusion left="11" top="13" right="24" bottom="27" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="priest">
@@ -80616,6 +80627,33 @@
       <bounds region="18">
         <inclusion left="29" top="34" right="35" bottom="37" />
         <inclusion left="41" top="26" right="43" bottom="36" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="drakeMinions">
+      <minimumDelay>1800</minimumDelay>
+      <maximumDelay>2100</maximumDelay>
+      <maximum>6</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="level14Lich" size="1" minimum="3" maximum="3" />
+      <entry entity="level14Minotaur" size="1" minimum="2" maximum="2" />
+      <entry entity="level14Manticora" size="1" minimum="2" maximum="2" />
+      <bounds region="43">
+        <inclusion left="28" top="3" right="31" bottom="8" />
+        <inclusion left="20" top="5" right="27" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -95999,7 +95999,9 @@
     };
 
     goblin.Wield(new Longbow());
-    goblin.Equip(new LeatherArmor());    
+    goblin.Equip(new LeatherArmor());  
+    
+    goblin.AddStatus(new NightVisionStatus(goblin));
 
     goblin.AddGold(66);
     goblin.AddLoot(
@@ -96153,7 +96155,9 @@
     };
 
     orc.Wield(new Crossbow());
-    orc.Equip(new LeatherArmor());    
+    orc.Equip(new LeatherArmor());   
+    
+    orc.AddStatus(new NightVisionStatus(orc));
 
     orc.AddGold(79);
     orc.AddLoot(
@@ -98638,7 +98642,7 @@
         Name = "dragon",
         
         MaxHealth = 2100, Health = 2100,
-        MaxMana = 20, Mana = 20,
+        MaxMana = 100, Mana = 100,
         BaseDodge = 28,
         
         Experience = 85594,
@@ -98692,7 +98696,7 @@
     {
         /* Expected output of damage is 60 per turn based on replay from Indi..DOOM. */
         new CreatureSpell<WhirlwindSpell>(
-            skillLevel: 15, cost: 20)
+            skillLevel: 15, cost: 100)
     };
     
     dragon.AddLoot(new LootPack(

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -98642,7 +98642,7 @@
         Name = "dragon",
         
         MaxHealth = 2100, Health = 2100,
-        MaxMana = 100, Mana = 100,
+        MaxMana = 40, Mana = 40,
         BaseDodge = 28,
         
         Experience = 85594,
@@ -98696,7 +98696,7 @@
     {
         /* Expected output of damage is 60 per turn based on replay from Indi..DOOM. */
         new CreatureSpell<WhirlwindSpell>(
-            skillLevel: 15, cost: 100)
+            skillLevel: 15, cost: 40)
     };
     
     dragon.AddLoot(new LootPack(

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -102648,11 +102648,11 @@ var gargoyle = new Gargoyle()
     gargoyle.Attacks = new CreatureAttackCollection
     {
         { 
-            new CreatureAttack(11, 15, 20, "The gargoyle strikes you with its claws.",
+            new CreatureAttack(13, 15, 20, "The gargoyle strikes you with its claws.",
                                                      new AttackPoisonComponent(10)),     60
         }, 
         {
-            new CreatureAttack(11, 16, 22, "The gargoyle batters you with its wings."),      40
+            new CreatureAttack(13, 16, 22, "The gargoyle batters you with its wings."),      40
         }, 
     };
     

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -99607,7 +99607,7 @@
         new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    .3), 
-        new LootPackEntry(true, UpperTreasure,    0.15)
+        new LootPackEntry(true, LowerTreasure,    0.15)
     ));
     
     return wyvern;
@@ -99673,7 +99673,7 @@
         new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    .3), 
-        new LootPackEntry(true, UpperTreasure,    0.15)
+        new LootPackEntry(true, LowerTreasure,    0.15)
     ));
     
     return wyvern;
@@ -99739,7 +99739,7 @@
         new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    .3), 
-        new LootPackEntry(true, UpperTreasure,    0.15)
+        new LootPackEntry(true, LowerTreasure,    0.15)
     ));
     
     return wyvern;
@@ -99804,7 +99804,7 @@
         new LootPackEntry(true, UnderkingdomGems,       2,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, UnderkingdomBottles,    10), 
         new LootPackEntry(true, UtilityItems,    .3), 
-        new LootPackEntry(true, UpperTreasure,    0.15)
+        new LootPackEntry(true, LowerTreasure,    0.15)
     ));
     
     return wyvern;
@@ -100538,6 +100538,7 @@
     
     orc.Wield(new Longbow());
     orc.Equip(new LeatherArmor());
+    orc.AddStatus(new NightVisionStatus(orc));
             
     orc.AddGold(112);
     orc.AddLoot(new LootPack(
@@ -100909,7 +100910,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.55), 
+        new LootPackEntry(true, LowerTreasure,    0.55), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     
@@ -101022,7 +101023,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.5), 
+        new LootPackEntry(true, LowerTreasure,    0.5), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     
@@ -101617,7 +101618,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorHigh), 
         new LootPackEntry(true, UnderkingdomBottles,    50), 
         new LootPackEntry(true, UtilityItems,    3), 
-        new LootPackEntry(true, UpperTreasure,    0.63)
+        new LootPackEntry(true, LowerTreasure,    0.63)
     ));
     
     return lurker;
@@ -101899,7 +101900,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.37), 
+        new LootPackEntry(true, LowerTreasure,    0.37), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     
@@ -101947,7 +101948,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.5), 
+        new LootPackEntry(true, LowerTreasure,    0.5), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     
@@ -101994,7 +101995,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.55), 
+        new LootPackEntry(true, LowerTreasure,    0.55), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     
@@ -102042,7 +102043,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.5), 
+        new LootPackEntry(true, LowerTreasure,    0.5), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     return orc;
@@ -102089,7 +102090,7 @@
         new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, UnderkingdomBottles,    20), 
         new LootPackEntry(true, UnderkingdomPotions,    0.2), 
-        new LootPackEntry(true, UpperTreasure,    0.37), 
+        new LootPackEntry(true, LowerTreasure,    0.37), 
         new LootPackEntry(true, UtilityItems,    1)
     ));
     
@@ -102605,6 +102606,76 @@
         new LootPackEntry(true, UtilityItems,    1)
     ));
     return orc;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="level13Gargoyle">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+var gargoyle = new Gargoyle()
+    {
+        MaxHealth = 145, Health = 145,
+        BaseDodge = 24,
+        HideDetection = 28,
+        Experience = 6825,
+        MagicProtection = 17,
+        Movement = 3,
+        CanFly = true,
+        BasePenetration = ShieldPenetration.Heavy,
+        
+        Immunity = CreatureImmunity.Bow | CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Poison,
+        Weakness = CreatureWeakness.Silver,
+
+        FireProtection = 100,
+    };
+    
+    gargoyle.AddStatus(new NightVisionStatus(gargoyle));
+    
+    gargoyle.Attacks = new CreatureAttackCollection
+    {
+        { 
+            new CreatureAttack(11, 15, 20, "The gargoyle strikes you with its claws.",
+                                                     new AttackPoisonComponent(10)),     60
+        }, 
+        {
+            new CreatureAttack(11, 16, 22, "The gargoyle batters you with its wings."),      40
+        }, 
+    };
+    
+    gargoyle.Blocks = new CreatureBlockCollection
+    {
+            new CreatureBlock(6, "the armor"),
+            new CreatureBlock(3, "a claw"),
+            new CreatureBlock(1, "a wing")
+    };
+
+    gargoyle.Wield(new Greatsword());    
+
+    gargoyle.AddGold(115);
+    gargoyle.AddLoot(
+        new LootPack(
+        new LootPackEntry(true, UnderkingdomGems,       10.4,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, UnderkingdomBottles,    20), 
+        new LootPackEntry(true, UnderkingdomPotions,    0.2), 
+        new LootPackEntry(true, UpperTreasure,    0.55), 
+        new LootPackEntry(true, UtilityItems,    1)
+        ));
+
+    return gargoyle;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -104104,6 +104175,7 @@
       <entry entity="Level14EliteTrollGuard" size="1" minimum="11" maximum="11" />
       <bounds region="9">
         <inclusion left="4" top="11" right="13" bottom="20" />
+        <inclusion left="6" top="22" right="11" bottom="25" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -104553,6 +104625,7 @@
       <entry entity="level12Cursetroll" size="1" minimum="1" maximum="1" />
       <entry entity="level12TrollRHammer" size="3" minimum="1" maximum="1" />
       <entry entity="level12Hob" size="3" minimum="3" maximum="3" />
+      <entry entity="level12OrcArcher" size="1" minimum="3" maximum="4" />
       <bounds region="11">
         <inclusion left="3" top="3" right="17" bottom="19" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -104609,6 +104682,7 @@
       <entry entity="level12Cursetroll" size="1" minimum="1" maximum="1" />
       <entry entity="level12TrollRHammer" size="3" minimum="1" maximum="1" />
       <entry entity="level12Hob" size="3" minimum="3" maximum="3" />
+      <entry entity="level12OrcArcher" size="1" minimum="3" maximum="4" />
       <bounds region="11">
         <inclusion left="3" top="24" right="17" bottom="39" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -105234,6 +105308,55 @@
         <inclusion left="17" top="2" right="49" bottom="21" />
       </bounds>
     </spawn>
+    <spawn type="RegionSpawner" name="tk300courtyardGarg">
+      <minimumDelay>600</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <maximum>3</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="level13Gargoyle" size="1" minimum="2" maximum="3" />
+      <bounds region="8">
+        <inclusion left="2" top="2" right="15" bottom="6" />
+        <exclusion left="2" top="7" right="15" bottom="7" />
+        <exclusion left="16" top="2" right="16" bottom="7" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="tk300DungeonNotSafe">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
+      <maximum>2</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="level13Gargoyle" size="1" minimum="1" maximum="2" />
+      <bounds region="8">
+        <inclusion left="28" top="4" right="36" bottom="10" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
   </spawns>
   <treasures>
     <treasure name="UnderkingdomBottles">
@@ -105463,7 +105586,7 @@
       </entry>
     </treasure>
     <treasure name="UpperTreasure">
-      <entry weight="1">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -105472,7 +105595,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -105481,7 +105604,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="5">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -105494,7 +105617,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new FireIceProtectionRing();
+	return new DexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -105580,6 +105703,44 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new FireballOrb();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="LowerTreasure">
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongStrengthRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new ShieldRing();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new FireIceProtectionRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
Axe:
Reworked some boundaries to encourage some additional ranging to interrupt scripting

adjusted Mama to not roam on the ledge - this allows for players to strategize as a group
Also reduced Mama spawn timer

Updated prone chances and loot from Giant - there's not really a good reason to go to the Giant, as he's harder than Kosh with a worse payout.  He's still harder than Kosh, but at least there's a potion chance now

undead treasure
changed the treasure from the undead area to be specific, not just upper glacier - dropped the lower level items, added low chance of dex - loot more in line with higher level area

Leng:
add Manticora to drake, adjusted timers

Bumped down number of concussion wiz and up number of fire wiz to better align with difficulty at level

Adjusted script-able areas to disincentivize scripting at the waterfall

Oak:
Updated Windy to have a longer cast regen time

Updated to help alleviate scripting in -2

UK:
Adjusted -300 with gargs to help alleviate scripting

Adjusted sewers to help alleviate scripting

Balanced dex ring drops