### PR TITLE
Nomad cliff balance

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -80142,12 +80142,10 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level11Archer" size="3" minimum="3" maximum="3" />
-      <entry entity="level11Fighter" size="3" minimum="7" maximum="7" />
-      <entry entity="level11Centaur" size="1" minimum="1" maximum="1" />
+      <entry entity="level11Archer" size="3" minimum="5" maximum="5" />
+      <entry entity="level11Fighter" size="3" minimum="9" maximum="9" />
+      <entry entity="level11Centaur" size="1" minimum="2" maximum="2" />
       <entry entity="level11Scorpion" size="1" minimum="3" maximum="3" />
-      <entry entity="level8Bee" size="3" minimum="2" maximum="2" />
-      <entry entity="level9Raven" size="1" minimum="3" maximum="3" />
       <bounds region="20">
         <inclusion left="26" top="8" right="33" bottom="14" />
         <inclusion left="5" top="10" right="25" bottom="23" />

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -76084,7 +76084,7 @@
         },
         { 
             new CreatureAttack(11,     12, 18,     "The scorpion stings you with his tail.", 
-                                                    new AttackPoisonComponent(12)),                 50
+                                                    new AttackPoisonComponent(10)),                 50
         },
     };
     
@@ -76204,7 +76204,7 @@
         new CreatureBasicAttack(12)
     };
     
-    fighter.Wield(new Longbow());
+    fighter.Wield(new Shortbow());
     fighter.Equip(new LeatherArmor());    
     
     fighter.AddGold(130);


### PR DESCRIPTION
Decreased scorpion poison by 2,

decreased nomad archers from Longbows to Shortbows. Level above has longbows. I feel it's much more appropriate as we've had lots of feedback about the archers.

We can decrease the total number if still a problem but I think this will make the area more attractive to hunting

Took bees and ravens from nomad as well and compensated with more nomads. I think with the decreased archer threat and the ability to pull into non-dense spawns this edit is also appropriate.

Those bee poisons stack.

Density is still .16 which is lower than other spawns. (need to look at density still)