### PR TITLE
Currently Yas Ninjas have a 20 skill attack, which is 3 higher than shid …

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100854,9 +100854,6 @@
         Experience = 10699,
         
         CanCharge = true,
-        
-        BasePenetration = ShieldPenetration.Medium,
-    
     };
     
     

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100851,18 +100851,18 @@
         MaxHealth = 209, Health = 209,
         BaseDodge = 27,
         HideDetection = 29,    
-        Experience = 11000,
+        Experience = 10699,
         
         CanCharge = true,
         
-        BasePenetration = ShieldPenetration.Heavy,
+        BasePenetration = ShieldPenetration.Medium,
     
     };
     
     
     trollguard.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(18)
+        new CreatureBasicAttack(16)
     };
     
     trollguard.Wield(new Halberd());
@@ -101773,22 +101773,22 @@
         BaseDodge = 28,
         HideDetection = 28,
         Experience = 10918,
-        BasePenetration = ShieldPenetration.Heavy,
+        BasePenetration = ShieldPenetration.Medium,
         CanJumpkick = true,
     };
     
     martialartist.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(20,      10, 18,      "The ninja hits you with a flurry of fists.",
+            new CreatureAttack(18,      10, 18,      "The ninja hits you with a flurry of fists.",
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(20,      11, 20,     "The ninja slams his fist into your chest.",
+            new CreatureAttack(18,      11, 20,     "The ninja slams his fist into your chest.",
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(20,      13, 22,     "The ninja knocks you back with a forceful kick.",
+            new CreatureAttack(18,      13, 22,     "The ninja knocks you back with a forceful kick.",
                                                         new AttackProneComponent(5), 
                                                         new AttackStunComponent(5)),               20
         },


### PR DESCRIPTION
…ninjas and then way higher than most crits/mobs and higher than most lair crits (carfel). Also they have a Medium Penetration, which Yas has Heavy. I still disagree with a hand having heavy pen unless they have some special gauntlets they wear/drop. TK Elite Guards are quite a bit tougher now due to Halberds were fixed. I don't believe just because they are Elite Guards, they should have a Heavy Pen pen. It should be based on Weapon. Additionally due to the crit/mob density and such they represent way more of a threat now than TK himself. There are 11 guards now with Heavy Pen and level 18 skill. I am moving it back to 16. I am letting the pen inherit from base of halberd now (Medium) and the skill the be more representative of a level14 crit