### PR TITLE
[just bug fix] updating some spawn Max on Vlad

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -80274,8 +80274,8 @@
     </spawn>
     <spawn type="RegionSpawner" name="Vlad">
       <minimumDelay>10800</minimumDelay>
-      <maximumDelay>18000</maximumDelay>
-      <maximum>4</maximum>
+      <maximumDelay>14400</maximumDelay>
+      <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -80301,8 +80301,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladtower1">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
+      <minimumDelay>9000</minimumDelay>
+      <maximumDelay>10800</maximumDelay>
       <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -80329,9 +80329,9 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladTower2">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
-      <maximum>8</maximum>
+      <minimumDelay>9000</minimumDelay>
+      <maximumDelay>10800</maximumDelay>
+      <maximum>6</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -80354,8 +80354,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladTower3">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
+      <minimumDelay>9000</minimumDelay>
+      <maximumDelay>10800</maximumDelay>
       <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -80273,7 +80273,7 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Vlad">
-      <minimumDelay>10800</minimumDelay>
+      <minimumDelay>7200</minimumDelay>
       <maximumDelay>14400</maximumDelay>
       <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="true">
@@ -80301,8 +80301,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladtower1">
-      <minimumDelay>9000</minimumDelay>
-      <maximumDelay>10800</maximumDelay>
+      <minimumDelay>3000</minimumDelay>
+      <maximumDelay>3600</maximumDelay>
       <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -80329,8 +80329,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladTower2">
-      <minimumDelay>9000</minimumDelay>
-      <maximumDelay>10800</maximumDelay>
+      <minimumDelay>3000</minimumDelay>
+      <maximumDelay>3600</maximumDelay>
       <maximum>6</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -80354,8 +80354,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladTower3">
-      <minimumDelay>9000</minimumDelay>
-      <maximumDelay>10800</maximumDelay>
+      <minimumDelay>3000</minimumDelay>
+      <maximumDelay>3600</maximumDelay>
       <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>

--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -80273,8 +80273,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Vlad">
-      <minimumDelay>7200</minimumDelay>
-      <maximumDelay>14400</maximumDelay>
+      <minimumDelay>10800</minimumDelay>
+      <maximumDelay>18000</maximumDelay>
       <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="true">
         <block><![CDATA[]]></block>
@@ -80301,8 +80301,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladtower1">
-      <minimumDelay>3000</minimumDelay>
-      <maximumDelay>3600</maximumDelay>
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -80329,8 +80329,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladTower2">
-      <minimumDelay>3000</minimumDelay>
-      <maximumDelay>3600</maximumDelay>
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>6</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -80354,8 +80354,8 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="vladTower3">
-      <minimumDelay>3000</minimumDelay>
-      <maximumDelay>3600</maximumDelay>
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>


### PR DESCRIPTION
Nothing Major. Bug fix for possible vlad not spawn + reasonable spawn time for vlad tower. Currently in HC each layer respawns in 5 mins!

Tower 1: Was 15-20 mins Now 2h30-3h
Tower 2: Was 15-20 mins Now 2h30-3h. Also changed Max spawns to 6 just because there are only 6 that are setup so 8 is impossible.
Tower 3: Was 15-20 mins Now 2h30-3h
Vlad: Was 3h-5h Now 3h-4h. Also changed max to 5 as otherwise there is a 1 in 4 chance Vlad would not spawn at all! 5 entities can spawn.