### PR TITLE
Wendy Update

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -98839,7 +98839,7 @@
         Name = "dragon",
         
         MaxHealth = 2100, Health = 2100,
-        MaxMana = 20, Mana = 20,
+        MaxMana = 6, Mana = 6,
         BaseDodge = 28,
         
         Experience = 85594,
@@ -98893,7 +98893,7 @@
     {
         /* Expected output of damage is 28 per tick. 84 per turn */
         new CreatureSpell<WhirlwindSpell>(
-            skillLevel: 7, cost: 20)
+            skillLevel: 7, cost: 6)
     };
     
     dragon.AddLoot(new LootPack(


### PR DESCRIPTION
I actually like Wendy's whirlwind damage where it's at - it can be healed through.

Feedback is that there isn't enough threat on her with the once per minute cast.

I propose reduction of total mana to let her cast 3.33 times per minute.

Threatening but easily played through