### PR TITLE
Oak UD Tweak to Banshees

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -97942,7 +97942,7 @@
 	var banshee = new Banshee()
     {
         MaxHealth = 99, Health = 99,
-        MaxMana = 11, Mana = 11,
+        MaxMana = 6, Mana = 6,
         BaseDodge = 23,
         HideDetection = 26,
         Experience = 7222,
@@ -97959,7 +97959,7 @@
     banshee.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 2.7, cost: 3)
+            skillLevel: 2, cost: 3)
     };
 
     banshee.Wield(new Spear());    

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -97959,7 +97959,7 @@
     banshee.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 2, cost: 3)
+            skillLevel: 2.3, cost: 3)
     };
 
     banshee.Wield(new Spear());    


### PR DESCRIPTION
Oak UD is in pretty good shape, with the exception of loot and the banshees. 

This first change is a small tweak in damage:

32.4 damage a cast per pack --> 27.6 damage per pack

Banshee mana from 11 -> 6  (3 cast per pack, with 1 primed to go... down to 2 cast per pack)

This will reduce the burst damage from having multiple packs of banshees... and bring them back to 2 cast per pack. 

The rest of Oak UD feels pretty good to me, sans some lack of itemization. 

And sorry for the two-commit thing... I tweaked it down to skill level 2, and then changed my mind and split the difference. 