### PR TITLE
Main Gauche added to Lich twins

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -98451,7 +98451,6 @@
             new LootPackEntry(true, oakGenericGems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, (from, container) => new ManaPotion(), 100.0),
             new LootPackEntry(true, (from, container) => new PermanentDexterityPotion(), 100.0),
-            new LootPackEntry(true, (from, container) => new MainGauche(), 100.0),
             new LootPackEntry(true, dungeon5Rings, 100.0)
         ));
 

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.92.0.0">
+<segment name="Oakvael" version="0.93.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -98451,6 +98451,7 @@
             new LootPackEntry(true, oakGenericGems, 25.0, gemsPriceMutator),
             new LootPackEntry(true, (from, container) => new ManaPotion(), 100.0),
             new LootPackEntry(true, (from, container) => new PermanentDexterityPotion(), 100.0),
+            new LootPackEntry(true, (from, container) => new MainGauche(), 100.0),
             new LootPackEntry(true, dungeon5Rings, 100.0)
         ));
 

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100044,7 +100044,7 @@
         Body = 206,
         
         MaxHealth = 1800, Health = 1800,
-        BaseDodge = 26,
+        BaseDodge = 24,
         HideDetection = 28,
         Alignment = Alignment.Evil,
         
@@ -100072,7 +100072,7 @@
         new CreatureBasicAttack(18, 18, 30)
     };
     
-    carfel.Wield(new YasnakiDagger());
+    carfel.Wield(new MainGauche());
     carfel.Wield(new YasnakiDagger());
         
     carfel.AddGold(4800);


### PR DESCRIPTION
After a long discussion with the fellas in voice chat, we decided it would be better to toss my new Main Gauche defense dagger on the Lich Twins. They are underutilized, and they are a relatively low barrier to entry for a thief. 

For now I have it dropped in the container, I realize that this could be easily abused but traditionally the Lich twins use hand skill so I didn't want to mess that up. 