### PR TITLE
Mana/Cast ration balance

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104720,7 +104720,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 43, Health = 43,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 14,
         HideDetection = 22,         
         Experience = 1306,
@@ -104737,7 +104737,7 @@
             skillLevel: 6, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 3, cost: 3, 
+            skillLevel: 3, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -105213,7 +105213,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 57, Health = 57,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 16,
         HideDetection = 23,        
         Experience = 1881,
@@ -105231,7 +105231,7 @@
             skillLevel: 7, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 4, cost: 3, 
+            skillLevel: 4, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -106194,7 +106194,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 71, Health = 71,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 18,
         HideDetection = 23,        
         Experience = 2708,
@@ -107612,7 +107612,7 @@
         Body = (female ? 37 : 38), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 105, Health = 105,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 19,
     
         Experience = 5262,
@@ -107641,7 +107641,7 @@
             skillLevel: 11, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false), 100, TimeSpan.FromSeconds(15.0) },
         { new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 3, 
+            skillLevel: 6, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false), 100, TimeSpan.Zero }
     };
     
@@ -107754,7 +107754,7 @@
         Body = (female ? 37 : 38), IsFemale = female,
         HideDetection = 23,    
         MaxHealth = 100, Health = 100,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 19,
     
         Experience = 5262,
@@ -107775,7 +107775,7 @@
             skillLevel: 11, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 3, 
+            skillLevel: 6, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };    
     
@@ -108863,7 +108863,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 91, Health = 91,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 20,
         HideDetection = 23,        
         Experience = 4513,
@@ -108881,7 +108881,7 @@
             skillLevel: 12, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 8, cost: 3, 
+            skillLevel: 8, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     

--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -98888,7 +98888,7 @@ return orc;
             skillLevel: 5, cost: 7, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 5, cost: 3,
+            skillLevel: 5, cost: 5,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
@@ -99297,7 +99297,7 @@ return orc;
             skillLevel: 6, cost: 7, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 3, 
+            skillLevel: 6, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -99930,7 +99930,7 @@ return orc;
         Body = (female ? 37 : 38), IsFemale = female,
             
         MaxHealth = 70, Health = 70,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 16,
     
         Experience = 3045,
@@ -99951,7 +99951,7 @@ return orc;
             skillLevel: 8, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 3, 
+            skillLevel: 6, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -77277,7 +77277,7 @@
         Body = (isFemale ? 37 : 38), IsFemale = isFemale,
         HideDetection = 23,    
         MaxHealth = 99, Health = 99,
-        MaxMana = 31, Mana = 31,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 18,
     
         Experience = 3654,
@@ -77296,7 +77296,7 @@
     {
         { 
             new CreatureSpell<ConcussionSpell>(
-                skillLevel: 7, cost: 16, instantCast: false,
+                skillLevel: 7, cost: 6, instantCast: false,
                 mantra: SpellHelper.GenerateMantra()),   50
         },
         {
@@ -77351,7 +77351,7 @@
         Body = 38,
         HideDetection = 23,       
         MaxHealth = 99, Health = 99,
-        MaxMana = 31, Mana = 31,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 17,
     
         Experience = 3654,
@@ -77370,12 +77370,12 @@
     {
         { 
             new CreatureSpell<CreateWebSpell>(
-                skillLevel: 9, cost: 16, 
+                skillLevel: 9, cost: 6, 
                 mantra: SpellHelper.GenerateMantra(), instantCast: false),   75
         },
         {
             new CreatureSpell<MagicMissileSpell>(
-                skillLevel: 6, cost: 6, 
+                skillLevel: 6, cost: 5, 
                 mantra: SpellHelper.GenerateMantra(), instantCast: false),   25
         }
     };

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -96371,10 +96371,10 @@
     orc.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CreateWebSpell>(
-            skillLevel: 7, cost: 4,
+            skillLevel: 7, cost: 6,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 3,
+            skillLevel: 6, cost: 5,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
 
@@ -96643,10 +96643,10 @@
     orc.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CreateWebSpell>(
-            skillLevel: 9, cost: 4,
+            skillLevel: 9, cost: 6,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 4,
+            skillLevel: 6, cost: 5,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
 
@@ -96815,7 +96815,7 @@
         Body = (female ? 37 : 38), IsFemale = female,
         HideDetection = 25,       
         MaxHealth = 72, Health = 72,
-        MaxMana = 21, Mana = 21,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 15,
         BasePenetration = ShieldPenetration.VeryLight,
 
@@ -96838,7 +96838,7 @@
             skillLevel: 9, cost: 6,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 9, cost: 3, 
+            skillLevel: 9, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
 
@@ -97650,7 +97650,7 @@
         Body = (female ? 37 : 38), IsFemale = female,
         HideDetection = 26,     
         MaxHealth = 96, Health = 96,
-        MaxMana = 21, Mana = 21,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 19,
         BasePenetration = ShieldPenetration.Light,
 
@@ -97671,7 +97671,7 @@
             skillLevel: 11, cost: 6,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 9, cost: 3,
+            skillLevel: 9, cost: 5,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
 
@@ -98265,7 +98265,7 @@
 	var spectre = new Spectre()
     {
         MaxHealth = 140, Health = 140,
-        MaxMana = 18, Mana = 18,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 23,
         HideDetection = 26,
         Experience = 9094,
@@ -98349,7 +98349,7 @@
     wight.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 11, cost: 3,
+            skillLevel: 11, cost: 5,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
     };
 

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -101016,7 +101016,7 @@
     troll.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 8, cost: 10, 
+            skillLevel: 6, cost: 10, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
@@ -101110,7 +101110,7 @@
     var orc = new Orc()
     {
         MaxHealth = 88, Health = 88,
-        MaxMana = 21, Mana = 21,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 18,
         HideDetection = 25,
         Experience = 4179,
@@ -101125,7 +101125,7 @@
     orc.Spells = new CreatureSpellCollection()
     {
        { new CreatureSpell<CreateWebSpell>(
-            skillLevel: 11, cost: 10, 
+            skillLevel: 11, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),  75, TimeSpan.Zero },
        { new CreatureSpell<MagicMissileSpell>(
             skillLevel: 8, cost: 5, 
@@ -101168,7 +101168,7 @@
     var goblin = new Goblin()
     {
         MaxHealth = 68, Health = 68,
-        MaxMana = 16, Mana = 16,
+        MaxMana = 12, Mana = 12,
         BaseDodge = 20,
         BasePenetration = ShieldPenetration.VeryLight,        
         Experience = 3900,
@@ -101187,7 +101187,7 @@
             skillLevel: 12, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 3, cost: 3, 
+            skillLevel: 3, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
     
@@ -101406,7 +101406,7 @@
     var spectre = new Spectre()
     {
         MaxHealth = 140, Health = 140,
-        MaxMana = 31, Mana = 31,
+        MaxMana = 16, Mana = 16,
         BaseDodge = 23,
         HideDetection = 28, 
         Experience = 10699,
@@ -101425,10 +101425,10 @@
     spectre.Spells = new CreatureSpellCollection()
     {
        { new CreatureSpell<StunSpell>(
-            skillLevel: 14, cost: 16, 
+            skillLevel: 14, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   75 },
        { new CreatureSpell<DeathSpell>(
-            skillLevel: 9, cost: 6, 
+            skillLevel: 9, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 }
     };
     
@@ -101826,7 +101826,7 @@
         Body = 192,
         HideDetection = 28,      
         MaxHealth = 133, Health = 133,
-        MaxMana = 31, Mana = 31,
+        MaxMana = 16, Mana = 16,
         BaseDodge = 23,
         BasePenetration = ShieldPenetration.Light,
         Experience = 10918,
@@ -101845,13 +101845,13 @@
     wizard.Spells = new CreatureSpellCollection()
     {
         { new CreatureSpell<ConcussionSpell>(
-            skillLevel: 13, cost: 16, 
+            skillLevel: 13, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   50 },
         { new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 10, cost: 6, 
+            skillLevel: 10, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 },
         { new CreatureSpell<IceStormSpell>(
-            skillLevel: 15, cost: 6, 
+            skillLevel: 15, cost: 5, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 }
     };
     
@@ -101896,7 +101896,7 @@
         HideDetection = 28,
         Experience = 10918,
         BasePenetration = ShieldPenetration.Light,
-        MaxMana = 31, Mana = 31,
+        MaxMana = 21, Mana = 21,
             
     };
     thaum.AddStatus(new NightVisionStatus(thaum));
@@ -101909,7 +101909,7 @@
     thaum.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 7, cost: 10, 
+            skillLevel: 4, cost: 10, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
@@ -102660,7 +102660,7 @@
     troll.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel: 8, cost: 10, 
+            skillLevel: 7, cost: 10, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         


### PR DESCRIPTION
Noted by players that some casters had extreme amounts of casting occuring:

Kes -> UK Decreased the amount of magic missiles cast across the board (average monster has the chance of 2-3 spells before coming in on the player - will still exist to cast more)

UK Yasnaki Thaumaturges are decreased from 7 curse to 4 curse - 3 monsters in a pack vs 4 undead banshees that are 2.7 and will be nerfed soon. They will also cast 2 sets before closing in one players.

UK Undead: Spectre will now cast a maximum of 3 deaths instead of potentially 6 from before.

Oak Undead, the spectres will cast 2 deaths, wight will cast 2 curses instead of 4.