### PR TITLE
Kesmai early progression update

### DIFF
--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -61806,8 +61806,8 @@
           <indestructible>true</indestructible>
         </component>
         <component type="RopeComponent">
-          <destinationX>16</destinationX>
-          <destinationY>36</destinationY>
+          <destinationX>17</destinationX>
+          <destinationY>35</destinationY>
           <destinationRegion>11</destinationRegion>
           <teleporterId>255</teleporterId>
         </component>
@@ -96855,7 +96855,7 @@
                 
     elderTroll.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(7, 25, 30,
+        new CreatureBasicAttack(5, 10, 25,
             new AttackProneComponent(15.0), new AttackStunComponent(15.0))
     };
                 
@@ -100768,7 +100768,8 @@ return orc;
         new LootPackEntry(true, kesmaiwideGems,       100,     gemsPriceMutatorVeryHigh),
         new LootPackEntry(true, kesmaiwideGems,       100,     gemsPriceMutatorVeryHigh),
             new LootPackEntry(true, (from, container) => new ScorpionRobe(),        100),
-            new LootPackEntry(true, (from, container) => new SteelLongsword(),        50.0)
+            new LootPackEntry(true, (from, container) => new SteelLongsword(),        50.0),
+            new LootPackEntry(true, (from, container) => new TigerSkull(), 100)
         ));
     
     return dragon;
@@ -103501,20 +103502,11 @@ else
       </entry>
     </treasure>
     <treasure name="dungeon1Treasure">
-      <entry weight="14">
+      <entry weight="9">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new WeakStrengthRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="5">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new RamSkull();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -103716,15 +103708,6 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new TigerSkull();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="dungeon3Treasure">
       <entry weight="20">
@@ -103741,15 +103724,6 @@ else
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new FireProtectionAmulet();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="20">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new TigerSkull();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -103877,24 +103851,6 @@ else
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new IceProtectionRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new BlindResistanceRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="dungeon4Rings">
       <entry weight="1">
@@ -104014,15 +103970,6 @@ else
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new WeakShieldRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new RamSkull();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
@@ -19,13 +19,19 @@ namespace Kesmai.Server.Items
 		public override int Hindrance => 1;
 
 		/// <inheritdoc />
-		public override int SlashingProtection => 1;
+		public override int SlashingProtection => 2;
 
 		/// <inheritdoc />
-		public override int PiercingProtection => 1;
+		public override int PiercingProtection => 2;
 
 		/// <inheritdoc />
-		public override int BashingProtection => 1;
+		public override int BashingProtection => 2;
+
+		/// <inheritdoc />
+		public override int ProjectileProtection => 2;
+
+		/// <inheritdoc />
+		public override int ProtectionFromIce => 5;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="LizardScales"/> class.

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
@@ -19,14 +19,17 @@ namespace Kesmai.Server.Items
 		public override int Hindrance => 1;
 
 		/// <inheritdoc />
-		public override int SlashingProtection => 1;
+		public override int SlashingProtection => 2;
 
 		/// <inheritdoc />
-		public override int PiercingProtection => 1;
+		public override int PiercingProtection => 2;
 
 		/// <inheritdoc />
-		public override int BashingProtection => 1;
+		public override int BashingProtection => 2;
 
+		/// <inheritdoc />
+		public override int ProjectileProtection => 2;
+		
 		/// <inheritdoc />
 		public override int ProtectionFromFire => 5;
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Jackets/GriffinJacket.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Jackets/GriffinJacket.cs
@@ -16,9 +16,6 @@ namespace Kesmai.Server.Items
 		/// <remarks>Robes have a default <see cref="Hindrance"/> value of 1.</remarks>
 		public override int Hindrance => 0;
 		
-		/// <inheritdoc />
-		public override int ProtectionFromFire => 10;
-
         /// <summary>
 		/// Initializes a new instance of the <see cref="GriffinJacket"/> class.
 		/// </summary>
@@ -31,5 +28,40 @@ namespace Kesmai.Server.Items
 		{
 			entries.Add(new LocalizationEntry(6200000, 6200195)); /* [You are looking at] [a vest made from the feathers of a griffin.] */
 		}
+
+				protected override bool OnEquip(MobileEntity entity)
+		{
+			if (!base.OnEquip(entity))
+				return false;
+
+			if (!entity.GetStatus(typeof(BlindResistanceStatus), out var resistance))
+			{
+				resistance = new BlindResistanceStatus(entity)
+				{
+					Inscription = new SpellInscription() { SpellId = 47 }
+				};
+				resistance.AddSource(new ItemSource(this));
+				
+				entity.AddStatus(resistance);
+			}
+			else
+			{
+				resistance.AddSource(new ItemSource(this));
+			}
+
+			return true;
+		}
+
+		protected override bool OnUnequip(MobileEntity entity)
+		{
+			if (!base.OnUnequip(entity))
+				return false;
+			
+			if (entity.GetStatus(typeof(BlindResistanceStatus), out var resistance))
+				resistance.RemoveSourceFor(this);
+
+			return true;
+		}
+	}
 	}
 }

--- a/Source/Kesmai.Server/Game/Items/Equipment/Jackets/GrizzlyJacket.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Jackets/GrizzlyJacket.cs
@@ -12,6 +12,12 @@ namespace Kesmai.Server.Items
         /// <inheritdoc />
 		public override int Weight => 2000;
         
+		/// <inheritdoc />
+		public override int Hindrance => 0;
+		
+		/// <inheritdoc />
+		public override int ProtectionFromFire => 10;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="GrizzlyJacket"/> class.
 		/// </summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Jackets/PolarBearJacket.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Jackets/PolarBearJacket.cs
@@ -12,6 +12,12 @@ namespace Kesmai.Server.Items
         /// <inheritdoc />
 		public override int Weight => 1600;
 
+		/// <inheritdoc />
+		public override int Hindrance => 0;
+		
+		/// <inheritdoc />
+		public override int ProtectionFromIce => 10;
+
         /// <summary>
 		/// Initializes a new instance of the <see cref="PolarBearJacket"/> class.
 		/// </summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Jackets/SharkJacket.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Jackets/SharkJacket.cs
@@ -13,7 +13,7 @@ namespace Kesmai.Server.Items
 		public override int Weight => 1200;
 
         /// <inheritdoc />
-		public override int Hindrance => 1;
+		public override int Hindrance => 0;
 
         /// <summary>
 		/// Initializes a new instance of the <see cref="SharkJacket"/> class.
@@ -29,6 +29,40 @@ namespace Kesmai.Server.Items
 
 			if (Identified)
 				entries.Add(new LocalizationEntry(6250099)); /* The jacket appears quite ordinary. */
+		}
+
+		protected override bool OnEquip(MobileEntity entity)
+		{
+			if (!base.OnEquip(entity))
+				return false;
+
+			if (!entity.GetStatus(typeof(BreatheWaterStatus), out var status))
+			{
+				status = new BreatheWaterStatus(entity)
+				{
+					Inscription = new SpellInscription() { SpellId = 4 }
+				};
+				status.AddSource(new ItemSource(this));
+				
+				entity.AddStatus(status);
+			}
+			else
+			{
+				status.AddSource(new ItemSource(this));
+			}
+
+			return true;
+		}
+
+		protected override bool OnUnequip(MobileEntity entity)
+		{
+			if (!base.OnUnequip(entity))
+				return false;
+
+			if (entity.GetStatus(typeof(BreatheWaterStatus), out var status))
+				status.RemoveSourceFor(this);
+
+			return true;
 		}
 	}
 }

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/SpikedClub.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/SpikedClub.cs
@@ -22,6 +22,9 @@ namespace Kesmai.Server.Items
 		/// <inheritdoc />
 		public override int BaseArmorBonus => 1;
 
+				/// <inheritdoc />
+		public override int BaseAttackBonus => 2;
+
 		/// <inheritdoc />
 		public override Skill Skill => Skill.Mace;
 
@@ -41,7 +44,7 @@ namespace Kesmai.Server.Items
 			entries.Add(new LocalizationEntry(6200000, 6200139)); /* [You are looking at] [a huge wooden club with a metal spike.] */
 
 			if (Identified)
-				entries.Add(new LocalizationEntry(6250081)); /* The club appears quite ordinary. */
+				entries.Add(new LocalizationEntry(6250080)); /* The combat adds for this weapon are +2. */
 		}
 	}
 }


### PR DESCRIPTION
armor progression fix, there is now a clear prgression of armors for the early (pre dragon scale) armors
skulls now only come from lairs in kes.
Trog difficulty reduced to incorporate into armor and skull path.

Implemented some purpose for jackets.  Can be used until robes become better or by ma pre kimono.

Removed some rings from -3 that dropped before element was encountered