### PR TITLE
Wizard Magic Hat

### DIFF
--- a/Content/Localization/Enu.xml
+++ b/Content/Localization/Enu.xml
@@ -284,6 +284,7 @@
   <entry index="6000101">feather</entry>
   <entry index="6000102">idol</entry>
   <entry index="6005000">corpse</entry>
+  <entry index="6000103">Hat</entry>
 
   <entry index="6100000">{0}</entry>
   <entry index="6100009">You can't do that here.</entry>
@@ -691,6 +692,7 @@
   <entry index="6200351">The gem turns to gold in your backpack.</entry>
   <entry index="6200352">The gem turns to gold at your feet.</entry>
   <entry index="6200353">a large gnarled staff with a ram skull attached.</entry>
+  <entry index="6200354">a spectacular azure wizards hat with bright yellow stars.</entry>
 
   <entry index="6250001">The armor seems quite ordinary.</entry>
   <entry index="6250002">The combat adds for this weapon are +5.</entry>
@@ -825,6 +827,7 @@
   <entry index="6250131">Inside you see a red liquid.</entry>
   <entry index="6250132">Inside you see a clear liquid.</entry>
   <entry index="6250133">Inside you see a yellow liquid.</entry>
+  <entry index="6250134">The hat emenates power, and shimmers as you touch it. It contains the spell of Night Vision.</entry>
  
   <entry index="6300001">You feel a momentary vibration in the {0} as you lift it.</entry>
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Helmets/WizardHat.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Helmets/WizardHat.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.IO;
+using Kesmai.Server.Network;
+
+namespace Kesmai.Server.Items
+{
+	public partial class WizardHat : Helmet, ITreasure
+	{
+		/// <inheritdoc />
+		public override int LabelNumber => 6000103;
+
+		/// <inheritdoc />
+		public override uint BasePrice => 3000;
+
+		/// <inheritdoc />
+		public override int Weight => 80;
+		
+		/// <inheritdoc />
+		public override int ProtectionFromStun => 10;
+		
+		/// <inheritdoc />
+		
+	    public override int MagicProtection => 15;
+		
+		/// <inheritdoc />
+		public override bool ProvidesNightVision => true;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="WizardHat"/> class.
+		/// </summary>
+		public WizardHat() : base(35)
+		{
+		}
+		
+		/// <inheritdoc />
+		public override bool CanEquip(MobileEntity entity)
+		{
+			if (entity is PlayerEntity { Profession: Wizard })
+				return true;
+
+			return false;
+		}
+		
+
+		/// <inheritdoc />
+		public override void GetDescription(List<LocalizationEntry> entries)
+		{
+			entries.Add(new LocalizationEntry(6200000, 6200354)); /* [You are looking at] [a spectacular azure wizards hat with bright yellow stars.] */
+
+			if (Identified)
+				entries.Add(new LocalizationEntry(6250134)); /* The hat emenates power, and shimmers as you touch it. It contains the spell of Night Vision. */
+		}
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/98596410/163599699-f7dbff0a-a63e-49f8-84fa-8fcdf38f0070.png)

Created a Wizard Hat that provides:

**10 Stun protection** - Figure we can debate this factor
**Night Vision** ,- No one will use it if it doesn't have this.
**15 Magic Protection** - The griffin skull already gave 15 to fire and ice, this will just make it 15 across the board. 

Also... it's Wizard only. Thought about making it work for thaums too.. but I figured we could discuss that. Wizards need it since they don't have big boys in blue to hide behind. 

As for drop locations.... OL.. Vlad.. Bloodlands somewhere? 

This is a collaboration with Tenser, he's taking care of the art side, but see example above. 