### PR TITLE
Fixed an issue where experience modifier artifacts remained

### DIFF
--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -174,7 +174,6 @@
       <id>1</id>
       <name>Surface</name>
       <height>0</height>
-      <experienceMultiplier>1.1</experienceMultiplier>
       <level>5</level>
       <tile x="0" y="0">
         <component type="ObstructionComponent">
@@ -43171,7 +43170,6 @@
       <id>11</id>
       <name>Dungeon -1</name>
       <height>-10</height>
-      <experienceMultiplier>1.05</experienceMultiplier>
       <level>3</level>
       <tile x="2" y="2">
         <component type="StaticComponent">
@@ -54108,7 +54106,6 @@
       <id>12</id>
       <name>Dungeon -2</name>
       <height>-20</height>
-      <experienceMultiplier>1.1</experienceMultiplier>
       <level>5</level>
       <tile x="1" y="2">
         <component type="WallComponent">
@@ -64001,7 +63998,6 @@
       <id>13</id>
       <name>Dungeon -3</name>
       <height>-30</height>
-      <experienceMultiplier>1.15</experienceMultiplier>
       <level>8</level>
       <tile x="10" y="0" />
       <tile x="11" y="0" />

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -57067,8 +57067,6 @@
       <id>11</id>
       <name>Lightning Caves</name>
       <height>-80</height>
-      <experienceMultiplier>2.2</experienceMultiplier>
-      <healthMultiplier>1.3</healthMultiplier>
       <level>22</level>
       <tile x="0" y="0">
         <component type="WallComponent">


### PR DESCRIPTION
Sewer modifier was in when we were originally using the -100 tunnels monster values. With new system experience modifiers are unneeded (but should we go with Kora's ideas of weighting zones for gold/xp/loot balance we can edit as needed).