### PR TITLE
Thief Trainer in Lockpick Town

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -47846,6 +47846,123 @@
       <name>Lockpick Town</name>
       <height>150</height>
       <level>14</level>
+      <tile x="6" y="-2">
+        <component type="WallComponent">
+          <wall>149</wall>
+          <destroyed>150</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="7" y="-2">
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="8" y="-2">
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="9" y="-2">
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="10" y="-2">
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="11" y="-2">
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="6" y="-1">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="7" y="-1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="8" y="-1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="9" y="-1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="10" y="-1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="11" y="-1">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="6" y="0">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="7" y="0">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="8" y="0">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="9" y="0">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="10" y="0">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="11" y="0">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
       <tile x="3" y="1">
         <component type="StaticComponent">
           <static>175</static>
@@ -47884,10 +48001,39 @@
       </tile>
       <tile x="6" y="1">
         <component type="WallComponent">
-          <wall>145</wall>
-          <destroyed>147</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="7" y="1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="8" y="1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="9" y="1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="10" y="1">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="11" y="1">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
         </component>
       </tile>
       <tile x="3" y="2">
@@ -47941,6 +48087,9 @@
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
       </tile>
       <tile x="8" y="2">
         <component type="StaticComponent">
@@ -47952,6 +48101,9 @@
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
       </tile>
       <tile x="9" y="2">
         <component type="WallComponent">
@@ -47959,6 +48111,24 @@
           <destroyed>147</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="10" y="2">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="11" y="2">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
         </component>
       </tile>
       <tile x="3" y="3">
@@ -48012,6 +48182,21 @@
           <destroyed>148</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="10" y="3">
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+      </tile>
+      <tile x="11" y="3">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
         </component>
       </tile>
       <tile x="1" y="4">
@@ -48126,22 +48311,31 @@
         </component>
       </tile>
       <tile x="10" y="4">
-        <component type="StaticComponent">
-          <static>175</static>
-        </component>
-        <component type="WallComponent">
-          <wall>145</wall>
-          <destroyed>147</destroyed>
-          <ruins>0</ruins>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>145</secretId>
+          <destroyedId>82</destroyedId>
+          <isSecret>true</isSecret>
           <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
         </component>
       </tile>
       <tile x="11" y="4">
         <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>183</ground>
+        </component>
+        <component type="WallComponent">
           <wall>145</wall>
           <destroyed>147</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="1" y="5">
@@ -108216,6 +108410,39 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
+    <entity name="lockpickThiefTrainer">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+ var trainer = new ThiefTrainer()
+    {
+        BaseDodge = 10,
+        MaxHealth = 50, Health = 50,
+
+        Experience = 50,
+        
+        Alignment = Alignment.Neutral
+    };
+    
+    trainer.SetTraining(Skill.Magic, 8, 19);
+    
+    return trainer;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
   </entities>
   <spawns>
     <spawn type="LocationSpawner" name="axeSEShopkeeper">
@@ -109409,6 +109636,26 @@
       </script>
       <entry entity="BossNotableLevel11KWolf" size="1" minimum="1" maximum="1" />
       <location x="13" y="10" region="23" />
+    </spawn>
+    <spawn type="LocationSpawner" name="lockpickThiefTrainer">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <script name="OnAfterSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    spawn.Name = "Jars";
+    spawn.Body = 47;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <location x="7" y="-1" region="15" />
     </spawn>
     <spawn type="RegionSpawner" name="Surface Dungeon">
       <minimumDelay>600</minimumDelay>

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -48188,6 +48188,16 @@
         <component type="FloorComponent">
           <ground>183</ground>
         </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>1</destinationX>
+          <destinationY>12</destinationY>
+          <destinationRegion>15</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions>Fighter,Martial Artist,Thaumaturge,Wizard,Knight</professions>
+          <alignments select="all" />
+          <message>610053</message>
+        </component>
       </tile>
       <tile x="11" y="3">
         <component type="WallComponent">


### PR DESCRIPTION
Added a Thief Trainer to lockpick town, giving thieves a training option that allows them the ability to push gold from a bank. 

Created a Thief area behind a secret door to the north of the wizard trainer in lockpick. 

Second Commit added a teleporter to keep the riff raff out of the thieves guild. 