### PR TITLE
Increase value of certain treasure items.

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/CrystalGauntlets.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/CrystalGauntlets.cs
@@ -11,7 +11,7 @@ namespace Kesmai.Server.Items
 		public override int LabelNumber => 6000041;
 
         /// <inheritdoc />
-		public override uint BasePrice => 1;
+		public override uint BasePrice => 1500;
 
         /// <inheritdoc />
 		public override int Weight => 200;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/SwiftGauntlets.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/SwiftGauntlets.cs
@@ -9,7 +9,7 @@ namespace Kesmai.Server.Items
 	public partial class SwiftGauntlets : Gauntlets, ITreasure
 	{
 		/// <inheritdoc />
-		public override uint BasePrice => 1;
+		public override uint BasePrice => 2000;
 
 		/// <inheritdoc />
 		public override int Weight => 100;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/BlackBroadsword.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/BlackBroadsword.cs
@@ -11,7 +11,11 @@ namespace Kesmai.Server.Items
 		public override int LabelNumber => 6000019;
 
 		/// <inheritdoc />
-		public override uint BasePrice => 1;
+		/// <remarks>
+		/// The individual components give 1700. If the item were to be broken by a player,
+		/// it would award better experience.
+		/// </remarks>
+		public override uint BasePrice => 1000;
 
 		/// <inheritdoc />
 		public override int Weight => 4160;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/HummingbirdSword.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/HummingbirdSword.cs
@@ -9,7 +9,7 @@ namespace Kesmai.Server.Items
 	public partial class HummingbirdSword : ShortSword, ITreasure
 	{
 		/// <inheritdoc />
-		public override uint BasePrice => 1;
+		public override uint BasePrice => 2000;
 		
 		/// <inheritdoc />
 		public override int BaseAttackBonus => 4;


### PR DESCRIPTION
Certain treasures don't have value to them. A BBS sells for 1 coin, or CGs for 1. It impacts the experience awarded when broken.  You would now get 15k experience for breaking someone's BBS.