### PR TITLE
Changes to Misericorde Dagger and how it drops

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -106596,8 +106596,7 @@
         new LootPackEntry(true, AxeGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, AxeGems,       100,     gemsPriceMutatorVeryHigh), 
        new LootPackEntry(true, YetiTreasure,     100.0),       
-       new LootPackEntry(true, (from, container) => new ManaPotion(),        100),
-       new LootPackEntry(true, (from, container) => new MisericordeDagger(),        100)
+       new LootPackEntry(true, (from, container) => new ManaPotion(),        100)
    ));
     
    return yeti;
@@ -106609,6 +106608,12 @@
         <block><![CDATA[
     if (killer is PlayerEntity player)
     {
+    
+        var backpack = source.Backpack;
+    
+        if (backpack != null)
+            backpack.AddItem(new MisericordeDagger(player));
+            
         var quest = Quests.GetQuest<KnightsDragonSlayerQuest>();
     
         if (quest != null && quest.InProgress(player))

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/MisericordeDagger.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/MisericordeDagger.cs
@@ -11,7 +11,19 @@ namespace Kesmai.Server.Items
 		public override uint BasePrice => 30;
 
 		/// <inheritdoc />
-		public override int BaseAttackBonus => 3;
+		public override ShieldPenetration Penetration => ShieldPenetration.VeryHeavy;
+
+		/// <inheritdoc />
+		public override int BaseArmorBonus => 3;
+
+		/// <inheritdoc />
+		public override int BaseAttackBonus => 4;
+
+		/// <inheritdoc />
+		public override int MinimumDamage => 1;
+
+		/// <inheritdoc />
+		public override int MaximumDamage => 10;
 
 		/// <inheritdoc />
 		public override WeaponFlags Flags => base.Flags | WeaponFlags.BlueGlowing | WeaponFlags.Neutral;
@@ -35,7 +47,7 @@ namespace Kesmai.Server.Items
 			entries.Add(new LocalizationEntry(6200000, 6200159)); /* [You are looking at] [an exquisite lemurian misericorde dagger whose honed finish reveals the wood grained texture of the metal. The dagger is emitting a faint blue glow. The weapon is neutral.] */
 
 			if (Identified)
-				entries.Add(new LocalizationEntry(6250007)); /* The combat adds for this weapon are +3. */
+				entries.Add(new LocalizationEntry(6250003)); /* The combat adds for this weapon are +4. */
 		}
 	}
 }

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/MisericordeDagger.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/MisericordeDagger.cs
@@ -11,10 +11,10 @@ namespace Kesmai.Server.Items
 		public override uint BasePrice => 30;
 
 		/// <inheritdoc />
-		public override ShieldPenetration Penetration => ShieldPenetration.VeryHeavy;
+		public override ShieldPenetration Penetration => ShieldPenetration.Medium;
 
 		/// <inheritdoc />
-		public override int BaseArmorBonus => 3;
+		public override int BaseArmorBonus => 2;
 
 		/// <inheritdoc />
 		public override int BaseAttackBonus => 4;
@@ -23,7 +23,7 @@ namespace Kesmai.Server.Items
 		public override int MinimumDamage => 1;
 
 		/// <inheritdoc />
-		public override int MaximumDamage => 10;
+		public override int MaximumDamage => 8;
 
 		/// <inheritdoc />
 		public override WeaponFlags Flags => base.Flags | WeaponFlags.BlueGlowing | WeaponFlags.Neutral;


### PR DESCRIPTION
Proposal to change Misericorde dagger to a less-powerful version of the BBS (Medium armor pen compared to Very Heavy, 1-10 damage instead of 2-12).

It will drop from yeti and bind to the person who gets the killing blow so no recall for twinking people.

It will also not be a returning weapon.

I believe there will be zero impact to balance but will make dagger players happy.