### PR TITLE
Normalize Axe Surface Gems with -3 gems. -3 is easier than axe surface

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104339,7 +104339,7 @@
         
     wraith.AddGold(70);
     wraith.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
@@ -104398,7 +104398,7 @@
         
     wolf.AddGold(70);
     wolf.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
@@ -104446,7 +104446,7 @@
             
     skeleton.AddGold(60);
     skeleton.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
         new LootPackEntry(true, AxePotions,     0.15),
@@ -104493,7 +104493,7 @@
             
     goblin.AddGold(60);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.37),
@@ -104541,7 +104541,7 @@
             
     orc.AddGold(70);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
@@ -104592,7 +104592,7 @@
     
     troll.AddGold(90);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.55),
         new LootPackEntry(true, AxePotions,     0.15),
@@ -104639,7 +104639,7 @@
             
     goblin.AddGold(60);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.37),
@@ -104700,7 +104700,7 @@
 
     gargoyle.AddGold(70);
     gargoyle.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.25),
         new LootPackEntry(true, AxePotions,     0.15),
@@ -104757,7 +104757,7 @@
             
     goblin.AddGold(60);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, AxeSurfaceGems,       7.4,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.37),
@@ -111575,7 +111575,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new GoldNugget(10000u);
+	return new GoldNugget(20000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -111584,7 +111584,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutEmerald(1800u);
+	return new UncutEmerald(1700u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -111593,7 +111593,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutDiamond(3300u);
+	return new UncutDiamond(3200u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -111584,7 +111584,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutEmerald(850u);
+	return new UncutEmerald(1800u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -111593,7 +111593,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new UncutDiamond(1600u);
+	return new UncutDiamond(3300u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -104339,7 +104339,7 @@
         
     wraith.AddGold(70);
     wraith.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, UtilityItems,    1),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
@@ -104398,7 +104398,7 @@
         
     wolf.AddGold(70);
     wolf.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
@@ -104446,7 +104446,7 @@
             
     skeleton.AddGold(60);
     skeleton.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       6.8,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
         new LootPackEntry(true, AxePotions,     0.15),
@@ -104493,7 +104493,7 @@
             
     goblin.AddGold(60);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.37),
@@ -104541,7 +104541,7 @@
             
     orc.AddGold(70);
     orc.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.5),
@@ -104592,7 +104592,7 @@
     
     troll.AddGold(90);
     troll.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.55),
         new LootPackEntry(true, AxePotions,     0.15),
@@ -104639,7 +104639,7 @@
             
     goblin.AddGold(60);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.37),
@@ -104700,7 +104700,7 @@
 
     gargoyle.AddGold(70);
     gargoyle.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorNormal), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorNormal), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.25),
         new LootPackEntry(true, AxePotions,     0.15),
@@ -104757,7 +104757,7 @@
             
     goblin.AddGold(60);
     goblin.AddLoot(new LootPack(
-        new LootPackEntry(true, AxeSurfaceGems,       14.7,     gemsPriceMutatorMedium), 
+        new LootPackEntry(true, AxeSurfaceGems,       4.8,     gemsPriceMutatorMedium), 
         new LootPackEntry(true, surfaceTreasureBottles,    20),
         new LootPackEntry(true, AxePotions,     0.15),
         new LootPackEntry(true, surfaceTreasureTreasure,   0.37),


### PR DESCRIPTION
* Upped the gem value to be "Slightly" higher than -3 gems 
-3 kesmai is based on Level 5 crits 
Axe Surface is based on Level 6 crits

![image](https://user-images.githubusercontent.com/90510109/164709362-78b49caf-cba9-43fd-84c7-e3bf5e06234c.png)
