### PR TITLE
Small fix to quest entities alignment

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Oakvael" version="0.94.0.0">
+<segment name="Oakvael" version="0.95.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -1243,8 +1243,6 @@
             Name = "Grove Keeper";
     
             CanLoot = false;
-			
-			Alignment = Alignment.Chaotic;
         }
     
         public int keepersooth = 0;
@@ -100023,6 +100021,7 @@
         Experience = 50,
         Movement = 0,
         HideDetection = 45,
+        Alignment = Alignment.Neutral,
     };
     
     dryad.AddStatus(new NightVisionStatus(dryad));

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -100036,12 +100036,7 @@
     dryad.Wield(new FineCrossbow());
     dryad.Equip(new ChainmailArmor());    
 
-    dryad.AddGold(500);
-    dryad.AddLoot(
-        new LootPack(
-
-            new LootPackEntry(true, groveTreasure, 100)
-        ));
+    dryad.AddGold(10);
 
     return dryad;
 ]]></block>


### PR DESCRIPTION
Keeper was unintendedly marked as chaotic instead of neutral. Quick fix.

Seems I forgot to open this one yesterday