### PR TITLE
Setting a reasonable level for Wendy's WW

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -98891,9 +98891,9 @@
 
     dragon.Spells = new CreatureSpellCollection()
     {
-        /* Expected output of damage is 60 per turn based on replay from Indi..DOOM. */
+        /* Expected output of damage is 28 per tick. 84 per turn */
         new CreatureSpell<WhirlwindSpell>(
-            skillLevel: 15, cost: 20)
+            skillLevel: 7, cost: 20)
     };
     
     dragon.AddLoot(new LootPack(


### PR DESCRIPTION
The original comment in the code shows they expected the damage to be 60 per turn but actually that was per tick. 3 Ticks per turn, so damage was actually 180 per turn, enough to kill anyone if they didnt move instantly at the right turn (verified by Vics replay).

Level 7 will have expected output of damage is 28 per tick. 84 per turn, which is still high but potentially survivable.

(excluding melee damage taken by Wendy)..
Very rough chart of effect of blaming through a level 7 WW:
![image](https://user-images.githubusercontent.com/43160559/163297791-2fce8a5d-7d6d-41ae-b175-582023fc9ec5.png)

Very rough chart of effect of Double blaming through a level 7 WW:
![image](https://user-images.githubusercontent.com/43160559/163297907-58f4d567-9296-4409-9206-ae23dc822b9d.png)
