### PR TITLE
Change Kosh Gaunt description (updated and ready for review)

### DIFF
--- a/Content/Localization/Enu.xml
+++ b/Content/Localization/Enu.xml
@@ -679,6 +679,7 @@
 	<entry index="6200339">a miniature decorative holiday tree.</entry>
 	<entry index="6200340">a star used for decorating holiday trees.</entry>
 	<entry index="6200341">an antique Lengian parrying dagger with a gold heron inscribed in the smooth blue gilted metal. The weapon feels exceptionally well balanced. The weapon is neutral.</entry>
+    <entry index="6200342">a pair of gauntlets made from leathery dragon skin with shiny blue-steel plates. The Gauntlets emit a Blue Glow.</entry>
 
   <entry index="6250001">The armor seems quite ordinary.</entry>
   <entry index="6250002">The combat adds for this weapon are +5.</entry>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/KoshGauntlets.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/KoshGauntlets.cs
@@ -54,7 +54,7 @@ namespace Kesmai.Server.Items
 		/// <inheritdoc />
 		public override void GetDescription(List<LocalizationEntry> entries)
 		{
-			entries.Add(new LocalizationEntry(6200000, 6200170)); /* [You are looking at] [a pair of leather gauntlets with steel plates.] */
+			entries.Add(new LocalizationEntry(6200000, 6200342)); /* [You are looking at] [a pair of gauntlets made from leathery dragon skin with shiny blue-steel plates. The Gauntlets emit a Blue Glow.] */
 
 			if (Identified)
 				entries.Add(new LocalizationEntry(6250094)); /* The combat adds for the gauntlets are +2. */


### PR DESCRIPTION
Changed the Kosh Gauntlet identify messages to a unique description:

"a pair of gauntlets made from leathery dragon skin with shiny blue-steel plates. The Gauntlets emit a Blue Glow."