### PR TITLE
Modifiable Items

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
@@ -75,6 +75,7 @@ namespace Kesmai.Server.Items
 			writer.Write((short)2); /* version */
 			
 			writer.Write((byte)_baseArmorBonus);
+			//Do we need to Serialize/Deserialize the Hue?
 		}
 
 		/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
@@ -1,11 +1,19 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Drawing;
 using Kesmai.Server.Network;
 
 namespace Kesmai.Server.Items
 {
 	public partial class LeatherArmor : Armor
 	{
+		/* Add a new backing field */
+		private int _baseArmorBonus;
+
+		private Color _hue;
+		
+		private string _rarity;
+		
 		/// <inheritdoc />
 		public override uint BasePrice => 25;
 
@@ -21,11 +29,28 @@ namespace Kesmai.Server.Items
 		/// <inheritdoc />
 		public override int BashingProtection => 1;
 		
+		public override int BaseArmorBonus // This is now configured to what we set.
+		{
+			get
+			{
+				if (Owner is PlayerEntity)
+					return _baseArmorBonus;
+
+				return 0;
+			}
+		}
+
+		public override Color Hue => _hue;
+		
+		
 		/// <summary>
 		/// Initializes a new instance of the <see cref="LeatherArmor"/> class.
 		/// </summary>
-		public LeatherArmor() : base(242)
+		public LeatherArmor(int armorBonus = 0) : base(242)
 		{
+			_baseArmorBonus = armorBonus;
+			_hue = Rarity.GetRarityColor(armorBonus);
+			_rarity = Rarity.GetRarity(armorBonus)
 		}
 		
 		/// <inheritdoc />
@@ -34,7 +59,45 @@ namespace Kesmai.Server.Items
 			entries.Add(new LocalizationEntry(6200000, 6200002)); /* [You are looking at] [a suit of leather armor.] */
 
 			if (Identified)
-				entries.Add(new LocalizationEntry(6250001)); /* The armor seems quite ordinary. */
+				entries.Add(new LocalizationEntry($"This armor seems quite {_rarity}"));
+			entries.Add(new LocalizationEntry($"This has +{_baseArmoronus} armor."));
+		}
+		
+		
+		/* This is pulled from the internal code to be exposed since we are modifying it */
+		/// <inheritdoc />
+		public override void Serialize(BinaryWriter writer)
+		{
+			base.Serialize(writer);
+
+			/* increment the version so items get saved as new version. */
+			//writer.Write((short)1); /* version */
+			writer.Write((short)2); /* version */
+			
+			writer.Write((byte)_baseArmorBonus);
+		}
+
+		/// <inheritdoc />
+		public override void Deserialize(BinaryReader reader)
+		{
+			base.Deserialize(reader);
+
+			var version = reader.ReadInt16();
+			
+			switch (version)
+			{
+				// Add a new block here to load items into the right version, and convert to new version.
+				case 2:
+				{
+					_baseArmorBonus = (int)reader.ReadByte();  // This property was added in version 2.
+
+					goto case 1; // Load any data from the older version.
+				}
+				case 1:
+				{
+					break;
+				}
+			}
 		}
 	}
 }

--- a/Source/Kesmai.Server/Game/Items/Rarity.cs
+++ b/Source/Kesmai.Server/Game/Items/Rarity.cs
@@ -1,0 +1,67 @@
+﻿using System.Drawing;
+
+namespace Kesmai.Server.Items
+public static class Rarity
+{
+	public static string GetRarity(int rarity.Clamp(0,5))
+	{
+		var rareText = "Common";
+		switch (rarity)
+		{
+			case 0:
+				break;
+
+			case 1:
+				rareText = "Uncommon";
+				break;
+			
+			case 2:
+				rareText = "Rare";
+				break;
+			
+			case 3:
+				rareText = "Epic";
+				break;
+
+			case 4:
+				rareText = "Legendary";
+				break;
+
+			case 5:
+				rareText = "Mythical";
+				break;
+		}
+		return rareText;
+	}
+	
+	public static Color GetRarityColor(int rarity.Clamp(0,5))
+	{		
+		var hue = Color.Transparent;
+		switch (rarity)
+		{
+			case 0:
+				break;
+
+			case 1:
+				hue = Color.FromArgb(0x781eff00);
+				break;
+			
+			case 2:
+				hue = Color.FromArgb(0x780070dd);
+				break;
+
+			case 3:
+				hue = Color.FromArgb(0x78a335ee);
+				break;
+
+			case 4:
+				hue = Color.FromArgb(0x78ff8000);
+				break;
+
+			case 5:
+				hue = Color.FromArgb(0x78dc143c);
+				break;
+		}
+		return hue;
+	}
+}			


### PR DESCRIPTION
Implement a Modifiable Leather Armor as a proof of concept for modifiable items.  Implement Rarity static class to assist with tinting and labeling modified items. The leather armor should take an int for the amount of BaseArmorBonus. This works for armors because most armors implement defenses as protections isntead of base armor. For Weapons, we would want the argument to add to the existing BaseAttackBonus and BaseArmorBonus of the modified item.