### PR TITLE
Experience tweaks on Sewers, Speedy and -300

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Underkingdom" version="0.92.0.0">
+<segment name="Underkingdom" version="0.93.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -57067,8 +57067,8 @@
       <id>11</id>
       <name>Lightning Caves</name>
       <height>-80</height>
-      <experienceMultiplier>2.2</experienceMultiplier>
-      <healthMultiplier>1.3</healthMultiplier>
+      <experienceMultiplier>1.8</experienceMultiplier>
+      <healthMultiplier>1.2</healthMultiplier>
       <level>22</level>
       <tile x="0" y="0">
         <component type="WallComponent">
@@ -100430,7 +100430,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 21,
         HideDetection = 25,            
-        Experience = 6018,
+        Experience = 7221,
         BasePenetration = ShieldPenetration.Light,
         CanFlee = true,
     };
@@ -100697,7 +100697,7 @@
         MaxMana = 13, Mana = 13,
         BaseDodge = 22,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 6018,
+        Experience = 7221,
         LightningResistance = 100,
         HideDetection = 25, 
     };
@@ -100754,7 +100754,7 @@
         MaxHealth = 128, Health = 128,
         BaseDodge = 22,
         HideDetection = 25,        
-        Experience = 6464,
+        Experience = 7441,
         BasePenetration = ShieldPenetration.Medium,
     };
     
@@ -100803,7 +100803,7 @@
         MaxHealth = 143, Health = 143,
         BaseDodge = 22,
         HideDetection = 25,           
-        Experience = 6800,
+        Experience = 7441,
         BasePenetration = ShieldPenetration.Medium,
     };
     
@@ -100904,7 +100904,7 @@
         MaxHealth = 130, Health = 130,
         BaseDodge = 21,
         HideDetection = 25,
-        Experience = 6018,
+        Experience = 7221,
         BasePenetration = ShieldPenetration.Medium,
     };
     
@@ -101061,7 +101061,7 @@
         MaxHealth = 114, Health = 114,
         BaseDodge = 23,
         HideDetection = 25,
-        Experience = 6464,
+        Experience = 7756,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 31, Mana = 31,
             
@@ -102554,7 +102554,7 @@
         MaxMana = 13, Mana = 13,
         BaseDodge = 22,
         BasePenetration = ShieldPenetration.VeryLight,
-        Experience = 6018,
+        Experience = 7221,
         HideDetection = 25,
     };
     
@@ -102752,7 +102752,7 @@ var gargoyle = new Gargoyle()
         MaxHealth = 145, Health = 145,
         BaseDodge = 24,
         HideDetection = 28,
-        Experience = 6825,
+        Experience = 7756,
         MagicProtection = 17,
         Movement = 3,
         CanFly = true,


### PR DESCRIPTION
After reviewing the xp settings in these areas I understand why the spawn modifiers were set in the sewers. Both -100 and Sewers share the same mob table, so the xp modifier in sewers was placed to make them give a little bit more experience without having to make another set of mobs. I decided to continue using the experience modifier in sewers, but made the following changes:

- Adjusted the XP modifier in sewers from 2.2 to 1.8 - This brings the xp in line with areas of similar difficulty (TT, Ianta Leng, and Griff Cliffs Leng)
- Raised the XP of the shared -300/Speedy mobs by a modifier of 1.2. This was changed directly in the entities tab. This should put both Speedy and -300 in line with the xp/hour gained in sewers currently.

Darkice worked on these changes with me, and agrees with them as well. 