### PR TITLE
fix gap in walls you cant go through

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -92087,6 +92087,11 @@
           <destroyed>161</destroyed>
           <ruins>170</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+        </component>
       </tile>
       <tile x="28" y="5">
         <component type="FloorComponent">


### PR DESCRIPTION
It looked like a gap you could go through but you cant and cant see through it. It just looks wrong. I changed the upright wall into a corner wall so displays correctly. No change in functionality

was
![image](https://user-images.githubusercontent.com/43160559/165079294-9c6c4052-59cd-416a-8b86-0970a5303982.png)

now
![image](https://user-images.githubusercontent.com/43160559/165079352-ec7b6af6-8a62-4812-9cdf-18e2fe4c7267.png)
