### PR TITLE
Make Axe giant drop a random pot every kill

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -105318,7 +105318,7 @@
         new LootPackEntry(true, AxeGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, (from, container) => new ReturningHammer(),        100),
         new LootPackEntry(true, (from, container) => new MoonstoneRing(),        100),
-        new LootPackEntry(true, AxePotions,        50)
+        new LootPackEntry(true, AxePotions,        100)
     ));
        
     return giant;


### PR DESCRIPTION
Based on a discord voice discussion:

A group of us felt that for the difficulty and skill required to kill the axe giant, his 50% chance of dropping a random pot was a little low. 