### PR TITLE
Calculate a figure for XP per Threat and Health

### DIFF
--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -91,6 +91,9 @@
                     <syncfusion:PropertyGridItem PropertyName="HP" />
                     <syncfusion:PropertyGridItem PropertyName="Threat"/>
                     <syncfusion:PropertyGridItem PropertyName="Flags"/>
+                    <syncfusion:PropertyGridItem PropertyName="MeleeXPPerThreat" DisplayName="XP/Melee Threat"/>
+                    <syncfusion:PropertyGridItem PropertyName="RangedXPPerThreat" DisplayName="XP/Range Threat"/>
+                    <syncfusion:PropertyGridItem PropertyName="MagicXPPerThreat" DisplayName="XP/Magic Threat"/>
                 </syncfusion:PropertyGrid.Items>
             </syncfusion:PropertyGrid>
             <StackPanel Grid.Row="3" Margin="0,3,0,0">

--- a/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SpawnsDocument.xaml
@@ -287,9 +287,11 @@
                             <syncfusion:PropertyGridItem PropertyName="OpenFloorTiles" IsReadOnly="True" />
                             <syncfusion:PropertyGridItem PropertyName="TotalHP" IsReadOnly="True" />
                             <syncfusion:PropertyGridItem PropertyName="TotalXP" IsReadOnly="True" />
-                            <!-- Threat calc for a spawn needs work. This may not even be something we can 'guess' at without compiling the segment
-                            <syncfusion:PropertyGridItem PropertyName="Threat" IsReadOnly="True" />
-                            -->
+							<!-- Threat calc for a spawn needs work. This may not even be something we can 'guess' at without compiling the segment-->
+							<syncfusion:PropertyGridItem PropertyName="Threat" IsReadOnly="True" />
+                            <syncfusion:PropertyGridItem PropertyName="MeleeXPPerThreat" DisplayName="XP/Melee Threat"/>
+                            <syncfusion:PropertyGridItem PropertyName="RangedXPPerThreat" DisplayName="XP/Range Threat"/>
+                            <syncfusion:PropertyGridItem PropertyName="MagicXPPerThreat" DisplayName="XP/Magic Threat"/>
                         </syncfusion:PropertyGrid.Items>
                     </syncfusion:PropertyGrid>
                     
@@ -405,6 +407,27 @@
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <DataGridTextColumn MinWidth="70" Header="Flags" Binding="{Binding Entity.Flags}" IsReadOnly="True">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Background" Value="LightGray"></Setter>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn MinWidth="70" Header="XP/Melee Threat" Binding="{Binding Entity.MeleeXPPerThreat}" IsReadOnly="True">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Background" Value="LightGray"></Setter>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn MinWidth="70" Header="XP/Range Threat" Binding="{Binding Entity.RangedXPPerThreat}" IsReadOnly="True">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Background" Value="LightGray"></Setter>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn MinWidth="70" Header="XP/Magic Threat" Binding="{Binding Entity.MagicXPPerThreat}" IsReadOnly="True">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Background" Value="LightGray"></Setter>


### PR DESCRIPTION
The idea is to give a figure we can compare and see at a glance if something may currently be giving out too much or to little XP based on its stats.

The resolution of an anomaly could be to change a combination of the XP, or the Skill or the Health of  the creature to balance it.

Initially a value around 3.5 seems to be about in keeping. Values off this May want looking at.. but this is just a tool and its far from exact. It can sometimes highlight a creature has Something wrong.

Currently Magic threat values are approximated on "Magic" values and these could need adjusting.

There are also a couple of improvements that could be made in the calculations if this is proving useful and wanted.

As this doesnt already exist as such - it should not adversely effect the editor, its simply new information.