### PR TITLE
UK Gargoyle converted to lurker

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Underkingdom" version="0.93.0.0">
+<segment name="Underkingdom" version="0.92.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -102859,6 +102859,76 @@ var gargoyle = new Gargoyle()
         <block><![CDATA[]]></block>
       </script>
     </entity>
+    <entity name="level13Lurker">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var lurker = new Lurker()
+    {
+        Name = "lurker",
+        MaxHealth = 143, Health = 143,
+        BaseDodge = 24,
+        BasePenetration = ShieldPenetration.Medium,
+        CanSwim = true,
+        CanWalk = false,  
+        Experience = 7578,
+        HideDetection = 25,
+        
+        
+        Immunity = CreatureImmunity.Poison | CreatureImmunity.Magic,
+            
+        VisibilityDistance = 0,
+    };
+    
+    lurker.AddStatus(new NightVisionStatus(lurker));
+    lurker.AddStatus(new BreatheWaterStatus(lurker));
+    
+    lurker.Attacks = new CreatureAttackCollection()
+    {
+        { 
+            new CreatureAttack(14,     10, 20,      "The lurker whips you with a tentacle"),  50 
+        }, 
+        {
+            new CreatureAttack(14,     5, 22,     "The lurker bites you.",
+                                                    new AttackPoisonComponent(12)),           50
+        }
+    };
+    
+    lurker.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(6, "a tentacle"),
+        new CreatureBlock(4, "sharp fangs")
+    };
+    
+    lurker.AddGold(146);
+    lurker.AddLoot(new LootPack(
+        new LootPackEntry(true, (from, container) => new PermanentStrengthPotion(),       5),
+        new LootPackEntry(true, (from, container) => new YouthPotion(),       5),
+        new LootPackEntry(true, (from, container) => new ManaPotion(),       5), 
+        new LootPackEntry(true, UnderkingdomPotions,    0.05),
+        new LootPackEntry(true, UnderkingdomGems,       7.2,     gemsPriceMutatorHigh), 
+        new LootPackEntry(true, UnderkingdomBottles,    50), 
+        new LootPackEntry(true, UtilityItems,    3), 
+        new LootPackEntry(true, UpperTreasure,    0.63)
+    ));
+    
+    return lurker;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
   </entities>
   <spawns>
     <spawn type="LocationSpawner" name="UKPawner">
@@ -105486,10 +105556,10 @@ var gargoyle = new Gargoyle()
         <inclusion left="17" top="2" right="49" bottom="21" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="tk300courtyardGarg">
-      <minimumDelay>600</minimumDelay>
-      <maximumDelay>900</maximumDelay>
-      <maximum>3</maximum>
+    <spawn type="RegionSpawner" name="tk300poolLurker">
+      <minimumDelay>1200</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -105504,11 +105574,9 @@ var gargoyle = new Gargoyle()
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level13Gargoyle" size="1" minimum="2" maximum="3" />
+      <entry entity="level13Lurker" size="1" minimum="1" maximum="1" />
       <bounds region="8">
-        <inclusion left="2" top="2" right="15" bottom="6" />
-        <exclusion left="2" top="7" right="15" bottom="7" />
-        <exclusion left="16" top="2" right="16" bottom="7" />
+        <inclusion left="2" top="2" right="5" bottom="5" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="tk300DungeonNotSafe">


### PR DESCRIPTION
Converting the gargoyle to a more appropriate monster, and toning it down to one that spawns every 7-10 minutes instead of 3.5 - 5.

Has high attack value, has poison, but doesn't respawn like crazy and punish people trying to hunt in the zone.

Between the pillar and a single monster this will adequately stop scripting without going overboard like it is now according to feedback.