### PR TITLE
WorldForge - prefer new art assets over BIN art

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/TerrainManager.cs
+++ b/Source/Kesmai.WorldForge/Editor/TerrainManager.cs
@@ -85,6 +85,7 @@ namespace Kesmai.WorldForge
 				var mgcb = File.ReadAllLines(mgcbFile).ToList();
 				var existingTextures = mgcb.Where(line => line.StartsWith("#begin ")).Select(line => line.Substring(7,line.Length-11)); // get just the texture filename, exclude the header (7) and extension(4)
 				var newTextures = externalTextures.Except(existingTextures, StringComparer.InvariantCultureIgnoreCase).Except(missingTextures, StringComparer.InvariantCultureIgnoreCase).ToList();
+				newTextures = newTextures.Where(t => File.Exists($@"{Core.CustomArtPath}\{t}.png")).ToList(); // Only modify mgcb file if the new texture actually exists.
 				if (newTextures.Count > 0)
 				{
 					foreach (var texture in newTextures)

--- a/Source/Kesmai.WorldForge/Game/GameSprite.cs
+++ b/Source/Kesmai.WorldForge/Game/GameSprite.cs
@@ -70,22 +70,25 @@ namespace Kesmai.WorldForge
 			var bounds = Vector4F.Parse((string)sourceElement);
 
 			Texture2D sourceTexture = null;
-			try
-			{ // how can I test if a file is in the contentManager's storage?
-				sourceTexture = contentManager.Load<Texture2D>((string)textureElement);
-			} catch { }
 
-			if (sourceTexture == null) { 
-				var customTexturePath = $@"{Core.CustomArtPath}\{(string)textureElement}.png";
-				if (File.Exists(customTexturePath)){
-					using (var sourceStream = File.Open(customTexturePath, FileMode.Open, FileAccess.Read, FileShare.None))
-						sourceTexture = Texture2D.FromStream(graphicsDevice.GraphicsDevice, sourceStream);
-				} else {
-					throw(new MissingTextureException((string)textureElement));
-				}
+			//Prefer loose art files, if they exist.
+			var customTexturePath = $@"{Core.CustomArtPath}\{(string)textureElement}.png";
+			if (File.Exists(customTexturePath))
+			{
+				using (var sourceStream = File.Open(customTexturePath, FileMode.Open, FileAccess.Read, FileShare.None))
+					sourceTexture = Texture2D.FromStream(graphicsDevice.GraphicsDevice, sourceStream);
 			}
 
-			if (sourceTexture == null) { return; }
+			if (sourceTexture == null) {
+				try
+				{
+					sourceTexture = contentManager.Load<Texture2D>((string)textureElement);
+				} 
+				catch
+				{
+					throw (new MissingTextureException((string)textureElement));
+				}
+			}
 
 			var sourceBounds = new Rectangle((int)bounds.X, (int)bounds.Y, (int)bounds.Z, (int)bounds.W);
 			var sourceWidth = sourceBounds.Width;


### PR DESCRIPTION
Minor tweak. When revisiting existing sprites WF currently prefers art in the BIN files. This changes it to prefer art in the Content directory if present.
Also, if a terrain references a file that doesn't exist (typo in png name or missing file) do not populate the mgcb file with that art.