### PR TITLE
Changes to what mobs flee

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104469,6 +104469,7 @@
         BaseDodge = 13,
         HideDetection = 22,        
         Experience = 1306,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -104566,8 +104567,6 @@
         Experience = 1804,
                 
         Movement = 2,
-                
-        CanFlee = true,
     };
     
     troll.Attacks = new CreatureAttackCollection()
@@ -104615,6 +104614,7 @@
         BaseDodge = 13,
         HideDetection = 22,         
         Experience = 1306,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -104724,6 +104724,7 @@
         BaseDodge = 14,
         HideDetection = 22,         
         Experience = 1306,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -104781,6 +104782,7 @@
         HideDetection = 23,        
         Experience = 1881,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -104829,8 +104831,6 @@
         Experience = 2700,
         BasePenetration = ShieldPenetration.Light,
         Movement = 2,
-                
-        CanFlee = true,
     };
     
     troll.Attacks = new CreatureAttackCollection()
@@ -105218,6 +105218,7 @@
         HideDetection = 23,        
         Experience = 1881,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -105331,6 +105332,7 @@
         HideDetection = 23,        
         Experience = 1881,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -105933,6 +105935,7 @@
         HideDetection = 23,        
         Experience = 2708,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -106151,6 +106154,7 @@
         HideDetection = 23,        
         Experience = 2708,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -106199,6 +106203,7 @@
         HideDetection = 23,        
         Experience = 2708,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -106407,7 +106412,6 @@
         HideDetection = 23,        
         Experience = 3482,
         BasePenetration = ShieldPenetration.VeryLight,
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -106512,7 +106516,6 @@
                 
         Movement = 2,
         BasePenetration = ShieldPenetration.VeryLight,
-        CanFlee = true,
     };
     
     troll.Attacks = new CreatureAttackCollection()

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -98328,8 +98328,6 @@ return orc;
         Experience = 1503,
                 
         Movement = 2,
-                
-        CanFlee = true,
     };
                 
     troll.Attacks = new CreatureAttackCollection()
@@ -98528,6 +98526,7 @@ return orc;
         BaseDodge = 12,
                 
         Experience = 1088,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -98576,6 +98575,7 @@ return orc;
         BaseDodge = 12,
                 
         Experience = 1088,
+        CanFlee = true,
     };
         
     goblin.Attacks = new CreatureAttackCollection()

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Leng" version="0.93.0.0">
+<segment name="Leng" version="0.92.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -76675,7 +76675,6 @@
         BaseDodge = 19,
         Experience = 5015,
         HideDetection = 26,
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -76823,7 +76822,6 @@
         BaseDodge = 19,
         Experience = 5015,
         HideDetection = 26,
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.93.0.0">
+<segment name="Oakvael" version="0.92.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -95809,6 +95809,7 @@
         Experience = 482,
 
         Movement = 2,
+        CanFlee = true,
     };
     
     kobold.Attacks = new CreatureAttackCollection
@@ -96103,6 +96104,7 @@
         HideDetection = 21,
         Experience = 1567,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection
@@ -96151,6 +96153,7 @@
         HideDetection = 21,
         Experience = 1567,
         BasePenetration = ShieldPenetration.VeryLight,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection
@@ -96203,8 +96206,6 @@
         HideDetection = 21,
         Movement = 2,
         BasePenetration = ShieldPenetration.VeryLight,
-
-        CanFlee = true,
     };
     
     troll.AddStatus(new NightVisionStatus(troll));
@@ -97420,8 +97421,6 @@
         BasePenetration = ShieldPenetration.Light,
 
         Movement = 2,
-
-        CanFlee = true,
     };
     
     troll.Attacks = new CreatureAttackCollection
@@ -97471,8 +97470,6 @@
         BasePenetration = ShieldPenetration.Light,
 
         Experience = 4179,
-
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection
@@ -97522,8 +97519,6 @@
         BasePenetration = ShieldPenetration.Light,
 
         Experience = 4179,
-
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Underkingdom" version="0.93.0.0">
+<segment name="Underkingdom" version="0.92.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -100433,7 +100433,6 @@
         HideDetection = 25,            
         Experience = 6018,
         BasePenetration = ShieldPenetration.Light,
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -100650,7 +100649,6 @@
         BasePenetration = ShieldPenetration.Light,
         Experience = 5015,
         HideDetection = 25, 
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -101176,6 +101174,7 @@
         Experience = 3900,
         FireProtection = 100,
         HideDetection = 25,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -101957,6 +101956,7 @@
         BasePenetration = ShieldPenetration.Light,
         Experience = 3900,  
         HideDetection = 25,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -102004,6 +102004,7 @@
         BasePenetration = ShieldPenetration.Light,
         Experience = 3250,  
         HideDetection = 25,
+        CanFlee = true,
     };
     
     goblin.Attacks = new CreatureAttackCollection()
@@ -102051,7 +102052,6 @@
         BasePenetration = ShieldPenetration.Light,
         Experience = 4179,
         HideDetection = 25, 
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -102146,7 +102146,6 @@
         HideDetection = 25,         
         Experience = 4179,
         BasePenetration = ShieldPenetration.Light,
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -102193,6 +102192,7 @@
         BasePenetration = ShieldPenetration.Light,       
         Experience = 3250,
         HideDetection = 25,
+        CanFlee = true,
     };
     
     
@@ -102705,7 +102705,6 @@
         HideDetection = 25,         
         Experience = 5015,
         BasePenetration = ShieldPenetration.Light,
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()
@@ -102822,7 +102821,6 @@ var gargoyle = new Gargoyle()
         BasePenetration = ShieldPenetration.Light,
         Experience = 4179,
         HideDetection = 25, 
-        CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection()


### PR DESCRIPTION
Trolls over level 5 and Orcs over level 10 no longer can flee. Goblins up to level 15 have the canflee flag.