### PR TITLE
Throwable preference on Main Gauche

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100072,8 +100072,9 @@
         new CreatureBasicAttack(18, 18, 30)
     };
     
-    carfel.Wield(new MainGauche());
     carfel.Wield(new YasnakiDagger());
+    carfel.Wield(new MainGauche());
+    
         
     carfel.AddGold(4800);
     carfel.AddLoot(new LootPack(

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/MainGauche.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/MainGauche.cs
@@ -30,7 +30,7 @@ namespace Kesmai.Server.Items
 		protected override int PoisonedItemId => 312;
 		
 		/// <inherit />
-		public override WeaponFlags Flags => base.Flags | WeaponFlags.Silver | WeaponFlags.Neutral;
+		public override WeaponFlags Flags => WeaponFlags.Piercing | WeaponFlags.Silver | WeaponFlags.Neutral;
 
 		/// <inherit />
 		public override bool CanBind => true;


### PR DESCRIPTION
Ok, I need a little help from the big boys on this one. I want to take the throwable flag off the Main Gauche so it just sits in your offhand like a regular weapon (it's really too big of a dagger to throw anyway) and allow the thief to press / and throw his rdagger from the main hand without it launching the blocking weapon.

So what I did:

- Removed base.flags from MainGauche.cs and inserted the weapon flags I wanted to keep from the dagger base class. This should remove the throwable/quickthrow flags from the base dagger class?

@jkachhad  Does this work the way I think it does? Appreciate some help/input, or even better.. .if you know a way to fix this issue that doesn't require us to remove the throw flags. 