### PR TITLE
bug fix where text for portals only showed when spawns are on

### DIFF
--- a/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
+++ b/Source/Kesmai.WorldForge/Game/Screens/WorldGraphicsScreen.cs
@@ -996,11 +996,11 @@ namespace Kesmai.WorldForge
 								_drawStrings.Add(Tuple.Create($"{r.Name} " + r.Threat.ToString(), new Vector2(bounds.Left + 2, bounds.Top + 2 + (offset * 15)), Color.Black));
 							}
 						}
-						//draw all strings on top..
-						foreach (Tuple<String, Vector2, Color> _drawString in _drawStrings)
-                        {
-							spritebatch.DrawString(_font, _drawString.Item1, _drawString.Item2, _drawString.Item3);
-						}
+					}
+					//draw all strings on top..
+					foreach (Tuple<String, Vector2, Color> _drawString in _drawStrings)
+					{
+						spritebatch.DrawString(_font, _drawString.Item1, _drawString.Item2, _drawString.Item3);
 					}
 					if (_presenter.Visibility.ShowComments)
                     {


### PR DESCRIPTION
Very simple fix for a bug I created on WorldForge with my previous update. Text for portals only showed when spawn regions were also turned on. I have just moved the text draw loop out of the area just for spawn regions.