### PR TITLE
Enhancements/oakvael serp level

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -102289,7 +102289,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
+      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
       <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
@@ -102321,7 +102321,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
+      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
       <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
@@ -102354,7 +102354,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
+      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
       <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
@@ -102386,7 +102386,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
+      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
       <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -102001,7 +102001,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
+      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
       <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -102000,14 +102000,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="12" />
-      <entry entity="level9Orc" size="3" minimum="10" maximum="14" />
+      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
+      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="3" maximum="6" />
-      <entry entity="level9Wizard" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
       <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
       <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
       <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
       <bounds region="235">
@@ -102288,14 +102288,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="12" />
-      <entry entity="level9Orc" size="3" minimum="10" maximum="14" />
+      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
+      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="3" maximum="6" />
-      <entry entity="level9Wizard" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
       <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
       <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
       <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
       <bounds region="235">
@@ -102320,14 +102320,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="12" />
-      <entry entity="level9Orc" size="3" minimum="10" maximum="14" />
+      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
+      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="3" maximum="6" />
-      <entry entity="level9Wizard" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
       <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
       <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
       <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
       <bounds region="235">
@@ -102353,14 +102353,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="12" />
-      <entry entity="level9Orc" size="3" minimum="10" maximum="14" />
+      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
+      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="3" maximum="6" />
-      <entry entity="level9Wizard" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
       <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
       <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
       <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
       <bounds region="235">
@@ -102385,14 +102385,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="12" />
-      <entry entity="level9Orc" size="3" minimum="10" maximum="14" />
+      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
+      <entry entity="level9Orc" size="3" minimum="14" maximum="16" />
       <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
       <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="3" maximum="6" />
-      <entry entity="level9Wizard" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
       <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="3" maximum="6" />
+      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
       <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
       <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
       <bounds region="235">


### PR DESCRIPTION
1) Established Serp Level had way too many casters and salamanders
2) Reduced casters to have 2-3 per quadrant (NE/NW/SE/SW)
3) Upped the Orc/Hob pack ratio to account for density readjustment
4) Fixed an issue that could arise if Tim.the.enchanter AoEs the other lair crits and they turn around/kill him. OnDeath had a "