### PR TITLE
Fixed grove heart

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1229,6 +1229,31 @@
 //                var tile7 = Segment.FindTile(34, 51, 236);
 //                tile7.Add(new Obstruction(266, false));
                 new OakGroveBow().Move(Location, true, Segment);
+                
+                Emote($"the heart begins absorbing fresh nutrients from the ground, but it shivers as a furious meow is heard in the distance.");
+                
+                EmitSound(228, 3, 9);
+                
+                EmitSound(228, 3, 9);
+                
+                EmitSound(228, 3, 9);
+                
+                var tile = source.Segment.FindTile(72, 11, 236);
+    
+                if (tile != null && tile.ContainsComponent<Obstruction>())
+                {
+                    var component = tile.GetComponent<Obstruction>();
+                    tile.Remove(component);
+                }
+                
+                var tile2 = source.Segment.FindTile(77, 17, 236);
+            
+                if (tile2 != null && tile2.ContainsComponent<Obstruction>())
+                {
+                    var component = tile2.GetComponent<Obstruction>();
+                    tile2.Remove(component);
+                }
+                
                 Timer.DelayCall(TimeSpan.FromSeconds(0.2), () => Delete());
             }
             EmitSound(220, 3, 9);
@@ -1478,6 +1503,7 @@
             }
         }
     }
+    
 ]]></block>
     <block><![CDATA[]]></block>
   </script>
@@ -73631,8 +73657,8 @@
       </tile>
       <tile x="26" y="44">
         <component type="StaircaseComponent">
-          <destinationX>32</destinationX>
-          <destinationY>53</destinationY>
+          <destinationX>78</destinationX>
+          <destinationY>47</destinationY>
           <destinationRegion>236</destinationRegion>
           <teleporterId>126</teleporterId>
         </component>
@@ -80205,6 +80231,2787 @@
       <name>Grove</name>
       <height>-230</height>
       <level>26</level>
+      <tile x="42" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="44" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="45" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="52" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="54" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="55" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="56" y="-22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="41" y="-21" />
+      <tile x="42" y="-21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="44" y="-21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="46" y="-21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="52" y="-21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="53" y="-21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="42" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="44" y="-20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="53" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="54" y="-20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="60" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="61" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="62" y="-20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="42" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="44" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="45" y="-19">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="46" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="47" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="51" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="52" y="-19">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-19">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="54" y="-19">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="55" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="58" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="59" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="60" y="-19">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-19">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-18">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-18">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="46" y="-18">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="50" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="52" y="-18">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-18">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="54" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="57" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="58" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="60" y="-18">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="62" y="-18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="45" y="-17">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-17">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="47" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="48" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="50" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="-17">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-17">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="53" y="-17">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="54" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="56" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="57" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="58" y="-17">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-17">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="60" y="-17">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="61" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="62" y="-17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="46" y="-16">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="49" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="50" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="-16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="52" y="-16">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="55" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="57" y="-16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-16">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="59" y="-16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="60" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="61" y="-16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="-15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-15">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="50" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="-15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-15">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="54" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="55" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="56" y="-15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-15">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="60" y="-15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="-14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="47" y="-14">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="51" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-14">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="55" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-14">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="59" y="-14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="-13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-13">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-13">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-13">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-13">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="58" y="-13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="59" y="-13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="44" y="-12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="-12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-12">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="47" y="-12">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-12">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-12">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-12">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="60" y="-12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="43" y="-11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="-11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="-11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-11">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-11">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-11">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="48" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-10">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="55" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-10">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-10">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="61" y="-10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="43" y="-9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-9">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="52" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="57" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-9">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="42" y="-8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="-8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="47" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-8">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-8">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-8">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="62" y="-8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="42" y="-7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-7">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="51" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-7">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-7">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="42" y="-6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-6">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-6">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-6">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="-6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="56" y="-6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="57" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-6">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="63" y="-6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="42" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="-5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="46" y="-5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-5">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="54" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="55" y="-5" />
+      <tile x="56" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="57" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="58" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="59" y="-5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-5">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="-5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
       <tile x="11" y="-4">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80461,6 +83268,201 @@
           <static>226</static>
         </component>
       </tile>
+      <tile x="42" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="-4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-4">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="-4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="53" y="-4" />
+      <tile x="54" y="-4" />
+      <tile x="55" y="-4" />
+      <tile x="56" y="-4" />
+      <tile x="57" y="-4" />
+      <tile x="58" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="-4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-4">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="64" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="65" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="66" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="67" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="68" y="-4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
       <tile x="9" y="-3">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -80636,6 +83638,319 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+      </tile>
+      <tile x="42" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="44" y="-3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-3">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="52" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="53" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="54" y="-3" />
+      <tile x="55" y="-3" />
+      <tile x="56" y="-3" />
+      <tile x="57" y="-3" />
+      <tile x="58" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="60" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="61" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="62" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="63" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="64" y="-3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="65" y="-3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="-3">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="67" y="-3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="69" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="70" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="71" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="72" y="-3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="7" y="-2">
@@ -80841,6 +84156,321 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="-2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="46" y="-2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-2">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="54" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="55" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="56" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="57" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="58" y="-2">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="59" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="-2">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="65" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="-2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="73" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="74" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="75" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="76" y="-2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="6" y="-1">
@@ -81162,6 +84792,334 @@
         </component>
       </tile>
       <tile x="42" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="43" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="44" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="45" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="46" y="-1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="-1">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="-1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="-1">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="61" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="-1">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="71" y="-1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="72" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="-1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="-1">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="75" y="-1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="76" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="77" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="78" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="79" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="-1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="81" y="-1">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
@@ -81511,6 +85469,257 @@
           <static>227</static>
         </component>
       </tile>
+      <tile x="44" y="0">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="0">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="0">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="0">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="0">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="50" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="0">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="0">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="56" y="0">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="57" y="0">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="58" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="0">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="0">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="0">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="0">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="0">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="0">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="0">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="0">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="82" y="0" />
       <tile x="0" y="1">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
@@ -81963,6 +86172,288 @@
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="43" y="1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="44" y="1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="46" y="1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="1">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="48" y="1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="50" y="1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="51" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="53" y="1">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="54" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="1">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="1">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="1">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="1">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="1">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="1">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="1">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="1">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
@@ -82294,9 +86785,15 @@
         </component>
       </tile>
       <tile x="40" y="2">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
         </component>
       </tile>
       <tile x="41" y="2">
@@ -82310,6 +86807,323 @@
         </component>
       </tile>
       <tile x="42" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="47" y="2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="2">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="2">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="2">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="2">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="2">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="63" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="2">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="65" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="67" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="68" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="69" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="70" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="71" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="72" y="2">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="73" y="2">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="74" y="2">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="75" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="2">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="79" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="2">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="2">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -82688,7 +87502,8 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="3">
+      <tile x="39" y="3" />
+      <tile x="40" y="3">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -82701,23 +87516,332 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="40" y="3">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
-        </component>
-      </tile>
       <tile x="41" y="3">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
         </component>
       </tile>
       <tile x="42" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="44" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="45" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="47" y="3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="3">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="3">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="3">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="63" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="64" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="65" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="66" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="67" y="3" />
+      <tile x="68" y="3" />
+      <tile x="69" y="3" />
+      <tile x="70" y="3" />
+      <tile x="71" y="3" />
+      <tile x="72" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="73" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="74" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="75" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="76" y="3">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="77" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="3">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="79" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="3">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="3">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83095,7 +88219,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="4">
+      <tile x="39" y="4" />
+      <tile x="40" y="4" />
+      <tile x="41" y="4">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83108,24 +88234,331 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="40" y="4">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="4">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
       <tile x="42" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="43" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="4">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="45" y="4">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="46" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="47" y="4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="48" y="4">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="4">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="51" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="52" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="53" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="55" y="4">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="4">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="4">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="61" y="4">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="63" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="64" y="4" />
+      <tile x="65" y="4" />
+      <tile x="66" y="4" />
+      <tile x="67" y="4" />
+      <tile x="68" y="4" />
+      <tile x="69" y="4" />
+      <tile x="72" y="4" />
+      <tile x="73" y="4" />
+      <tile x="74" y="4" />
+      <tile x="76" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="77" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="78" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="79" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="81" y="4">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
@@ -83500,35 +88933,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="5">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="5">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="5">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
-        </component>
-      </tile>
+      <tile x="39" y="5" />
+      <tile x="40" y="5" />
+      <tile x="41" y="5" />
       <tile x="42" y="5">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -83542,6 +88949,193 @@
           <static>227</static>
         </component>
       </tile>
+      <tile x="43" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="44" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="47" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="48" y="5">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="5">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="5">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="52" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="5">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="5">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="62" y="5">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="67" y="5" />
+      <tile x="68" y="5" />
+      <tile x="69" y="5" />
+      <tile x="70" y="5" />
+      <tile x="71" y="5" />
+      <tile x="72" y="5" />
+      <tile x="75" y="5" />
+      <tile x="76" y="5" />
+      <tile x="81" y="5" />
+      <tile x="82" y="5" />
       <tile x="0" y="6">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
@@ -83889,7 +89483,11 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="6">
+      <tile x="39" y="6" />
+      <tile x="40" y="6" />
+      <tile x="41" y="6" />
+      <tile x="42" y="6" />
+      <tile x="43" y="6">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83902,23 +89500,141 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="40" y="6">
+      <tile x="44" y="6">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
+      </tile>
+      <tile x="45" y="6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="46" y="6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="47" y="6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="6">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="51" y="6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="52" y="6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="6">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="6">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
         <component type="TreeComponent">
-          <tree>100</tree>
+          <tree>99</tree>
           <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="41" y="6">
+      <tile x="58" y="6">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="42" y="6">
+      <tile x="59" y="6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="6">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="6">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -83931,6 +89647,39 @@
           <static>227</static>
         </component>
       </tile>
+      <tile x="62" y="6" />
+      <tile x="63" y="6" />
+      <tile x="64" y="6" />
+      <tile x="70" y="6" />
+      <tile x="71" y="6" />
+      <tile x="72" y="6" />
+      <tile x="73" y="6" />
+      <tile x="77" y="6" />
+      <tile x="82" y="6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="83" y="6">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="84" y="6" />
+      <tile x="85" y="6" />
+      <tile x="86" y="6" />
       <tile x="0" y="7">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
@@ -84276,34 +90025,25 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="7">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="7">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="7">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
+      <tile x="39" y="7" />
+      <tile x="40" y="7" />
+      <tile x="41" y="7" />
       <tile x="42" y="7">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="7">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
@@ -84312,6 +90052,336 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="44" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="47" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="7">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="51" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="52" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="7">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="7">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="62" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="63" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="64" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="65" y="7" />
+      <tile x="66" y="7" />
+      <tile x="72" y="7" />
+      <tile x="73" y="7" />
+      <tile x="74" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="75" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="76" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="77" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="78" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="79" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="81" y="7">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="82" y="7">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="83" y="7">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
         </component>
       </tile>
       <tile x="0" y="8">
@@ -84709,35 +90779,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="8">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="8">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
-        </component>
-      </tile>
-      <tile x="41" y="8">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
+      <tile x="39" y="8" />
+      <tile x="40" y="8" />
+      <tile x="41" y="8" />
       <tile x="42" y="8">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -84749,6 +90793,430 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="44" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="47" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="8">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="52" y="8">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="53" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="8">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="8">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="60" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="61" y="8">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="62" y="8">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="8">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="8">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="65" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="66" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="67" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="68" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="69" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="70" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="71" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="72" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="73" y="8">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="74" y="8">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="75" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="8">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="83" y="8">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
         </component>
       </tile>
       <tile x="3" y="9">
@@ -85001,31 +91469,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="9">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="9">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="9">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
+      <tile x="39" y="9" />
+      <tile x="40" y="9" />
+      <tile x="41" y="9" />
       <tile x="42" y="9">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -85037,6 +91483,362 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+      </tile>
+      <tile x="43" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="44" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="47" y="9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="49" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="52" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="9">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="9">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="57" y="9">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="59" y="9">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="60" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="61" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="62" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="63" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="64" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="9">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="9">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="70" y="9">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <static>374</static>
+        </component>
+      </tile>
+      <tile x="71" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="9">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="83" y="9">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
         </component>
       </tile>
       <tile x="3" y="10">
@@ -85445,32 +92247,22 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="10">
+      <tile x="39" y="10" />
+      <tile x="40" y="10" />
+      <tile x="41" y="10">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
           <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="10">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="10">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
         </component>
       </tile>
       <tile x="42" y="10">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -85481,6 +92273,374 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="43" y="10">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="44" y="10">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="10">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="47" y="10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="49" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="10">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="52" y="10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="10">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="10">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="60" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="61" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="62" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="10">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="10">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="71" y="10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <static>374</static>
+        </component>
+      </tile>
+      <tile x="72" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="10">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="10">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="83" y="10">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="3" y="11">
@@ -85759,7 +92919,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="11">
+      <tile x="39" y="11" />
+      <tile x="40" y="11" />
+      <tile x="41" y="11">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -85772,13 +92934,7 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="40" y="11">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="11">
+      <tile x="42" y="11">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -85788,7 +92944,31 @@
           <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="42" y="11">
+      <tile x="43" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="11">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="11">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="11">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -85799,6 +92979,341 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="49" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaircaseComponent">
+          <destinationX>113</destinationX>
+          <destinationY>38</destinationY>
+          <destinationRegion>236</destinationRegion>
+          <teleporterId>181</teleporterId>
+        </component>
+      </tile>
+      <tile x="50" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="51" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="11">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="11">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="11">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="60" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="61" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="62" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="11">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="11">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="72" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <static>374</static>
+        </component>
+      </tile>
+      <tile x="74" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="11">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="77" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="78" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="79" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="81" y="11">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="82" y="11">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="3" y="12">
@@ -86137,7 +93652,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="12">
+      <tile x="39" y="12" />
+      <tile x="40" y="12" />
+      <tile x="41" y="12">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -86148,21 +93665,57 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="12">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="12">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
         </component>
       </tile>
       <tile x="42" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="43" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="12">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="12">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="12">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="47" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="48" y="12">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -86173,6 +93726,312 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
+        </component>
+      </tile>
+      <tile x="49" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="50" y="12">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="51" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="53" y="12">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="12">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="12">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="60" y="12">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="61" y="12">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="62" y="12">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="12">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="12">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="12">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="12">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="74" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="75" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="76" y="12">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="83" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="84" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="85" y="12">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="3" y="13">
@@ -86415,7 +94274,21 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="39" y="13">
+      <tile x="39" y="13" />
+      <tile x="40" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="13">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -86427,8 +94300,27 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
       </tile>
-      <tile x="40" y="13">
+      <tile x="42" y="13">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="43" y="13">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -86438,13 +94330,33 @@
           <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="41" y="13">
+      <tile x="44" y="13">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="13">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="13">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="47" y="13">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="42" y="13">
+      <tile x="48" y="13">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -86457,6 +94369,342 @@
           <static>227</static>
         </component>
       </tile>
+      <tile x="49" y="13">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="51" y="13">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="13">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="13">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="13">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="13">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="13">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="58" y="13">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="59" y="13">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="60" y="13">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="61" y="13">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="62" y="13">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="13">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="13">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="13">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="75" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="76" y="13" />
+      <tile x="77" y="13" />
+      <tile x="78" y="13" />
+      <tile x="79" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="80" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="81" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="82" y="13">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="83" y="13">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="84" y="13">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="85" y="13">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="89" y="13" />
       <tile x="3" y="14">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
@@ -87049,7 +95297,8 @@
           <static>226</static>
         </component>
       </tile>
-      <tile x="39" y="14">
+      <tile x="39" y="14" />
+      <tile x="40" y="14">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -87060,12 +95309,6 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
-        </component>
-      </tile>
-      <tile x="40" y="14">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
         </component>
       </tile>
       <tile x="41" y="14">
@@ -87074,11 +95317,123 @@
           <ground>23</ground>
         </component>
         <component type="TreeComponent">
-          <tree>99</tree>
+          <tree>100</tree>
           <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="42" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="14">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="14">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="14">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="49" y="14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="50" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="14">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="53" y="14">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="14">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="14">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -87091,251 +95446,300 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="22" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="23" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="24" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="25" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="26" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="27" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="28" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="29" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="30" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="31" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="32" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="33" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="34" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="35" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="36" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="37" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="38" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="39" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
+      <tile x="58" y="14">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
       </tile>
-      <tile x="40" y="15">
+      <tile x="59" y="14">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="60" y="14">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="61" y="14">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="62" y="14">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="14">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="14">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="14">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="76" y="14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="77" y="14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="78" y="14">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="79" y="14">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="83" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="84" y="14">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="85" y="14">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="22" y="15" />
+      <tile x="23" y="15" />
+      <tile x="24" y="15" />
+      <tile x="25" y="15" />
+      <tile x="26" y="15" />
+      <tile x="27" y="15" />
+      <tile x="28" y="15" />
+      <tile x="29" y="15" />
+      <tile x="30" y="15" />
+      <tile x="31" y="15" />
+      <tile x="32" y="15" />
+      <tile x="33" y="15" />
+      <tile x="34" y="15" />
+      <tile x="35" y="15" />
+      <tile x="36" y="15" />
+      <tile x="37" y="15" />
+      <tile x="38" y="15" />
+      <tile x="39" y="15" />
+      <tile x="40" y="15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="41" y="15">
@@ -87343,166 +95747,384 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
       </tile>
       <tile x="42" y="15">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="22" y="16">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="23" y="16">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="24" y="16">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="25" y="16">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <static>101</static>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="26" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="16">
+      <tile x="43" y="15">
         <component type="FloorComponent">
           <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="30" y="16">
+      <tile x="44" y="15">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
-          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="31" y="16">
+      <tile x="45" y="15">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="15">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="15">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="48" y="15">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="50" y="15">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="15">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="15">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="15">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="15">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="15">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="56" y="15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="57" y="15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="58" y="15">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="60" y="15">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="61" y="15">
         <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>1005</static>
         </component>
       </tile>
-      <tile x="32" y="16">
+      <tile x="62" y="15">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="63" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="15">
         <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="33" y="16">
+      <tile x="75" y="15">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="34" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="76" y="15">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
-      <tile x="35" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="77" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="36" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
+      <tile x="78" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="37" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="79" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="38" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
+      <tile x="80" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="39" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="TreeComponent">
-          <tree>99</tree>
-          <canGrow>true</canGrow>
+      <tile x="81" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
+      <tile x="82" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="83" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="84" y="15">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="85" y="15">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="22" y="16" />
+      <tile x="23" y="16" />
+      <tile x="24" y="16" />
+      <tile x="25" y="16" />
+      <tile x="26" y="16" />
+      <tile x="27" y="16" />
+      <tile x="28" y="16" />
+      <tile x="29" y="16" />
+      <tile x="30" y="16" />
+      <tile x="31" y="16" />
+      <tile x="32" y="16" />
+      <tile x="33" y="16" />
+      <tile x="34" y="16" />
+      <tile x="35" y="16" />
+      <tile x="36" y="16" />
+      <tile x="37" y="16" />
+      <tile x="38" y="16" />
+      <tile x="39" y="16" />
       <tile x="40" y="16">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="41" y="16">
@@ -87516,6 +96138,54 @@
         </component>
       </tile>
       <tile x="42" y="16">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="43" y="16">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="16">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="49" y="16">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -87528,7 +96198,316 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="16" y="17">
+      <tile x="50" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="51" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="16">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="16">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="58" y="16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="16">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="60" y="16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="61" y="16">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="62" y="16">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="16">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="16">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="77" y="16">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <static>374</static>
+        </component>
+      </tile>
+      <tile x="78" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="83" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="84" y="16">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="85" y="16">
+        <component type="ObstructionComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <obstruction>374</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="90" y="16" />
+      <tile x="16" y="17" />
+      <tile x="17" y="17" />
+      <tile x="19" y="17" />
+      <tile x="20" y="17" />
+      <tile x="22" y="17" />
+      <tile x="23" y="17" />
+      <tile x="24" y="17" />
+      <tile x="25" y="17" />
+      <tile x="26" y="17" />
+      <tile x="27" y="17" />
+      <tile x="28" y="17" />
+      <tile x="29" y="17" />
+      <tile x="30" y="17" />
+      <tile x="31" y="17" />
+      <tile x="32" y="17" />
+      <tile x="33" y="17" />
+      <tile x="34" y="17" />
+      <tile x="35" y="17" />
+      <tile x="36" y="17" />
+      <tile x="37" y="17" />
+      <tile x="38" y="17" />
+      <tile x="39" y="17">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
@@ -87537,54 +96516,13 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="17" y="17">
+      <tile x="40" y="17">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="19" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>228</destroyed>
-          <ruins>170</ruins>
-        </component>
-      </tile>
-      <tile x="20" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="22" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
@@ -87594,175 +96532,11 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
-      </tile>
-      <tile x="23" y="17">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="24" y="17">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="25" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="28" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="29" y="17">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="17">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="17">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="17">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
+          <wall>157</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="34" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="35" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="36" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="37" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="38" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="39" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="40" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
@@ -87771,35 +96545,67 @@
         </component>
       </tile>
       <tile x="41" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <static>103</static>
         </component>
       </tile>
       <tile x="42" y="17">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="17">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="17">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="47" y="17">
+        <component type="FloorComponent">
+          <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <static>103</static>
         </component>
+      </tile>
+      <tile x="48" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="17">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
@@ -87807,124 +96613,288 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="16" y="18">
+      <tile x="50" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="17">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
         <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
+          <static>102</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="55" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="17">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="58" y="17">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="17">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="17">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="61" y="17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="62" y="17">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
           <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>226</static>
         </component>
       </tile>
-      <tile x="19" y="18">
+      <tile x="63" y="17">
         <component type="FloorComponent">
-          <color r="0" g="255" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="22" y="18">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+      <tile x="64" y="17">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="23" y="18">
+      <tile x="65" y="17">
         <component type="WaterComponent">
           <color r="129" g="95" b="95" a="255" />
           <ground>374</ground>
           <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="24" y="18">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="66" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="25" y="18">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="67" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="26" y="18">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="68" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="27" y="18">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+      <tile x="69" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="28" y="18">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+      <tile x="70" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="29" y="18">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+      <tile x="71" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="30" y="18">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+      <tile x="72" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="31" y="18">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
+      <tile x="73" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="32" y="18">
+      <tile x="74" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="17">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="83" y="17">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="84" y="17">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
           <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>226</static>
         </component>
       </tile>
-      <tile x="17" y="19">
+      <tile x="85" y="17">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
@@ -87932,8 +96902,8 @@
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
@@ -87952,113 +96922,362 @@
           <static>226</static>
         </component>
       </tile>
-      <tile x="20" y="19">
+      <tile x="90" y="17" />
+      <tile x="16" y="18" />
+      <tile x="19" y="18" />
+      <tile x="22" y="18" />
+      <tile x="23" y="18" />
+      <tile x="24" y="18" />
+      <tile x="25" y="18" />
+      <tile x="26" y="18" />
+      <tile x="27" y="18" />
+      <tile x="28" y="18" />
+      <tile x="29" y="18" />
+      <tile x="30" y="18" />
+      <tile x="31" y="18" />
+      <tile x="32" y="18" />
+      <tile x="39" y="18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="40" y="18">
         <component type="FloorComponent">
-          <color r="0" g="255" b="0" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="41" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="42" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="18">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="18">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="18">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="46" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="47" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="50" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="18">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="52" y="18">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="18">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="58" y="18">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaircaseComponent">
+          <destinationX>121</destinationX>
+          <destinationY>46</destinationY>
+          <destinationRegion>236</destinationRegion>
+          <teleporterId>181</teleporterId>
+        </component>
+      </tile>
+      <tile x="59" y="18">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="60" y="18">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="61" y="18">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="62" y="18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="63" y="18">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+      </tile>
+      <tile x="64" y="18">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="22" y="19">
+      <tile x="65" y="18">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="18">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
-          <destroyed>161</destroyed>
+          <destroyed>160</destroyed>
           <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
       </tile>
-      <tile x="23" y="19">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="19">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="19">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="19">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="19">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="19">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="19">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="19">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="19">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="19">
+      <tile x="78" y="18">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
+          <wall>157</wall>
+          <destroyed>160</destroyed>
           <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <color r="129" g="95" b="95" a="255" />
+          <static>374</static>
         </component>
       </tile>
-      <tile x="34" y="19">
+      <tile x="79" y="18">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="18">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
@@ -88067,10 +97286,47 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="35" y="19">
+      <tile x="81" y="18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="82" y="18">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="83" y="18">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
@@ -88084,67 +97340,94 @@
           <static>226</static>
         </component>
       </tile>
-      <tile x="36" y="19">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="38" y="19">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
+      <tile x="90" y="18" />
+      <tile x="17" y="19" />
+      <tile x="20" y="19" />
+      <tile x="22" y="19" />
+      <tile x="23" y="19" />
+      <tile x="24" y="19" />
+      <tile x="25" y="19" />
+      <tile x="26" y="19" />
+      <tile x="27" y="19" />
+      <tile x="28" y="19" />
+      <tile x="29" y="19" />
+      <tile x="30" y="19" />
+      <tile x="31" y="19" />
+      <tile x="32" y="19" />
+      <tile x="34" y="19" />
+      <tile x="35" y="19" />
+      <tile x="36" y="19" />
+      <tile x="38" y="19" />
       <tile x="39" y="19">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <static>227</static>
         </component>
       </tile>
       <tile x="40" y="19">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+      </tile>
+      <tile x="41" y="19">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="42" y="19">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="43" y="19">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="19">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="19">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="19">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="19">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="19">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
@@ -88153,41 +97436,11 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="43" y="19">
+      <tile x="49" y="19">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
         </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="44" y="19">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="22" y="20">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88199,71 +97452,68 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
-      </tile>
-      <tile x="23" y="20">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="20">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
-      <tile x="25" y="20">
+      <tile x="50" y="19">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="26" y="20">
+      <tile x="51" y="19">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
       </tile>
-      <tile x="27" y="20">
+      <tile x="52" y="19">
         <component type="FloorComponent">
           <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="28" y="20">
+      <tile x="53" y="19">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="29" y="20">
+      <tile x="54" y="19">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="30" y="20">
+      <tile x="55" y="19">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="31" y="20">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="56" y="19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
+      </tile>
+      <tile x="57" y="19">
         <component type="StaticComponent">
-          <static>101</static>
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
-      </tile>
-      <tile x="32" y="20">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88275,37 +97525,172 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
-      </tile>
-      <tile x="34" y="20">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>226</static>
         </component>
       </tile>
-      <tile x="35" y="20">
+      <tile x="58" y="19">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="19">
         <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
-        <component type="HiddenTeleporterComponent">
-          <destinationX>14</destinationX>
-          <destinationY>41</destinationY>
-          <destinationRegion>235</destinationRegion>
-          <lightphases select="all" />
-          <moonphases select="all" />
-          <professions select="all" />
-          <alignments select="all" />
+      </tile>
+      <tile x="60" y="19">
+        <component type="FloorComponent">
+          <ground>23</ground>
         </component>
       </tile>
-      <tile x="36" y="20">
+      <tile x="61" y="19">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="19">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="63" y="19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="64" y="19">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="65" y="19">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="19">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="19">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="19">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="19">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88318,7 +97703,24 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="38" y="20">
+      <tile x="79" y="19">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="19">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88330,258 +97732,103 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
       </tile>
+      <tile x="22" y="20" />
+      <tile x="23" y="20" />
+      <tile x="24" y="20" />
+      <tile x="25" y="20" />
+      <tile x="26" y="20" />
+      <tile x="27" y="20" />
+      <tile x="28" y="20" />
+      <tile x="29" y="20" />
+      <tile x="30" y="20" />
+      <tile x="31" y="20" />
+      <tile x="32" y="20" />
+      <tile x="34" y="20" />
+      <tile x="35" y="20" />
+      <tile x="36" y="20" />
+      <tile x="38" y="20" />
       <tile x="39" y="20">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
-        <component type="HiddenTeleporterComponent">
-          <destinationX>14</destinationX>
-          <destinationY>41</destinationY>
-          <destinationRegion>235</destinationRegion>
-          <lightphases select="all" />
-          <moonphases select="all" />
-          <professions select="all" />
-          <alignments select="all" />
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="40" y="20">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="41" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="42" y="20">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="43" y="20">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-        <component type="HiddenTeleporterComponent">
-          <destinationX>14</destinationX>
-          <destinationY>41</destinationY>
-          <destinationRegion>235</destinationRegion>
-          <lightphases select="all" />
-          <moonphases select="all" />
-          <professions select="all" />
-          <alignments select="all" />
         </component>
       </tile>
       <tile x="44" y="20">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="17" y="21">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="20" y="21">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="22" y="21">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="23" y="21">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="24" y="21">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="25" y="21">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="26" y="21">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="27" y="21">
         <component type="FloorComponent">
           <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="28" y="21">
+      <tile x="45" y="20">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="29" y="21">
+      <tile x="46" y="20">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="30" y="21">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="31" y="21">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="32" y="21">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
+          <static>103</static>
         </component>
       </tile>
-      <tile x="34" y="21">
+      <tile x="47" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="20">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88594,14 +97841,107 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="35" y="21">
+      <tile x="49" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="20">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="20">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="57" y="20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="59" y="20">
         <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="36" y="21">
+      <tile x="60" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="61" y="20">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="63" y="20">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="64" y="20">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88614,60 +97954,375 @@
           <static>227</static>
         </component>
       </tile>
+      <tile x="65" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="20">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="20">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="79" y="20">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="20">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="17" y="21" />
+      <tile x="20" y="21" />
+      <tile x="22" y="21" />
+      <tile x="23" y="21" />
+      <tile x="24" y="21" />
+      <tile x="25" y="21" />
+      <tile x="26" y="21" />
+      <tile x="27" y="21" />
+      <tile x="28" y="21" />
+      <tile x="29" y="21" />
+      <tile x="30" y="21" />
+      <tile x="31" y="21" />
+      <tile x="32" y="21" />
+      <tile x="34" y="21" />
+      <tile x="35" y="21" />
+      <tile x="36" y="21" />
       <tile x="38" y="21">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
           <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
         </component>
       </tile>
       <tile x="39" y="21">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
       <tile x="40" y="21">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+      </tile>
+      <tile x="41" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="42" y="21">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="43" y="21">
         <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="21">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="49" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="52" y="21">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="21">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="55" y="21">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="57" y="21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="58" y="21">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="59" y="21">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="60" y="21">
+        <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="44" y="21">
+      <tile x="61" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="62" y="21">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="21">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="64" y="21">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88676,116 +98331,129 @@
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="22" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
+      <tile x="65" y="21">
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="23" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="22">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="22">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="31" y="22">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-        <component type="StaticComponent">
-          <static>89</static>
-        </component>
-      </tile>
-      <tile x="33" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="34" y="22">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <static>23</static>
         </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="66" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="21">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="21">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="21">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="21">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="21">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="21">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="21">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="21">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
@@ -88795,66 +98463,24 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
       </tile>
-      <tile x="35" y="22">
-        <component type="FloorComponent">
-          <color r="198" g="31" b="74" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="37" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
+      <tile x="22" y="22" />
+      <tile x="23" y="22" />
+      <tile x="24" y="22" />
+      <tile x="25" y="22" />
+      <tile x="26" y="22" />
+      <tile x="27" y="22" />
+      <tile x="28" y="22" />
+      <tile x="29" y="22" />
+      <tile x="30" y="22" />
+      <tile x="31" y="22" />
+      <tile x="32" y="22" />
+      <tile x="33" y="22" />
+      <tile x="34" y="22" />
+      <tile x="35" y="22" />
+      <tile x="36" y="22" />
+      <tile x="37" y="22" />
       <tile x="38" y="22">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -88865,159 +98491,74 @@
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
         </component>
       </tile>
       <tile x="39" y="22">
         <component type="FloorComponent">
-          <color r="198" g="31" b="74" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
       <tile x="40" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>103</static>
         </component>
       </tile>
       <tile x="41" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="42" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="43" y="22">
         <component type="FloorComponent">
-          <color r="198" g="18" b="54" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
       <tile x="44" y="22">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="45" y="22">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="22">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
         <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
+          <static>103</static>
         </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+      </tile>
+      <tile x="47" y="22">
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <static>102</static>
         </component>
       </tile>
-      <tile x="19" y="23">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-          <blockVision>true</blockVision>
-        </component>
-      </tile>
-      <tile x="20" y="23">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-          <blockVision>true</blockVision>
-        </component>
-      </tile>
-      <tile x="21" y="23">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-          <blockVision>true</blockVision>
-        </component>
-      </tile>
-      <tile x="22" y="23">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
+      <tile x="48" y="22">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -89029,133 +98570,318 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
+      </tile>
+      <tile x="49" y="22">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="50" y="22">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="22">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="22">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="22">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="22">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="22">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="56" y="22">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="57" y="22">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
-      </tile>
-      <tile x="23" y="23">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
       </tile>
-      <tile x="24" y="23">
+      <tile x="58" y="22">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="23">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="23">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="23">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="23">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="23">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
           <static>101</static>
         </component>
       </tile>
-      <tile x="30" y="23">
+      <tile x="59" y="22">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="60" y="22">
+        <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="31" y="23">
+      <tile x="61" y="22">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="62" y="22">
+        <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="32" y="23">
+      <tile x="63" y="22">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="33" y="23">
+      <tile x="64" y="22">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="65" y="22">
         <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="34" y="23">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
-      <tile x="35" y="23">
+      <tile x="66" y="22">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="36" y="23">
+      <tile x="67" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="22">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="22">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="22">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="22">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="22">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="22">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="22">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="80" y="22">
         <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="37" y="23">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
+      <tile x="103" y="22" />
+      <tile x="104" y="22" />
+      <tile x="105" y="22" />
+      <tile x="106" y="22" />
+      <tile x="107" y="22" />
+      <tile x="108" y="22" />
+      <tile x="109" y="22" />
+      <tile x="110" y="22" />
+      <tile x="111" y="22" />
+      <tile x="112" y="22" />
+      <tile x="113" y="22" />
+      <tile x="114" y="22" />
+      <tile x="115" y="22" />
+      <tile x="19" y="23" />
+      <tile x="20" y="23" />
+      <tile x="21" y="23" />
+      <tile x="22" y="23" />
+      <tile x="23" y="23" />
+      <tile x="24" y="23" />
+      <tile x="25" y="23" />
+      <tile x="26" y="23" />
+      <tile x="27" y="23" />
+      <tile x="28" y="23" />
+      <tile x="29" y="23" />
+      <tile x="30" y="23" />
+      <tile x="31" y="23" />
+      <tile x="32" y="23" />
+      <tile x="33" y="23" />
+      <tile x="34" y="23" />
+      <tile x="35" y="23" />
+      <tile x="36" y="23" />
+      <tile x="37" y="23" />
       <tile x="38" y="23">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="39" y="23">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="40" y="23">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="41" y="23">
@@ -89163,13 +98889,14 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <static>101</static>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="42" y="23">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
@@ -89184,8 +98911,139 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
       </tile>
       <tile x="45" y="23">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="23">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="47" y="23">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="48" y="23">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="49" y="23">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="23">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="23">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="23">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="23">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="23">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="23">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="23">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="57" y="23">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -89198,152 +99056,270 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="19" y="24">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-          <blockVision>true</blockVision>
-        </component>
-      </tile>
-      <tile x="20" y="24">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-        </component>
-      </tile>
-      <tile x="21" y="24">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-        </component>
-      </tile>
-      <tile x="22" y="24">
+      <tile x="58" y="23">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="24">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
           <static>101</static>
         </component>
       </tile>
-      <tile x="26" y="24">
+      <tile x="59" y="23">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
           <static>101</static>
         </component>
       </tile>
-      <tile x="31" y="24">
+      <tile x="60" y="23">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="32" y="24">
+      <tile x="61" y="23">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="33" y="24">
+      <tile x="62" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="23">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="64" y="23">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="65" y="23">
         <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="34" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="35" y="24">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+      <tile x="66" y="23">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
         </component>
-      </tile>
-      <tile x="36" y="24">
         <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="37" y="24">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="StaticComponent">
+          <static>226</static>
         </component>
       </tile>
+      <tile x="67" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="23">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="23">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="23">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="23">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="80" y="23">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="81" y="23">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="103" y="23" />
+      <tile x="104" y="23" />
+      <tile x="105" y="23" />
+      <tile x="106" y="23" />
+      <tile x="107" y="23" />
+      <tile x="108" y="23" />
+      <tile x="109" y="23" />
+      <tile x="110" y="23" />
+      <tile x="111" y="23" />
+      <tile x="112" y="23" />
+      <tile x="113" y="23" />
+      <tile x="114" y="23" />
+      <tile x="115" y="23" />
+      <tile x="19" y="24" />
+      <tile x="20" y="24" />
+      <tile x="21" y="24" />
+      <tile x="22" y="24" />
+      <tile x="23" y="24" />
+      <tile x="24" y="24" />
+      <tile x="25" y="24" />
+      <tile x="26" y="24" />
+      <tile x="27" y="24" />
+      <tile x="28" y="24" />
+      <tile x="29" y="24" />
+      <tile x="30" y="24" />
+      <tile x="31" y="24" />
+      <tile x="32" y="24" />
+      <tile x="33" y="24" />
+      <tile x="34" y="24" />
+      <tile x="35" y="24" />
+      <tile x="36" y="24" />
+      <tile x="37" y="24" />
       <tile x="38" y="24">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="39" y="24">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
         </component>
       </tile>
       <tile x="40" y="24">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="41" y="24">
@@ -89369,11 +99345,24 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
       </tile>
       <tile x="45" y="24">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="24">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="24">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -89386,169 +99375,372 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="19" y="25">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-          <blockVision>true</blockVision>
+      <tile x="48" y="24">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
-      <tile x="20" y="25">
-        <component type="ObstructionComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
+      <tile x="49" y="24">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="21" y="25">
+      <tile x="50" y="24">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="24">
         <component type="FloorComponent">
           <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="22" y="25">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="24" y="25">
+      <tile x="52" y="24">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="25" y="25">
+      <tile x="53" y="24">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="26" y="25">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="25">
+      <tile x="54" y="24">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="28" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="29" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="33" y="25">
+      <tile x="55" y="24">
         <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
       </tile>
-      <tile x="34" y="25">
+      <tile x="56" y="24">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="35" y="25">
+      <tile x="57" y="24">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="58" y="24">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="59" y="24">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="60" y="24">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="61" y="24">
+        <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="36" y="25">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+      <tile x="62" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
+      <tile x="63" y="24">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="64" y="24">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="24">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="66" y="24">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="67" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="24">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="78" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="80" y="24">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="81" y="24">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="103" y="24" />
+      <tile x="104" y="24" />
+      <tile x="105" y="24" />
+      <tile x="106" y="24" />
+      <tile x="107" y="24" />
+      <tile x="108" y="24" />
+      <tile x="109" y="24" />
+      <tile x="110" y="24" />
+      <tile x="111" y="24" />
+      <tile x="112" y="24" />
+      <tile x="113" y="24" />
+      <tile x="114" y="24" />
+      <tile x="115" y="24" />
+      <tile x="19" y="25" />
+      <tile x="20" y="25" />
+      <tile x="21" y="25" />
+      <tile x="22" y="25" />
+      <tile x="23" y="25" />
+      <tile x="24" y="25" />
+      <tile x="25" y="25" />
+      <tile x="26" y="25" />
+      <tile x="27" y="25" />
+      <tile x="28" y="25" />
+      <tile x="29" y="25" />
+      <tile x="30" y="25" />
+      <tile x="31" y="25" />
+      <tile x="32" y="25" />
+      <tile x="33" y="25" />
+      <tile x="34" y="25" />
+      <tile x="35" y="25" />
+      <tile x="36" y="25" />
       <tile x="37" y="25">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="38" y="25">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="25">
         <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="40" y="25">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+      <tile x="38" y="25">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
         </component>
         <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="39" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="40" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
       <tile x="41" y="25">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
         </component>
       </tile>
       <tile x="42" y="25">
@@ -89559,7 +99751,7 @@
       </tile>
       <tile x="43" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
@@ -89570,6 +99762,22 @@
         </component>
       </tile>
       <tile x="45" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="25">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -89582,151 +99790,331 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="19" y="26">
-        <component type="ObstructionComponent">
+      <tile x="48" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="49" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="51" y="25">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="25">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="56" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="25">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="25">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="25">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="60" y="25">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="61" y="25">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="62" y="25">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="25">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="25">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="65" y="25">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="25">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="67" y="25">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="25">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="25">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="25">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="25">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="25">
+        <component type="WaterComponent">
           <color r="129" g="95" b="95" a="255" />
-          <obstruction>374</obstruction>
-          <blockVision>true</blockVision>
+          <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
-      <tile x="20" y="26">
+      <tile x="73" y="25">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="21" y="26">
+      <tile x="74" y="25">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="22" y="26">
+      <tile x="75" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="23" y="26">
+      <tile x="76" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="24" y="26">
+      <tile x="77" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="26">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="26">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="26">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>1005</static>
         </component>
       </tile>
-      <tile x="28" y="26">
+      <tile x="78" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="26">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="26">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>1005</static>
         </component>
       </tile>
-      <tile x="31" y="26">
+      <tile x="79" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="32" y="26">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="26">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="34" y="26">
+      <tile x="80" y="25">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
         </component>
       </tile>
-      <tile x="35" y="26">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="26">
+      <tile x="81" y="25">
         <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
       </tile>
+      <tile x="103" y="25" />
+      <tile x="104" y="25" />
+      <tile x="105" y="25" />
+      <tile x="106" y="25" />
+      <tile x="107" y="25" />
+      <tile x="108" y="25" />
+      <tile x="109" y="25" />
+      <tile x="110" y="25" />
+      <tile x="111" y="25" />
+      <tile x="112" y="25" />
+      <tile x="113" y="25" />
+      <tile x="114" y="25" />
+      <tile x="115" y="25" />
+      <tile x="19" y="26" />
+      <tile x="20" y="26" />
+      <tile x="21" y="26" />
+      <tile x="22" y="26" />
+      <tile x="23" y="26" />
+      <tile x="24" y="26" />
+      <tile x="25" y="26" />
+      <tile x="26" y="26" />
+      <tile x="27" y="26" />
+      <tile x="28" y="26" />
+      <tile x="29" y="26" />
+      <tile x="30" y="26" />
+      <tile x="31" y="26" />
+      <tile x="32" y="26" />
+      <tile x="33" y="26" />
+      <tile x="34" y="26" />
+      <tile x="35" y="26" />
+      <tile x="36" y="26" />
       <tile x="37" y="26">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="38" y="26">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
         </component>
       </tile>
       <tile x="39" y="26">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="40" y="26">
@@ -89734,35 +100122,49 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
       </tile>
       <tile x="41" y="26">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
         </component>
       </tile>
       <tile x="42" y="26">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
       <tile x="43" y="26">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
+          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
       <tile x="44" y="26">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
       <tile x="45" y="26">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="46" y="26">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="26">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -89775,7 +100177,53 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="19" y="27">
+      <tile x="48" y="26">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="26">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="26">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="26">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="26">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="26">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="54" y="26">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="55" y="26">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -89788,7 +100236,2545 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="20" y="27">
+      <tile x="56" y="26">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="57" y="26">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="26">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="59" y="26">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="60" y="26">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="61" y="26">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="63" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="26">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="26">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="66" y="26">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="67" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="26">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="26">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="26">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="103" y="26" />
+      <tile x="104" y="26" />
+      <tile x="105" y="26" />
+      <tile x="106" y="26" />
+      <tile x="107" y="26" />
+      <tile x="108" y="26" />
+      <tile x="109" y="26" />
+      <tile x="110" y="26" />
+      <tile x="111" y="26" />
+      <tile x="112" y="26" />
+      <tile x="113" y="26" />
+      <tile x="114" y="26" />
+      <tile x="115" y="26" />
+      <tile x="19" y="27" />
+      <tile x="20" y="27" />
+      <tile x="21" y="27" />
+      <tile x="22" y="27" />
+      <tile x="23" y="27" />
+      <tile x="24" y="27" />
+      <tile x="25" y="27" />
+      <tile x="26" y="27" />
+      <tile x="27" y="27" />
+      <tile x="28" y="27" />
+      <tile x="29" y="27" />
+      <tile x="30" y="27" />
+      <tile x="31" y="27" />
+      <tile x="32" y="27" />
+      <tile x="33" y="27" />
+      <tile x="34" y="27" />
+      <tile x="35" y="27" />
+      <tile x="36" y="27" />
+      <tile x="37" y="27">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="38" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="39" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="40" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="41" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="42" y="27">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="27">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="45" y="27">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="46" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="27">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>90</static>
+        </component>
+      </tile>
+      <tile x="48" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="50" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="27">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="54" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="27">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="56" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="27">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="58" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="27">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="60" y="27">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="61" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="62" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="27">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="27">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="67" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="27">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="27">
+        <component type="WaterComponent">
+          <color r="129" g="95" b="95" a="255" />
+          <ground>374</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="80" y="27">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="81" y="27">
+        <component type="StaticComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="82" y="27">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="98" y="27" />
+      <tile x="99" y="27" />
+      <tile x="100" y="27" />
+      <tile x="101" y="27" />
+      <tile x="102" y="27" />
+      <tile x="103" y="27" />
+      <tile x="104" y="27" />
+      <tile x="105" y="27" />
+      <tile x="106" y="27" />
+      <tile x="107" y="27" />
+      <tile x="108" y="27" />
+      <tile x="109" y="27" />
+      <tile x="110" y="27" />
+      <tile x="111" y="27" />
+      <tile x="112" y="27" />
+      <tile x="114" y="27" />
+      <tile x="115" y="27" />
+      <tile x="116" y="27" />
+      <tile x="117" y="27" />
+      <tile x="118" y="27" />
+      <tile x="119" y="27" />
+      <tile x="120" y="27" />
+      <tile x="121" y="27" />
+      <tile x="122" y="27" />
+      <tile x="123" y="27" />
+      <tile x="124" y="27" />
+      <tile x="125" y="27" />
+      <tile x="20" y="28" />
+      <tile x="21" y="28" />
+      <tile x="22" y="28" />
+      <tile x="23" y="28" />
+      <tile x="24" y="28" />
+      <tile x="25" y="28" />
+      <tile x="26" y="28" />
+      <tile x="27" y="28" />
+      <tile x="28" y="28" />
+      <tile x="29" y="28" />
+      <tile x="30" y="28" />
+      <tile x="31" y="28" />
+      <tile x="32" y="28" />
+      <tile x="33" y="28" />
+      <tile x="34" y="28" />
+      <tile x="35" y="28" />
+      <tile x="36" y="28" />
+      <tile x="37" y="28">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="38" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="39" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="40" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="41" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="42" y="28">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="28">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="46" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="47" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="50" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="28">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="53" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="58" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="61" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="64" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="65" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="28">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="28">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="73" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="80" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="28">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="28">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="98" y="28" />
+      <tile x="99" y="28" />
+      <tile x="100" y="28" />
+      <tile x="101" y="28" />
+      <tile x="102" y="28" />
+      <tile x="103" y="28" />
+      <tile x="104" y="28" />
+      <tile x="105" y="28" />
+      <tile x="106" y="28" />
+      <tile x="107" y="28" />
+      <tile x="108" y="28" />
+      <tile x="109" y="28" />
+      <tile x="110" y="28" />
+      <tile x="111" y="28" />
+      <tile x="112" y="28" />
+      <tile x="114" y="28" />
+      <tile x="115" y="28" />
+      <tile x="116" y="28" />
+      <tile x="117" y="28" />
+      <tile x="118" y="28" />
+      <tile x="119" y="28" />
+      <tile x="120" y="28" />
+      <tile x="121" y="28" />
+      <tile x="122" y="28" />
+      <tile x="123" y="28" />
+      <tile x="124" y="28" />
+      <tile x="125" y="28" />
+      <tile x="20" y="29" />
+      <tile x="21" y="29" />
+      <tile x="22" y="29" />
+      <tile x="23" y="29" />
+      <tile x="24" y="29" />
+      <tile x="25" y="29" />
+      <tile x="26" y="29" />
+      <tile x="27" y="29" />
+      <tile x="28" y="29" />
+      <tile x="29" y="29" />
+      <tile x="30" y="29" />
+      <tile x="31" y="29" />
+      <tile x="32" y="29" />
+      <tile x="33" y="29" />
+      <tile x="34" y="29" />
+      <tile x="35" y="29" />
+      <tile x="36" y="29" />
+      <tile x="37" y="29">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="38" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="39" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="40" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="41" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>100</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="42" y="29">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="29">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="46" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="49" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="29">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="29">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="59" y="29">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="60" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="29">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="63" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="64" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="65" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="69" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="70" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="29">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="74" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="75" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="80" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="81" y="29">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="82" y="29">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="98" y="29" />
+      <tile x="99" y="29" />
+      <tile x="100" y="29" />
+      <tile x="101" y="29" />
+      <tile x="102" y="29" />
+      <tile x="103" y="29" />
+      <tile x="104" y="29" />
+      <tile x="105" y="29" />
+      <tile x="106" y="29" />
+      <tile x="107" y="29" />
+      <tile x="108" y="29" />
+      <tile x="109" y="29" />
+      <tile x="110" y="29" />
+      <tile x="111" y="29" />
+      <tile x="112" y="29" />
+      <tile x="114" y="29" />
+      <tile x="115" y="29" />
+      <tile x="116" y="29" />
+      <tile x="117" y="29" />
+      <tile x="118" y="29" />
+      <tile x="119" y="29" />
+      <tile x="120" y="29" />
+      <tile x="121" y="29" />
+      <tile x="122" y="29" />
+      <tile x="123" y="29" />
+      <tile x="124" y="29" />
+      <tile x="125" y="29" />
+      <tile x="20" y="30" />
+      <tile x="21" y="30" />
+      <tile x="22" y="30" />
+      <tile x="23" y="30" />
+      <tile x="24" y="30" />
+      <tile x="25" y="30" />
+      <tile x="26" y="30" />
+      <tile x="27" y="30" />
+      <tile x="28" y="30" />
+      <tile x="29" y="30" />
+      <tile x="30" y="30" />
+      <tile x="31" y="30" />
+      <tile x="32" y="30" />
+      <tile x="33" y="30" />
+      <tile x="34" y="30" />
+      <tile x="35" y="30" />
+      <tile x="36" y="30" />
+      <tile x="37" y="30">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="38" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="39" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="40" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="41" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="42" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="30">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="30">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="47" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="48" y="30">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="49" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="30">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="53" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="55" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="60" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="30">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="66" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="67" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="72" y="30">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="73" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="30">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="76" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="77" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="78" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="79" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="80" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="81" y="30">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="82" y="30">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="98" y="30" />
+      <tile x="99" y="30" />
+      <tile x="100" y="30" />
+      <tile x="101" y="30" />
+      <tile x="102" y="30" />
+      <tile x="103" y="30" />
+      <tile x="104" y="30" />
+      <tile x="105" y="30" />
+      <tile x="106" y="30" />
+      <tile x="107" y="30" />
+      <tile x="108" y="30" />
+      <tile x="109" y="30" />
+      <tile x="110" y="30" />
+      <tile x="111" y="30" />
+      <tile x="112" y="30" />
+      <tile x="114" y="30" />
+      <tile x="115" y="30" />
+      <tile x="116" y="30" />
+      <tile x="117" y="30" />
+      <tile x="118" y="30" />
+      <tile x="119" y="30" />
+      <tile x="120" y="30" />
+      <tile x="121" y="30" />
+      <tile x="122" y="30" />
+      <tile x="123" y="30" />
+      <tile x="124" y="30" />
+      <tile x="125" y="30" />
+      <tile x="20" y="31" />
+      <tile x="21" y="31" />
+      <tile x="22" y="31" />
+      <tile x="23" y="31" />
+      <tile x="24" y="31" />
+      <tile x="25" y="31" />
+      <tile x="26" y="31" />
+      <tile x="27" y="31" />
+      <tile x="28" y="31" />
+      <tile x="29" y="31" />
+      <tile x="30" y="31" />
+      <tile x="31" y="31" />
+      <tile x="32" y="31" />
+      <tile x="33" y="31" />
+      <tile x="34" y="31" />
+      <tile x="35" y="31" />
+      <tile x="36" y="31" />
+      <tile x="37" y="31">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="38" y="31">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>23</static>
+        </component>
+      </tile>
+      <tile x="39" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="40" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="41" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="42" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="43" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="31">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="31">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="48" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="50" y="31">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="56" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="61" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="65" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="31">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="68" y="31">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="69" y="31">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="70" y="31">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="71" y="31">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="72" y="31">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="73" y="31">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="74" y="31">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="75" y="31">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="76" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="31">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="31">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="31">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="82" y="31">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="98" y="31" />
+      <tile x="99" y="31" />
+      <tile x="100" y="31" />
+      <tile x="101" y="31" />
+      <tile x="102" y="31" />
+      <tile x="103" y="31" />
+      <tile x="104" y="31" />
+      <tile x="105" y="31" />
+      <tile x="106" y="31" />
+      <tile x="107" y="31" />
+      <tile x="108" y="31" />
+      <tile x="109" y="31" />
+      <tile x="110" y="31" />
+      <tile x="111" y="31" />
+      <tile x="112" y="31" />
+      <tile x="114" y="31" />
+      <tile x="115" y="31" />
+      <tile x="116" y="31" />
+      <tile x="117" y="31" />
+      <tile x="118" y="31" />
+      <tile x="119" y="31" />
+      <tile x="120" y="31" />
+      <tile x="121" y="31" />
+      <tile x="122" y="31" />
+      <tile x="123" y="31" />
+      <tile x="124" y="31" />
+      <tile x="125" y="31" />
+      <tile x="20" y="32" />
+      <tile x="21" y="32" />
+      <tile x="22" y="32" />
+      <tile x="23" y="32" />
+      <tile x="24" y="32" />
+      <tile x="25" y="32" />
+      <tile x="26" y="32" />
+      <tile x="27" y="32" />
+      <tile x="28" y="32" />
+      <tile x="29" y="32" />
+      <tile x="30" y="32" />
+      <tile x="31" y="32" />
+      <tile x="32" y="32" />
+      <tile x="33" y="32" />
+      <tile x="34" y="32" />
+      <tile x="35" y="32" />
+      <tile x="36" y="32" />
+      <tile x="37" y="32" />
+      <tile x="38" y="32">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="39" y="32">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="40" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="41" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="42" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="43" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="32">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="49" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="32">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="55" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="61" y="32">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="32">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="63" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="32">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="67" y="32">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="32">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="69" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="70" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="71" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="72" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="73" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="74" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="76" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="77" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="78" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="79" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="80" y="32">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="32">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="82" y="32">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="83" y="32">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="98" y="32" />
+      <tile x="99" y="32" />
+      <tile x="100" y="32" />
+      <tile x="101" y="32" />
+      <tile x="102" y="32" />
+      <tile x="103" y="32" />
+      <tile x="104" y="32" />
+      <tile x="105" y="32" />
+      <tile x="106" y="32" />
+      <tile x="107" y="32" />
+      <tile x="108" y="32" />
+      <tile x="109" y="32" />
+      <tile x="110" y="32" />
+      <tile x="111" y="32" />
+      <tile x="112" y="32" />
+      <tile x="114" y="32" />
+      <tile x="115" y="32" />
+      <tile x="116" y="32" />
+      <tile x="117" y="32" />
+      <tile x="118" y="32" />
+      <tile x="119" y="32" />
+      <tile x="120" y="32" />
+      <tile x="121" y="32" />
+      <tile x="122" y="32" />
+      <tile x="123" y="32" />
+      <tile x="124" y="32" />
+      <tile x="125" y="32" />
+      <tile x="20" y="33" />
+      <tile x="21" y="33" />
+      <tile x="22" y="33" />
+      <tile x="23" y="33" />
+      <tile x="24" y="33" />
+      <tile x="25" y="33" />
+      <tile x="26" y="33" />
+      <tile x="27" y="33" />
+      <tile x="28" y="33" />
+      <tile x="29" y="33" />
+      <tile x="30" y="33" />
+      <tile x="31" y="33" />
+      <tile x="32" y="33" />
+      <tile x="33" y="33" />
+      <tile x="34" y="33" />
+      <tile x="35" y="33" />
+      <tile x="36" y="33" />
+      <tile x="37" y="33" />
+      <tile x="38" y="33">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="39" y="33">
         <component type="WallComponent">
           <color r="221" g="210" b="95" a="255" />
           <wall>157</wall>
@@ -89804,1319 +102790,16 @@
           <color r="135" g="123" b="123" a="255" />
           <static>374</static>
         </component>
-      </tile>
-      <tile x="21" y="27">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="22" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="24" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="27">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="29" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="27">
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="27">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="27">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="27">
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="37" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="27">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="27">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="40" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="41" y="27">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="43" y="27">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="44" y="27">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="45" y="27">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="28">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="22" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="23" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="27" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="28" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="32" y="28">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="34" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="28">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="28">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="37" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="28">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="40" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="28">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="43" y="28">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="44" y="28">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="45" y="28">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="29">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="22" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="24" y="29">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="29">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="30" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="29">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="29">
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="29">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="29">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="37" y="29">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="29">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="40" y="29">
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="41" y="29">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="29">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="43" y="29">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="44" y="29">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="30">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="22" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="23" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="30">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="30">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="28" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="30">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="30">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="30">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="30">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="30">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="40" y="30">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="41" y="30">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="43" y="30">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="44" y="30">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="31">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="22" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="31">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="29" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="31">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="33" y="31">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="31">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="37" y="31">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="31">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="31">
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="40" y="31">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="41" y="31">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="43" y="31">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="44" y="31">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="32">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="22" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="24" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="31" y="32">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="32">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>102</static>
-        </component>
-      </tile>
-      <tile x="37" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="32">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="32">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="43" y="32">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="44" y="32">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="33">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="22" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="23" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="33">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="33">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="32" y="33">
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="33" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="33">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="33">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="33">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="33">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="33">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
       <tile x="40" y="33">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
         </component>
       </tile>
       <tile x="41" y="33">
@@ -91130,6 +102813,10 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
       </tile>
       <tile x="43" y="33">
         <component type="FloorComponent">
@@ -91138,23 +102825,266 @@
         </component>
       </tile>
       <tile x="44" y="33">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>102</static>
         </component>
       </tile>
-      <tile x="20" y="34">
+      <tile x="45" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="33">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="33">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="33">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="33">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="59" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="33">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="62" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="63" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="65" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="67" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="33">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="69" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="70" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="71" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="72" y="33">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="73" y="33">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="74" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="75" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="76" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="77" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="78" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="79" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="80" y="33">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="33">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="82" y="33">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="83" y="33">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -91167,134 +103097,71 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="21" y="34">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="22" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="23" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="34">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+      <tile x="98" y="33" />
+      <tile x="99" y="33" />
+      <tile x="100" y="33" />
+      <tile x="101" y="33" />
+      <tile x="102" y="33" />
+      <tile x="103" y="33" />
+      <tile x="104" y="33" />
+      <tile x="105" y="33" />
+      <tile x="106" y="33" />
+      <tile x="107" y="33" />
+      <tile x="108" y="33" />
+      <tile x="109" y="33" />
+      <tile x="110" y="33" />
+      <tile x="111" y="33" />
+      <tile x="112" y="33" />
+      <tile x="114" y="33" />
+      <tile x="115" y="33" />
+      <tile x="116" y="33" />
+      <tile x="117" y="33" />
+      <tile x="118" y="33" />
+      <tile x="119" y="33" />
+      <tile x="120" y="33" />
+      <tile x="121" y="33" />
+      <tile x="122" y="33" />
+      <tile x="123" y="33" />
+      <tile x="124" y="33" />
+      <tile x="125" y="33" />
+      <tile x="20" y="34" />
+      <tile x="21" y="34" />
+      <tile x="22" y="34" />
+      <tile x="23" y="34" />
+      <tile x="24" y="34" />
+      <tile x="25" y="34" />
+      <tile x="26" y="34" />
+      <tile x="27" y="34" />
+      <tile x="28" y="34" />
+      <tile x="29" y="34" />
+      <tile x="30" y="34" />
+      <tile x="31" y="34" />
+      <tile x="32" y="34" />
+      <tile x="33" y="34" />
+      <tile x="34" y="34" />
+      <tile x="35" y="34" />
+      <tile x="36" y="34" />
+      <tile x="37" y="34" />
+      <tile x="38" y="34" />
+      <tile x="39" y="34">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="30" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="34">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="34">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="34">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="34">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="34">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="34">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="34">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="40" y="34">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
         </component>
       </tile>
       <tile x="41" y="34">
@@ -91308,35 +103175,281 @@
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
       </tile>
       <tile x="43" y="34">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="44" y="34">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="20" y="35">
+      <tile x="45" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="34">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="34">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="34">
+        <component type="FloorComponent">
+          <color r="3" g="82" b="255" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="52" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="58" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="34">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="34">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="63" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="34">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="69" y="34">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="70" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="34">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="72" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="34">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="74" y="34">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="75" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="76" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="34">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="78" y="34">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="34">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="82" y="34">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="83" y="34">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -91349,396 +103462,54 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="21" y="35">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="22" y="35">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="23" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="24" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="35">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="32" y="35">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="35">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="35">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="35">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="36" y="35">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="35">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
+      <tile x="98" y="34" />
+      <tile x="99" y="34" />
+      <tile x="100" y="34" />
+      <tile x="101" y="34" />
+      <tile x="102" y="34" />
+      <tile x="103" y="34" />
+      <tile x="104" y="34" />
+      <tile x="105" y="34" />
+      <tile x="106" y="34" />
+      <tile x="107" y="34" />
+      <tile x="108" y="34" />
+      <tile x="109" y="34" />
+      <tile x="110" y="34" />
+      <tile x="111" y="34" />
+      <tile x="112" y="34" />
+      <tile x="20" y="35" />
+      <tile x="21" y="35" />
+      <tile x="22" y="35" />
+      <tile x="23" y="35" />
+      <tile x="24" y="35" />
+      <tile x="25" y="35" />
+      <tile x="26" y="35" />
+      <tile x="27" y="35" />
+      <tile x="28" y="35" />
+      <tile x="29" y="35" />
+      <tile x="30" y="35" />
+      <tile x="31" y="35" />
+      <tile x="32" y="35" />
+      <tile x="33" y="35" />
+      <tile x="34" y="35" />
+      <tile x="35" y="35" />
+      <tile x="36" y="35" />
+      <tile x="37" y="35" />
+      <tile x="38" y="35" />
       <tile x="39" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="40" y="35">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="35">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="35">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="43" y="35">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="44" y="35">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="36">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="36">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="22" y="36">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="23" y="36">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="24" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="25" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="36">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="29" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="36">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="36">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="36" y="36">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="36">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="36">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="36">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="36">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="43" y="36">
-        <component type="WaterComponent">
-          <color r="129" g="95" b="95" a="255" />
-          <ground>374</ground>
-          <movementCost>3</movementCost>
-        </component>
-      </tile>
-      <tile x="44" y="36">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="20" y="37">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="21" y="37">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="22" y="37">
         <component type="WallComponent">
           <color r="221" g="210" b="95" a="255" />
           <wall>157</wall>
@@ -91754,38 +103525,87 @@
           <color r="135" g="123" b="123" a="255" />
           <static>374</static>
         </component>
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
       </tile>
-      <tile x="23" y="37">
+      <tile x="41" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="42" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="43" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="24" y="37">
+      <tile x="44" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="45" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="25" y="37">
+      <tile x="46" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="47" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="26" y="37">
+      <tile x="48" y="35">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
       </tile>
-      <tile x="27" y="37">
+      <tile x="49" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="28" y="37">
+      <tile x="50" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -91794,53 +103614,159 @@
           <static>102</static>
         </component>
       </tile>
-      <tile x="29" y="37">
+      <tile x="52" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="53" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="30" y="37">
+      <tile x="54" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="55" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="31" y="37">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="37">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="33" y="37">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="37">
+      <tile x="56" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="35" y="37">
+      <tile x="57" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="59" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="63" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="64" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="66" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="67" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="71" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="73" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="74" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -91849,393 +103775,549 @@
           <static>101</static>
         </component>
       </tile>
-      <tile x="36" y="37">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="37">
+      <tile x="75" y="35">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="38" y="37">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="37">
+      <tile x="76" y="35">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
         <component type="StaticComponent">
           <static>101</static>
         </component>
       </tile>
+      <tile x="77" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="78" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="79" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="80" y="35">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="81" y="35">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="82" y="35">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="83" y="35">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="98" y="35" />
+      <tile x="99" y="35" />
+      <tile x="100" y="35" />
+      <tile x="101" y="35" />
+      <tile x="102" y="35" />
+      <tile x="103" y="35" />
+      <tile x="104" y="35" />
+      <tile x="105" y="35" />
+      <tile x="106" y="35" />
+      <tile x="107" y="35" />
+      <tile x="108" y="35" />
+      <tile x="109" y="35" />
+      <tile x="110" y="35" />
+      <tile x="111" y="35" />
+      <tile x="112" y="35" />
+      <tile x="20" y="36" />
+      <tile x="21" y="36" />
+      <tile x="22" y="36" />
+      <tile x="23" y="36" />
+      <tile x="24" y="36" />
+      <tile x="25" y="36" />
+      <tile x="26" y="36" />
+      <tile x="27" y="36" />
+      <tile x="28" y="36" />
+      <tile x="29" y="36" />
+      <tile x="30" y="36" />
+      <tile x="31" y="36" />
+      <tile x="32" y="36" />
+      <tile x="33" y="36" />
+      <tile x="34" y="36" />
+      <tile x="35" y="36" />
+      <tile x="36" y="36" />
+      <tile x="37" y="36" />
+      <tile x="38" y="36" />
+      <tile x="39" y="36" />
+      <tile x="40" y="36">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="41" y="36">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="42" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="43" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="45" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="49" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="50" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="52" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="58" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="36">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="60" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="36">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="64" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="69" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="36">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="71" y="36">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="72" y="36">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="73" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="74" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="36">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="76" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="36">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="80" y="36">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="81" y="36">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="82" y="36">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="83" y="36">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="107" y="36" />
+      <tile x="108" y="36" />
+      <tile x="109" y="36" />
+      <tile x="110" y="36" />
+      <tile x="111" y="36" />
+      <tile x="112" y="36" />
+      <tile x="113" y="36" />
+      <tile x="114" y="36" />
+      <tile x="115" y="36" />
+      <tile x="116" y="36" />
+      <tile x="117" y="36" />
+      <tile x="118" y="36" />
+      <tile x="119" y="36" />
+      <tile x="120" y="36" />
+      <tile x="121" y="36" />
+      <tile x="122" y="36" />
+      <tile x="20" y="37" />
+      <tile x="21" y="37" />
+      <tile x="22" y="37" />
+      <tile x="23" y="37" />
+      <tile x="24" y="37" />
+      <tile x="25" y="37" />
+      <tile x="26" y="37" />
+      <tile x="27" y="37" />
+      <tile x="28" y="37" />
+      <tile x="29" y="37" />
+      <tile x="30" y="37" />
+      <tile x="31" y="37" />
+      <tile x="32" y="37" />
+      <tile x="33" y="37" />
+      <tile x="34" y="37" />
+      <tile x="35" y="37" />
+      <tile x="36" y="37" />
+      <tile x="37" y="37" />
+      <tile x="38" y="37" />
+      <tile x="39" y="37" />
       <tile x="40" y="37">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="41" y="37">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
           <static>101</static>
         </component>
       </tile>
       <tile x="42" y="37">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
         </component>
       </tile>
       <tile x="43" y="37">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
       </tile>
       <tile x="44" y="37">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>160</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
         </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>41</destroyed>
-          <ruins>45</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="22" y="38">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="23" y="38">
+      <tile x="45" y="37">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="24" y="38">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="38">
+      <tile x="46" y="37">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>103</static>
         </component>
       </tile>
-      <tile x="26" y="38">
+      <tile x="47" y="37">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
       </tile>
-      <tile x="27" y="38">
+      <tile x="48" y="37">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="28" y="38">
+      <tile x="49" y="37">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="38">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="38">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>102</static>
         </component>
       </tile>
-      <tile x="31" y="38">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="38">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="38">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="38">
+      <tile x="50" y="37">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="35" y="38">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="38">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="38">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="38" y="38">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="38">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="38">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="38">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="38">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="22" y="39">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="23" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="25" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="39">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="39">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="39">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="32" y="39">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="35" y="39">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="36" y="39">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="39">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="38" y="39">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="39">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="39">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="39">
+      <tile x="51" y="37">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -92244,7 +104326,1089 @@
           <static>102</static>
         </component>
       </tile>
+      <tile x="52" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="53" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="57" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="59" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="62" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="37">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="64" y="37">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="65" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="68" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="69" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="37">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="71" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="73" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="74" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="75" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="37">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="77" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="78" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="79" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="80" y="37">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="81" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="82" y="37">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="83" y="37">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="107" y="37" />
+      <tile x="108" y="37" />
+      <tile x="109" y="37" />
+      <tile x="110" y="37" />
+      <tile x="111" y="37" />
+      <tile x="112" y="37" />
+      <tile x="113" y="37">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="114" y="37">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="115" y="37">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="116" y="37">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="117" y="37" />
+      <tile x="118" y="37" />
+      <tile x="119" y="37" />
+      <tile x="120" y="37" />
+      <tile x="121" y="37" />
+      <tile x="122" y="37" />
+      <tile x="22" y="38" />
+      <tile x="23" y="38" />
+      <tile x="24" y="38" />
+      <tile x="25" y="38" />
+      <tile x="26" y="38" />
+      <tile x="27" y="38" />
+      <tile x="28" y="38" />
+      <tile x="29" y="38" />
+      <tile x="30" y="38" />
+      <tile x="31" y="38" />
+      <tile x="32" y="38" />
+      <tile x="33" y="38" />
+      <tile x="34" y="38" />
+      <tile x="35" y="38" />
+      <tile x="36" y="38" />
+      <tile x="37" y="38" />
+      <tile x="38" y="38" />
+      <tile x="39" y="38" />
+      <tile x="40" y="38">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="41" y="38">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>23</static>
+        </component>
+      </tile>
+      <tile x="42" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="43" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="44" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="45" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="50" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="51" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="58" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="59" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="63" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="64" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="65" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="69" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="71" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="74" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="75" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="76" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="38">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="38">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="81" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="82" y="38">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="83" y="38">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="107" y="38" />
+      <tile x="108" y="38" />
+      <tile x="109" y="38" />
+      <tile x="110" y="38" />
+      <tile x="111" y="38" />
+      <tile x="112" y="38">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="113" y="38">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="RopeComponent">
+          <destinationX>49</destinationX>
+          <destinationY>11</destinationY>
+          <destinationRegion>236</destinationRegion>
+          <teleporterId>237</teleporterId>
+        </component>
+      </tile>
+      <tile x="114" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="115" y="38">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="116" y="38">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="117" y="38">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="118" y="38" />
+      <tile x="119" y="38" />
+      <tile x="120" y="38" />
+      <tile x="121" y="38" />
+      <tile x="122" y="38" />
+      <tile x="22" y="39" />
+      <tile x="23" y="39" />
+      <tile x="24" y="39" />
+      <tile x="25" y="39" />
+      <tile x="26" y="39" />
+      <tile x="27" y="39" />
+      <tile x="28" y="39" />
+      <tile x="29" y="39" />
+      <tile x="30" y="39" />
+      <tile x="31" y="39" />
+      <tile x="32" y="39" />
+      <tile x="33" y="39" />
+      <tile x="34" y="39" />
+      <tile x="35" y="39" />
+      <tile x="36" y="39" />
+      <tile x="37" y="39" />
+      <tile x="38" y="39" />
+      <tile x="39" y="39" />
+      <tile x="40" y="39" />
+      <tile x="41" y="39">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
       <tile x="42" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="43" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="44" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="45" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="46" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="48" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>103</static>
+        </component>
+      </tile>
+      <tile x="49" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="52" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="54" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="58" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="60" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="61" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="66" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="67" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="71" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="74" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="75" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="76" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="77" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="78" y="39">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="79" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="39">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="82" y="39">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -92257,7 +105421,24 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="22" y="40">
+      <tile x="107" y="39" />
+      <tile x="108" y="39" />
+      <tile x="109" y="39" />
+      <tile x="110" y="39" />
+      <tile x="111" y="39">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="112" y="39">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -92269,171 +105450,393 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
-      </tile>
-      <tile x="23" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="40">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="40">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="30" y="40">
         <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="31" y="40">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
       </tile>
-      <tile x="32" y="40">
+      <tile x="113" y="39">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
-      <tile x="33" y="40">
+      <tile x="114" y="39">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="115" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="116" y="39">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="117" y="39">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
       </tile>
-      <tile x="34" y="40">
+      <tile x="118" y="39">
         <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="35" y="40">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
         </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
       </tile>
-      <tile x="36" y="40">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="40">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="38" y="40">
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="39" y="40">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
+      <tile x="119" y="39" />
+      <tile x="120" y="39" />
+      <tile x="121" y="39" />
+      <tile x="122" y="39" />
+      <tile x="22" y="40" />
+      <tile x="23" y="40" />
+      <tile x="24" y="40" />
+      <tile x="25" y="40" />
+      <tile x="26" y="40" />
+      <tile x="27" y="40" />
+      <tile x="28" y="40" />
+      <tile x="29" y="40" />
+      <tile x="30" y="40" />
+      <tile x="31" y="40" />
+      <tile x="32" y="40" />
+      <tile x="33" y="40" />
+      <tile x="34" y="40" />
+      <tile x="35" y="40" />
+      <tile x="36" y="40" />
+      <tile x="37" y="40" />
+      <tile x="38" y="40" />
+      <tile x="39" y="40" />
+      <tile x="40" y="40" />
       <tile x="41" y="40">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
         </component>
       </tile>
       <tile x="42" y="40">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
+          <wall>157</wall>
+          <destroyed>160</destroyed>
           <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>226</static>
         </component>
       </tile>
-      <tile x="22" y="41">
+      <tile x="43" y="40">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="44" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="45" y="40">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="46" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="47" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="48" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="49" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="50" y="40">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="51" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="52" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="54" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="57" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="59" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="63" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="66" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="67" y="40">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="68" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="40">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="70" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="72" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="73" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="75" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="76" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="77" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>1005</static>
+        </component>
+      </tile>
+      <tile x="78" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="40">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="40">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="81" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="82" y="40">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -92446,142 +105849,11 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="23" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="25" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="41">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="29" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="41">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="31" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="41">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="34" y="41">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="35" y="41">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="41">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="38" y="41">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="41">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="41">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="42" y="41">
+      <tile x="107" y="40" />
+      <tile x="108" y="40" />
+      <tile x="109" y="40" />
+      <tile x="110" y="40" />
+      <tile x="111" y="40">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -92594,7 +105866,96 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="22" y="42">
+      <tile x="112" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="113" y="40">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="114" y="40">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="115" y="40">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="116" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="117" y="40">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="118" y="40">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="119" y="40">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="120" y="40" />
+      <tile x="121" y="40" />
+      <tile x="122" y="40" />
+      <tile x="22" y="41" />
+      <tile x="23" y="41" />
+      <tile x="24" y="41" />
+      <tile x="25" y="41" />
+      <tile x="26" y="41" />
+      <tile x="27" y="41" />
+      <tile x="28" y="41" />
+      <tile x="29" y="41" />
+      <tile x="30" y="41" />
+      <tile x="31" y="41" />
+      <tile x="32" y="41" />
+      <tile x="33" y="41" />
+      <tile x="34" y="41" />
+      <tile x="35" y="41" />
+      <tile x="36" y="41" />
+      <tile x="37" y="41" />
+      <tile x="38" y="41" />
+      <tile x="39" y="41" />
+      <tile x="40" y="41" />
+      <tile x="41" y="41" />
+      <tile x="42" y="41" />
+      <tile x="43" y="41">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -92607,292 +105968,128 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="23" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="24" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="25" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="42">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="42">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="31" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="42">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="42">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="35" y="42">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="37" y="42">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="38" y="42">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="39" y="42">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="42">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="42" y="42">
+      <tile x="44" y="41">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
+          <wall>157</wall>
+          <destroyed>160</destroyed>
           <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="22" y="43">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+      <tile x="45" y="41">
+        <component type="FloorComponent">
+          <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
+          <static>102</static>
         </component>
       </tile>
-      <tile x="23" y="43">
+      <tile x="46" y="41">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="47" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="24" y="43">
+      <tile x="48" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="25" y="43">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="43">
+      <tile x="49" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>103</static>
         </component>
       </tile>
-      <tile x="27" y="43">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="43">
+      <tile x="50" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="29" y="43">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="30" y="43">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="31" y="43">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="43">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="43">
-        <component type="WallComponent">
-          <wall>225</wall>
-          <destroyed>228</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="34" y="43">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>223</wall>
-          <destroyed>226</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="35" y="43">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="43">
+      <tile x="51" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="37" y="43">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="38" y="43">
+      <tile x="52" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="39" y="43">
+      <tile x="53" y="41">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="40" y="43">
+      <tile x="54" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="55" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="57" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="59" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -92901,62 +106098,70 @@
           <static>102</static>
         </component>
       </tile>
-      <tile x="41" y="43">
+      <tile x="61" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="42" y="43">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="22" y="44">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="23" y="44">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="24" y="44">
+      <tile x="62" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="25" y="44">
+      <tile x="63" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="64" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="41">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="41">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="67" y="41">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="41">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
@@ -92965,150 +106170,68 @@
           <static>101</static>
         </component>
       </tile>
-      <tile x="26" y="44">
+      <tile x="72" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="27" y="44">
+      <tile x="73" y="41">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="28" y="44">
+      <tile x="74" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="29" y="44">
+      <tile x="75" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="41">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="41">
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>1005</static>
         </component>
       </tile>
-      <tile x="30" y="44">
+      <tile x="78" y="41">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="31" y="44">
+      <tile x="79" y="41">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="32" y="44">
+      <tile x="80" y="41">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="33" y="44">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
+      <tile x="81" y="41">
         <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="34" y="44">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="44">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="44">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <ground>12</ground>
         </component>
         <component type="StaticComponent">
-          <static>101</static>
+          <static>208</static>
         </component>
       </tile>
-      <tile x="37" y="44">
-        <component type="WallComponent">
-          <wall>224</wall>
-          <destroyed>227</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>89</ground>
-        </component>
-      </tile>
-      <tile x="38" y="44">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="44">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="44">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="44">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="42" y="44">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="23" y="45">
+      <tile x="82" y="41">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -93121,109 +106244,11 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="24" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="25" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="45">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="31" y="45">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="45">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="45">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="45">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="45">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="41" y="45">
+      <tile x="107" y="41" />
+      <tile x="108" y="41" />
+      <tile x="109" y="41" />
+      <tile x="110" y="41" />
+      <tile x="111" y="41">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -93236,7 +106261,45 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="23" y="46">
+      <tile x="112" y="41">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="113" y="41">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="114" y="41">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="115" y="41">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="116" y="41">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="117" y="41">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="118" y="41">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="119" y="41">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -93248,312 +106311,13 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
-      </tile>
-      <tile x="24" y="46">
         <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
+          <static>12</static>
         </component>
+      </tile>
+      <tile x="120" y="41">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="25" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="46">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="28" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="46">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="31" y="46">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="32" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="46">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="46">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="46">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="46">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="40" y="46">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="41" y="46">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="24" y="47">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="25" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="26" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="27" y="47">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="28" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="29" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="30" y="47">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="31" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="47">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="34" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="36" y="47">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="47">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="39" y="47">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>101</static>
-        </component>
-      </tile>
-      <tile x="40" y="47">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="24" y="48">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="25" y="48">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="26" y="48">
-        <component type="WallComponent">
-          <color r="221" g="210" b="95" a="255" />
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
@@ -93564,84 +106328,293 @@
           <static>226</static>
         </component>
         <component type="StaticComponent">
-          <color r="135" g="123" b="123" a="255" />
-          <static>374</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="27" y="48">
+      <tile x="121" y="41" />
+      <tile x="122" y="41" />
+      <tile x="22" y="42" />
+      <tile x="23" y="42" />
+      <tile x="24" y="42" />
+      <tile x="25" y="42" />
+      <tile x="26" y="42" />
+      <tile x="27" y="42" />
+      <tile x="28" y="42" />
+      <tile x="29" y="42" />
+      <tile x="30" y="42" />
+      <tile x="31" y="42" />
+      <tile x="32" y="42" />
+      <tile x="33" y="42" />
+      <tile x="34" y="42" />
+      <tile x="35" y="42" />
+      <tile x="36" y="42" />
+      <tile x="37" y="42" />
+      <tile x="38" y="42" />
+      <tile x="39" y="42" />
+      <tile x="40" y="42" />
+      <tile x="41" y="42" />
+      <tile x="42" y="42" />
+      <tile x="44" y="42">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="45" y="42">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>23</static>
+        </component>
+      </tile>
+      <tile x="46" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
         </component>
       </tile>
-      <tile x="28" y="48">
+      <tile x="47" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
-          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
         </component>
       </tile>
-      <tile x="29" y="48">
+      <tile x="48" y="42">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="49" y="42">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="30" y="48">
+      <tile x="50" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
-          <movementCost>2</movementCost>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
         </component>
       </tile>
-      <tile x="31" y="48">
+      <tile x="51" y="42">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="32" y="48">
+      <tile x="52" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
+          <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
-          <movementCost>2</movementCost>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
         </component>
       </tile>
-      <tile x="33" y="48">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="34" y="48">
+      <tile x="53" y="42">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="35" y="48">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="36" y="48">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="37" y="48">
+      <tile x="54" y="42">
         <component type="FloorComponent">
           <color r="0" g="212" b="0" a="255" />
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="38" y="48">
+      <tile x="55" y="42">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="42">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="57" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="63" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="42">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="67" y="42">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="68" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="76" y="42">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="77" y="42">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="78" y="42">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="79" y="42">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="80" y="42">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="81" y="42">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
@@ -93650,24 +106623,7 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="39" y="48">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="40" y="48">
+      <tile x="82" y="42">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
@@ -93695,7 +106651,11 @@
           <static>226</static>
         </component>
       </tile>
-      <tile x="26" y="49">
+      <tile x="107" y="42" />
+      <tile x="108" y="42" />
+      <tile x="109" y="42" />
+      <tile x="110" y="42" />
+      <tile x="111" y="42">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -93708,123 +106668,9 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="27" y="49">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="28" y="49">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="29" y="49">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="30" y="49">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="31" y="49">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="32" y="49">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="33" y="49">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="34" y="49">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="35" y="49">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="36" y="49">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="37" y="49">
-        <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="38" y="49">
+      <tile x="112" y="42">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="26" y="50">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="27" y="50">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="28" y="50">
-        <component type="WallComponent">
-          <color r="221" g="210" b="95" a="255" />
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
@@ -93835,88 +106681,48 @@
           <static>226</static>
         </component>
         <component type="StaticComponent">
-          <color r="135" g="123" b="123" a="255" />
-          <static>374</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="29" y="50">
+      <tile x="113" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="30" y="50">
+      <tile x="114" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="31" y="50">
+      <tile x="115" y="42">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
-      <tile x="32" y="50">
+      <tile x="116" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
-      <tile x="33" y="50">
+      <tile x="117" y="42">
         <component type="FloorComponent">
-          <color r="0" g="212" b="0" a="255" />
-          <ground>23</ground>
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
-      <tile x="34" y="50">
+      <tile x="118" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="35" y="50">
+      <tile x="119" y="42">
         <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
+          <ground>12</ground>
         </component>
       </tile>
-      <tile x="36" y="50">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>159</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="37" y="50">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="38" y="50">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
+      <tile x="120" y="42">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -93928,125 +106734,13 @@
           <color r="0" g="200" b="0" a="255" />
           <static>227</static>
         </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="121" y="42">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="28" y="51">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="29" y="51">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="30" y="51">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="31" y="51">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="32" y="51">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="33" y="51">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="34" y="51">
-        <component type="FloorComponent">
-          <color r="255" g="61" b="50" a="255" />
-          <ground>23</ground>
-          <movementCost>2</movementCost>
-        </component>
-      </tile>
-      <tile x="35" y="51">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="36" y="51">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="28" y="52">
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>158</wall>
-          <destroyed>161</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>227</static>
-        </component>
-      </tile>
-      <tile x="29" y="52">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="30" y="52">
-        <component type="WallComponent">
-          <color r="221" g="210" b="95" a="255" />
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
@@ -94057,31 +106751,1029 @@
           <static>226</static>
         </component>
         <component type="StaticComponent">
-          <color r="135" g="123" b="123" a="255" />
-          <static>374</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="31" y="52">
+      <tile x="122" y="42" />
+      <tile x="22" y="43" />
+      <tile x="23" y="43" />
+      <tile x="24" y="43" />
+      <tile x="25" y="43" />
+      <tile x="26" y="43" />
+      <tile x="27" y="43" />
+      <tile x="28" y="43" />
+      <tile x="29" y="43" />
+      <tile x="30" y="43" />
+      <tile x="31" y="43" />
+      <tile x="32" y="43" />
+      <tile x="33" y="43" />
+      <tile x="34" y="43" />
+      <tile x="35" y="43" />
+      <tile x="36" y="43" />
+      <tile x="37" y="43" />
+      <tile x="38" y="43" />
+      <tile x="39" y="43" />
+      <tile x="40" y="43" />
+      <tile x="41" y="43" />
+      <tile x="42" y="43" />
+      <tile x="43" y="43" />
+      <tile x="44" y="43" />
+      <tile x="45" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="46" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="47" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>23</static>
+        </component>
+      </tile>
+      <tile x="48" y="43">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="49" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="50" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="53" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="54" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="57" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="58" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="43">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="61" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="63" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="43">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="68" y="43">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="69" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="70" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="43">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="74" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="77" y="43">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="79" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="80" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="81" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="107" y="43" />
+      <tile x="108" y="43" />
+      <tile x="109" y="43" />
+      <tile x="110" y="43" />
+      <tile x="111" y="43" />
+      <tile x="112" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="113" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="114" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="115" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="116" y="43">
+        <component type="FloorComponent">
+          <color r="255" g="171" b="147" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="117" y="43">
         <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="32" y="52">
-        <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
-          <ground>23</ground>
-        </component>
-      </tile>
-      <tile x="33" y="52">
+      <tile x="118" y="43">
         <component type="FloorComponent">
           <color r="255" g="61" b="50" a="255" />
           <ground>23</ground>
           <movementCost>2</movementCost>
         </component>
       </tile>
-      <tile x="34" y="52">
+      <tile x="119" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="120" y="43">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="121" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="122" y="43">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="22" y="44" />
+      <tile x="23" y="44" />
+      <tile x="24" y="44" />
+      <tile x="25" y="44" />
+      <tile x="26" y="44" />
+      <tile x="27" y="44" />
+      <tile x="28" y="44" />
+      <tile x="29" y="44" />
+      <tile x="30" y="44" />
+      <tile x="31" y="44" />
+      <tile x="32" y="44" />
+      <tile x="33" y="44" />
+      <tile x="34" y="44" />
+      <tile x="35" y="44" />
+      <tile x="36" y="44" />
+      <tile x="37" y="44" />
+      <tile x="38" y="44" />
+      <tile x="39" y="44" />
+      <tile x="40" y="44" />
+      <tile x="41" y="44" />
+      <tile x="42" y="44" />
+      <tile x="45" y="44" />
+      <tile x="46" y="44" />
+      <tile x="47" y="44">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="48" y="44">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="49" y="44">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="50" y="44">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="51" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="52" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="53" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="54" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="55" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="56" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="60" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="44">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="69" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="75" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="44">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="44">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>208</static>
+        </component>
+      </tile>
+      <tile x="80" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="81" y="44">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="107" y="44" />
+      <tile x="108" y="44" />
+      <tile x="109" y="44" />
+      <tile x="110" y="44" />
+      <tile x="111" y="44" />
+      <tile x="112" y="44" />
+      <tile x="113" y="44">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="114" y="44">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="115" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="116" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="117" y="44">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="118" y="44">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="119" y="44">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="120" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="121" y="44">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="122" y="44">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="23" y="45" />
+      <tile x="24" y="45" />
+      <tile x="25" y="45" />
+      <tile x="26" y="45" />
+      <tile x="27" y="45" />
+      <tile x="28" y="45" />
+      <tile x="29" y="45" />
+      <tile x="30" y="45" />
+      <tile x="31" y="45" />
+      <tile x="32" y="45" />
+      <tile x="33" y="45" />
+      <tile x="34" y="45" />
+      <tile x="35" y="45" />
+      <tile x="36" y="45" />
+      <tile x="37" y="45" />
+      <tile x="38" y="45" />
+      <tile x="39" y="45" />
+      <tile x="40" y="45" />
+      <tile x="41" y="45" />
+      <tile x="47" y="45" />
+      <tile x="48" y="45">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="49" y="45">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="50" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="51" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="52" y="45">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="53" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="54" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="55" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="57" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="58" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>99</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="61" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="TreeComponent">
+          <tree>98</tree>
+          <canGrow>true</canGrow>
+        </component>
+      </tile>
+      <tile x="63" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="64" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="69" y="45">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="70" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="45">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="45">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="45">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="80" y="45">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>159</wall>
@@ -94090,24 +107782,7 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="35" y="52">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
-        </component>
-      </tile>
-      <tile x="36" y="52">
+      <tile x="81" y="45">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
@@ -94135,7 +107810,14 @@
           <static>226</static>
         </component>
       </tile>
-      <tile x="30" y="53">
+      <tile x="107" y="45" />
+      <tile x="108" y="45" />
+      <tile x="109" y="45" />
+      <tile x="110" y="45" />
+      <tile x="111" y="45" />
+      <tile x="112" y="45" />
+      <tile x="113" y="45" />
+      <tile x="114" y="45">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -94148,13 +107830,649 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="31" y="53">
+      <tile x="115" y="45">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="116" y="45">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="117" y="45">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="118" y="45">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="119" y="45">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="120" y="45">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="121" y="45">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="122" y="45">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="23" y="46" />
+      <tile x="24" y="46" />
+      <tile x="25" y="46" />
+      <tile x="26" y="46" />
+      <tile x="27" y="46" />
+      <tile x="28" y="46" />
+      <tile x="29" y="46" />
+      <tile x="30" y="46" />
+      <tile x="31" y="46" />
+      <tile x="32" y="46" />
+      <tile x="33" y="46" />
+      <tile x="34" y="46" />
+      <tile x="35" y="46" />
+      <tile x="36" y="46" />
+      <tile x="37" y="46" />
+      <tile x="38" y="46" />
+      <tile x="39" y="46" />
+      <tile x="40" y="46" />
+      <tile x="41" y="46" />
+      <tile x="49" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="50" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="51" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="52" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="53" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="54" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="55" y="46">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="56" y="46">
+        <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="32" y="53">
+      <tile x="57" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="58" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="46">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="60" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="61" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="63" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="70" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="71" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="74" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="46">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="46">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="79" y="46">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="80" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="107" y="46" />
+      <tile x="108" y="46" />
+      <tile x="109" y="46" />
+      <tile x="110" y="46" />
+      <tile x="111" y="46" />
+      <tile x="112" y="46" />
+      <tile x="113" y="46" />
+      <tile x="114" y="46" />
+      <tile x="115" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="116" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="117" y="46">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="118" y="46">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="119" y="46">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="120" y="46">
+        <component type="FloorComponent">
+          <color r="255" g="61" b="50" a="255" />
+          <ground>23</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="121" y="46">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="RopeComponent">
+          <destinationX>58</destinationX>
+          <destinationY>18</destinationY>
+          <destinationRegion>236</destinationRegion>
+          <teleporterId>512</teleporterId>
+        </component>
+      </tile>
+      <tile x="122" y="46">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="24" y="47" />
+      <tile x="25" y="47" />
+      <tile x="26" y="47" />
+      <tile x="27" y="47" />
+      <tile x="28" y="47" />
+      <tile x="29" y="47" />
+      <tile x="30" y="47" />
+      <tile x="31" y="47" />
+      <tile x="32" y="47" />
+      <tile x="33" y="47" />
+      <tile x="34" y="47" />
+      <tile x="35" y="47" />
+      <tile x="36" y="47" />
+      <tile x="37" y="47" />
+      <tile x="38" y="47" />
+      <tile x="39" y="47" />
+      <tile x="40" y="47" />
+      <tile x="51" y="47" />
+      <tile x="53" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="54" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="55" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="56" y="47">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="57" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="58" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="59" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="60" y="47">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="61" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="62" y="47">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="63" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="64" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="68" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="71" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="72" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="75" y="47">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="76" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="77" y="47">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="47">
         <component type="StaircaseComponent">
           <destinationX>26</destinationX>
           <destinationY>44</destinationY>
@@ -94162,13 +108480,330 @@
           <teleporterId>130</teleporterId>
         </component>
       </tile>
-      <tile x="33" y="53">
+      <tile x="79" y="47">
         <component type="FloorComponent">
-          <color r="3" g="82" b="255" a="255" />
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="80" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="107" y="47" />
+      <tile x="108" y="47" />
+      <tile x="109" y="47" />
+      <tile x="110" y="47" />
+      <tile x="111" y="47" />
+      <tile x="112" y="47" />
+      <tile x="113" y="47" />
+      <tile x="114" y="47" />
+      <tile x="115" y="47" />
+      <tile x="116" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="117" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="118" y="47">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="119" y="47">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="120" y="47">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="121" y="47">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="122" y="47" />
+      <tile x="24" y="48" />
+      <tile x="25" y="48" />
+      <tile x="26" y="48" />
+      <tile x="27" y="48" />
+      <tile x="28" y="48" />
+      <tile x="29" y="48" />
+      <tile x="30" y="48" />
+      <tile x="31" y="48" />
+      <tile x="32" y="48" />
+      <tile x="33" y="48" />
+      <tile x="34" y="48" />
+      <tile x="35" y="48" />
+      <tile x="36" y="48" />
+      <tile x="37" y="48" />
+      <tile x="38" y="48" />
+      <tile x="39" y="48" />
+      <tile x="40" y="48" />
+      <tile x="55" y="48">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="56" y="48">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="57" y="48">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="58" y="48">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="59" y="48">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="60" y="48">
+        <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
-      <tile x="34" y="53">
+      <tile x="61" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="62" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="63" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="64" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="65" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="66" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="68" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="70" y="48">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="48">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="72" y="48">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="73" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="74" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="76" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="77" y="48">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="78" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="79" y="48">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="80" y="48">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -94181,7 +108816,8 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="30" y="54">
+      <tile x="81" y="48" />
+      <tile x="117" y="48">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>158</wall>
@@ -94194,58 +108830,39 @@
           <static>227</static>
         </component>
       </tile>
-      <tile x="31" y="54">
-        <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
+      <tile x="118" y="48">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
-      </tile>
-      <tile x="32" y="54">
         <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
+          <static>12</static>
         </component>
+      </tile>
+      <tile x="119" y="48">
         <component type="WallComponent">
           <color r="255" g="210" b="95" a="255" />
           <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <color r="0" g="200" b="0" a="255" />
           <static>226</static>
         </component>
-      </tile>
-      <tile x="33" y="54">
         <component type="StaticComponent">
-          <color r="0" g="255" b="0" a="255" />
-          <static>23</static>
-        </component>
-        <component type="WallComponent">
-          <color r="255" g="210" b="95" a="255" />
-          <wall>157</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="StaticComponent">
-          <color r="0" g="200" b="0" a="255" />
-          <static>226</static>
+          <static>12</static>
         </component>
       </tile>
-      <tile x="34" y="54">
+      <tile x="120" y="48">
         <component type="StaticComponent">
           <color r="0" g="255" b="0" a="255" />
           <static>23</static>
@@ -94273,6 +108890,611 @@
           <static>226</static>
         </component>
       </tile>
+      <tile x="26" y="49" />
+      <tile x="27" y="49" />
+      <tile x="28" y="49" />
+      <tile x="29" y="49" />
+      <tile x="30" y="49" />
+      <tile x="31" y="49" />
+      <tile x="32" y="49" />
+      <tile x="33" y="49" />
+      <tile x="34" y="49" />
+      <tile x="35" y="49" />
+      <tile x="36" y="49" />
+      <tile x="37" y="49" />
+      <tile x="38" y="49" />
+      <tile x="58" y="49">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="59" y="49">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="60" y="49">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="61" y="49">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="62" y="49">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="63" y="49">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="64" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="65" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="66" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="67" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="68" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="69" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>102</static>
+        </component>
+      </tile>
+      <tile x="70" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="71" y="49">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="73" y="49">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="74" y="49">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="75" y="49">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="76" y="49">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="77" y="49">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>101</static>
+        </component>
+      </tile>
+      <tile x="78" y="49">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="79" y="49">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="80" y="49">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="81" y="49" />
+      <tile x="26" y="50" />
+      <tile x="27" y="50" />
+      <tile x="28" y="50" />
+      <tile x="29" y="50" />
+      <tile x="30" y="50" />
+      <tile x="31" y="50" />
+      <tile x="32" y="50" />
+      <tile x="33" y="50" />
+      <tile x="34" y="50" />
+      <tile x="35" y="50" />
+      <tile x="36" y="50" />
+      <tile x="37" y="50" />
+      <tile x="38" y="50" />
+      <tile x="61" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="62" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="63" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="64" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="65" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="66" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="67" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="68" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="69" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>12</static>
+        </component>
+      </tile>
+      <tile x="70" y="50">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="71" y="50">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="72" y="50">
+        <component type="FloorComponent">
+          <color r="0" g="212" b="0" a="255" />
+          <ground>23</ground>
+        </component>
+      </tile>
+      <tile x="73" y="50">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="74" y="50">
+        <component type="FloorComponent">
+          <ground>23</ground>
+        </component>
+        <component type="ObstructionComponent">
+          <color r="255" g="114" b="112" a="255" />
+          <obstruction>266</obstruction>
+          <blockVision>true</blockVision>
+        </component>
+      </tile>
+      <tile x="75" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>159</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="76" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="77" y="50">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="78" y="50">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="28" y="51" />
+      <tile x="29" y="51" />
+      <tile x="30" y="51" />
+      <tile x="31" y="51" />
+      <tile x="32" y="51" />
+      <tile x="33" y="51" />
+      <tile x="34" y="51" />
+      <tile x="35" y="51" />
+      <tile x="36" y="51" />
+      <tile x="69" y="51">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+      </tile>
+      <tile x="70" y="51">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="71" y="51">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="72" y="51">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="73" y="51">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="74" y="51">
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>160</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="75" y="51">
+        <component type="StaticComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <static>23</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>227</static>
+        </component>
+        <component type="WallComponent">
+          <color r="255" g="210" b="95" a="255" />
+          <wall>157</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <color r="0" g="200" b="0" a="255" />
+          <static>226</static>
+        </component>
+      </tile>
+      <tile x="81" y="51" />
+      <tile x="28" y="52" />
+      <tile x="29" y="52" />
+      <tile x="30" y="52" />
+      <tile x="31" y="52" />
+      <tile x="32" y="52" />
+      <tile x="33" y="52" />
+      <tile x="34" y="52" />
+      <tile x="35" y="52" />
+      <tile x="36" y="52" />
+      <tile x="71" y="52" />
+      <tile x="30" y="53" />
+      <tile x="31" y="53" />
+      <tile x="32" y="53" />
+      <tile x="33" y="53" />
+      <tile x="34" y="53" />
+      <tile x="30" y="54" />
+      <tile x="31" y="54" />
+      <tile x="32" y="54" />
+      <tile x="33" y="54" />
+      <tile x="34" y="54" />
+      <tile x="80" y="54" />
+      <tile x="81" y="54" />
+      <tile x="81" y="56" />
+      <tile x="82" y="61" />
+      <tile x="82" y="65" />
+      <tile x="83" y="68" />
+      <tile x="83" y="69" />
     </region>
   </regions>
   <locations>
@@ -99806,9 +115028,11 @@
         HideDetection = 30,
         CanCharge = true,
         MagicProtection = 20,
+        CanSwim = true,
     };
     
     centaur.AddStatus(new NightVisionStatus(centaur));
+    centaur.AddStatus(new BreatheWaterStatus(centaur));
     
     centaur.Attacks = new CreatureAttackCollection
     {
@@ -99820,7 +115044,7 @@
     centaur.AddGold(95);
     centaur.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakGenericGems, 14.8, gemsPriceMutatorVeryHigh),
+            new LootPackEntry(true, oakHeartGems, 4.5, gemsPriceMutatorHigh),
             new LootPackEntry(true, groveTreasure, 0.63)
         ));
     
@@ -99854,9 +115078,11 @@
         BasePenetration = ShieldPenetration.Medium,     
         Experience = 13095,
         HideDetection = 32,
+        CanSwim = true,
     };
     
     dryad.AddStatus(new NightVisionStatus(dryad));
+    dryad.AddStatus(new BreatheWaterStatus(dryad));
     
     dryad.Attacks = new CreatureAttackCollection
     {
@@ -99877,7 +115103,7 @@
     dryad.AddLoot(
         new LootPack(
             new LootPackEntry(true, (from, container) => new HickoryWand(), 1),
-            new LootPackEntry(true, oakGenericGems, 14.8, gemsPriceMutatorAboveAverage),
+            new LootPackEntry(true, oakHeartGems, 4.5, gemsPriceMutatorAboveAverage),
             new LootPackEntry(true, groveTreasure, 0.55)
         ));
     
@@ -99922,7 +115148,7 @@
     troll.AddGold(186);
     troll.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakGenericGems, 14.8, gemsPriceMutatorAboveAverage),
+            new LootPackEntry(true, oakHeartGems, 4.5, gemsPriceMutatorAboveAverage),
             new LootPackEntry(true, groveTreasure, 0.55)
         ));
     return troll;
@@ -99932,73 +115158,6 @@
       <script name="OnDeath" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnIncomingPlayer" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-    </entity>
-    <entity name="BossNotableLevel16Necro1">
-      <script name="OnSpawn" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    var necro = new HeartNecrotroph()
-    {
-        Name = "Azzeth",
-        MaxHealth = 900, Health = 900,
-        MaxMana = 7, Mana = 7,
-        BaseDodge = 31,
-        BasePenetration = ShieldPenetration.Heavy,     
-        Experience = 30814,
-        HideDetection = 38,
-        IsTethered = true,
-    };
-    
-    necro.AddStatus(new NightVisionStatus(necro));
-    necro.AddStatus(new BreatheWaterStatus(necro));
-    
-    necro.Attacks = new CreatureAttackCollection
-    {
-        new CreatureBasicAttack(22)
-    };
-    
-    necro.Spells = new CreatureSpellCollection()
-    {
-        new CreatureSpell<FireballSpell>(
-            skillLevel: 16, cost: 7)
-    };
-    
-    necro.Home = new RectangleBounds()
-    {
-        new Rectangle2D(42, 34, 43, 36, 236)
-    };
-    
-    necro.Wield(new BlackStaff());
-    
-    necro.AddGold(2100);
-    necro.AddLoot(
-        new LootPack(
-            new LootPackEntry(true, groveTreasure, 3)
-        ));
-    
-    return necro;
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnDeath" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    var tile = source.Segment.FindTile(43, 22, 236);
-    
-    if (tile != null && tile.ContainsComponent<Obstruction>())
-    {
-        var component = tile.GetComponent<Obstruction>();
-        tile.Remove(component);
-    }
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -100122,11 +115281,6 @@
     
     necro.Wield(new BlackStaff());
     
-    necro.Home = new RectangleBounds()
-    {
-        new Rectangle2D(23, 16, 25, 18, 236)
-    };
-    
     necro.AddGold(2100);
     necro.AddLoot(
         new LootPack(
@@ -100140,79 +115294,28 @@
       <script name="OnDeath" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
-    var tile = source.Segment.FindTile(35, 22, 236);
+    var tile = source.Segment.FindTile(45, -19, 236);
     
     if (tile != null && tile.ContainsComponent<Obstruction>())
     {
         var component = tile.GetComponent<Obstruction>();
         tile.Remove(component);
     }
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnIncomingPlayer" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-    </entity>
-    <entity name="BossNotableLevel16Necro2">
-      <script name="OnSpawn" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    var necro = new HeartNecrotroph()
+    
+    var tile2 = source.Segment.FindTile(54, -20, 236);
+
+    if (tile2 != null && tile2.ContainsComponent<Obstruction>())
     {
-        Name = "Vilvoron",
-        MaxHealth = 900, Health = 900,
-        MaxMana = 7, Mana = 7,
-        BaseDodge = 31,
-        BasePenetration = ShieldPenetration.Heavy,     
-        Experience = 30814,
-        HideDetection = 38,
-        IsTethered = true,
-    };
+        var component = tile2.GetComponent<Obstruction>();
+        tile2.Remove(component);
+    }
     
-    necro.AddStatus(new NightVisionStatus(necro));
-    necro.AddStatus(new BreatheWaterStatus(necro));
-    
-    necro.Attacks = new CreatureAttackCollection
+    var tile3 = source.Segment.FindTile(60, -18, 236);
+
+    if (tile3 != null && tile3.ContainsComponent<Obstruction>())
     {
-        new CreatureBasicAttack(22)
-    };
-    
-    necro.Spells = new CreatureSpellCollection()
-    {
-        new CreatureSpell<FireballSpell>(
-            skillLevel: 16, cost: 7)
-    };
-    
-    necro.Home = new RectangleBounds()
-    {
-        new Rectangle2D(21, 34, 23, 36, 236)
-    };
-    
-    necro.Wield(new BlackStaff());
-    
-    necro.AddGold(2100);
-    necro.AddLoot(
-        new LootPack(
-            new LootPackEntry(true, groveTreasure, 3)
-        ));
-    
-    return necro;
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnDeath" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    var tile = source.Segment.FindTile(39, 22, 236);
-    
-    if (tile != null && tile.ContainsComponent<Obstruction>())
-    {
-        var component = tile.GetComponent<Obstruction>();
-        tile.Remove(component);
+        var component = tile3.GetComponent<Obstruction>();
+        tile3.Remove(component);
     }
 ]]></block>
         <block><![CDATA[]]></block>
@@ -100395,6 +115498,121 @@
       <script name="OnDeath" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="BossNotableLevel16Necrotroph">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var necro = new HeartNecrotroph()
+    {
+        Name = "Necrotroph",
+        MaxHealth = 900, Health = 900,
+        MaxMana = 7, Mana = 7,
+        BaseDodge = 31,
+        BasePenetration = ShieldPenetration.Heavy,     
+        Experience = 30814,
+        HideDetection = 38,
+        IsTethered = true,
+        CanSwim = true,
+    };
+    
+    necro.AddStatus(new NightVisionStatus(necro));
+    necro.AddStatus(new BreatheWaterStatus(necro));
+    
+    necro.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(22)
+    };
+    
+    necro.Spells = new CreatureSpellCollection()
+    {
+        new CreatureSpell<FireballSpell>(
+            skillLevel: 15, cost: 7)
+    };
+    
+    necro.Wield(new BlackStaff());
+    
+    necro.AddGold(2100);
+    necro.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, groveTreasure, 3)
+        ));
+    
+    return necro;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="BossMajorLevel16Necrotroph">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var necro = new HeartNecrotroph()
+    {
+        Name = "Corrupter of the Grove",
+        MaxHealth = 9000, Health = 9000,
+        MaxMana = 12, Mana = 12,
+        BaseDodge = 35,
+        BasePenetration = ShieldPenetration.Heavy,     
+        Experience = 308140,
+        HideDetection = 38,
+        IsTethered = true,
+        CanStrikeCritically = false,
+        CanSwim = true,
+    };
+    
+    necro.AddStatus(new NightVisionStatus(necro));
+    necro.AddStatus(new BreatheWaterStatus(necro));
+    
+    necro.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(22, 58, 103)
+    };
+    
+    necro.Spells = new CreatureSpellCollection()
+    {
+        new CreatureSpell<FireStormSpell>(
+            skillLevel: 16, cost: 12)
+    };
+    
+    necro.Wield(new BlackStaff());
+    
+    necro.AddGold(2100);
+    necro.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, groveTreasure, 3)
+        ));
+    
+    return necro;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -101458,73 +116676,29 @@
       <entry entity="oakGorffwylltra" size="1" minimum="1" maximum="1" />
       <location x="3" y="2" region="225" />
     </spawn>
-    <spawn type="LocationSpawner" name="heartNecro1">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1500</maximumDelay>
-      <maximum>1</maximum>
-      <script name="OnAfterSpawn" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    if (spawn is CreatureEntity creature)
-    {
-        var tile = creature.Segment.FindTile(43, 22, 236);
-        
-        if (tile != null && !tile.ContainsComponent<Obstruction>())
-            tile.Add(new Obstruction(413, true));
-    }
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <entry entity="BossNotableLevel16Necro1" size="1" minimum="1" maximum="1" />
-      <location x="42" y="35" region="236" />
-    </spawn>
-    <spawn type="LocationSpawner" name="heartNecro2">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1500</maximumDelay>
-      <maximum>1</maximum>
-      <script name="OnAfterSpawn" enabled="true">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-    if (spawn is CreatureEntity creature)
-    {
-        var tile = creature.Segment.FindTile(39, 22, 236);
-        
-        if (tile != null && !tile.ContainsComponent<Obstruction>())
-            tile.Add(new Obstruction(413, true));
-    }
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <entry entity="BossNotableLevel16Necro2" size="1" minimum="1" maximum="1" />
-      <location x="22" y="35" region="236" />
-    </spawn>
     <spawn type="LocationSpawner" name="heartNecro3">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1500</maximumDelay>
+      <minimumDelay>2700</minimumDelay>
+      <maximumDelay>3600</maximumDelay>
       <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
     if (spawn is CreatureEntity creature)
     {
-        var tile = creature.Segment.FindTile(35, 22, 236);
+        var tile = creature.Segment.FindTile(45, -19, 236);
         
         if (tile != null && !tile.ContainsComponent<Obstruction>())
             tile.Add(new Obstruction(413, true));
+            
+        var tile2 = creature.Segment.FindTile(54, -20, 236);
+        
+        if (tile2 != null && !tile2.ContainsComponent<Obstruction>())
+            tile2.Add(new Obstruction(413, true));
+            
+        var tile3 = creature.Segment.FindTile(60, -18, 236);
+        
+        if (tile3 != null && !tile3.ContainsComponent<Obstruction>())
+            tile3.Add(new Obstruction(413, true));
     }
 ]]></block>
         <block><![CDATA[]]></block>
@@ -101537,7 +116711,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="BossNotableLevel16Necro3" size="1" minimum="1" maximum="1" />
-      <location x="24" y="17" region="236" />
+      <location x="116" y="42" region="236" />
     </spawn>
     <spawn type="LocationSpawner" name="heartKeeper">
       <minimumDelay>10800</minimumDelay>
@@ -101564,10 +116738,21 @@
       <minimumDelay>10800</minimumDelay>
       <maximumDelay>18000</maximumDelay>
       <maximum>1</maximum>
-      <script name="OnAfterSpawn" enabled="false">
+      <script name="OnAfterSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
-
+    if (spawn is CreatureEntity creature)
+    {
+        var tile = creature.Segment.FindTile(72, 11, 236);
+        
+        if (tile != null && !tile.ContainsComponent<Obstruction>())
+            tile.Add(new Obstruction(413, true));
+            
+        var tile2 = creature.Segment.FindTile(77, 17, 236);
+        
+        if (tile2 != null && !tile2.ContainsComponent<Obstruction>())
+            tile2.Add(new Obstruction(414, true));
+    }
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -101600,7 +116785,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="heartHealer" size="1" minimum="1" maximum="1" />
-      <location x="35" y="20" region="236" />
+      <location x="44" y="-20" region="236" />
     </spawn>
     <spawn type="LocationSpawner" name="heartHealer2">
       <minimumDelay>300</minimumDelay>
@@ -101621,7 +116806,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="heartHealer" size="1" minimum="1" maximum="1" />
-      <location x="39" y="20" region="236" />
+      <location x="54" y="-21" region="236" />
     </spawn>
     <spawn type="LocationSpawner" name="heartHealer3">
       <minimumDelay>300</minimumDelay>
@@ -101642,7 +116827,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="heartHealer" size="1" minimum="1" maximum="1" />
-      <location x="43" y="20" region="236" />
+      <location x="60" y="-19" region="236" />
     </spawn>
     <spawn type="LocationSpawner" name="questYuri">
       <minimumDelay>3600</minimumDelay>
@@ -101723,6 +116908,43 @@
       </script>
       <entry entity="oakConfessorGhost" size="1" minimum="1" maximum="1" />
       <location x="6" y="7" region="12" />
+    </spawn>
+    <spawn type="LocationSpawner" name="GroveHeartBoss">
+      <minimumDelay>10800</minimumDelay>
+      <maximumDelay>21600</maximumDelay>
+      <maximum>1</maximum>
+      <script name="OnAfterSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    if (spawn is CreatureEntity creature)
+    {
+        var tile = creature.Segment.FindTile(45, -19, 236);
+        
+        if (tile != null && !tile.ContainsComponent<Obstruction>())
+            tile.Add(new Obstruction(413, true));
+            
+        var tile2 = creature.Segment.FindTile(54, -20, 236);
+        
+        if (tile2 != null && !tile2.ContainsComponent<Obstruction>())
+            tile2.Add(new Obstruction(413, true));
+            
+        var tile3 = creature.Segment.FindTile(60, -18, 236);
+        
+        if (tile3 != null && !tile3.ContainsComponent<Obstruction>())
+            tile3.Add(new Obstruction(413, true));
+    }
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="BossMajorLevel16Necrotroph" size="1" minimum="1" maximum="1" />
+      <location x="80" y="9" region="236" />
     </spawn>
     <spawn type="RegionSpawner" name="portalPeacemakers">
       <minimumDelay>900</minimumDelay>
@@ -102164,9 +117386,10 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeart1">
-      <minimumDelay>1080</minimumDelay>
-      <maximumDelay>1320</maximumDelay>
+    <spawn type="RegionSpawner" name="GroveHeartPond">
+      <minimumDelay>1500</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>7</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102181,25 +117404,13 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="Level16Defender" size="2" minimum="11" maximum="11" />
-      <entry entity="level16Troll" size="4" minimum="22" maximum="22" />
-      <entry entity="level16Dryad" size="1" minimum="10" maximum="10" />
+      <entry entity="Level16Defender" size="2" minimum="3" maximum="3" />
+      <entry entity="level16Troll" size="4" minimum="2" maximum="2" />
+      <entry entity="level16Dryad" size="1" minimum="1" maximum="1" />
+      <entry entity="BossNotableLevel16Necrotroph" size="1" minimum="1" maximum="1" />
       <bounds region="236">
-        <inclusion left="40" top="1" right="41" bottom="16" />
-        <inclusion left="23" top="16" right="31" bottom="20" />
-        <inclusion left="32" top="16" right="39" bottom="16" />
-        <inclusion left="27" top="21" right="27" bottom="21" />
-        <inclusion left="23" top="22" right="29" bottom="44" />
-        <inclusion left="21" top="24" right="22" bottom="36" />
-        <inclusion left="30" top="22" right="31" bottom="28" />
-        <inclusion left="30" top="29" right="30" bottom="39" />
-        <inclusion left="34" top="23" right="44" bottom="27" />
-        <inclusion left="33" top="28" right="43" bottom="36" />
-        <inclusion left="32" top="38" right="40" bottom="44" />
-        <inclusion left="33" top="37" right="41" bottom="37" />
-        <inclusion left="41" top="38" right="41" bottom="43" />
-        <inclusion left="25" top="45" right="39" bottom="47" />
-        <inclusion left="29" top="48" right="35" bottom="51" />
+        <inclusion left="60" top="9" right="69" bottom="16" />
+        <inclusion left="70" top="12" right="75" bottom="18" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -102499,6 +117710,169 @@
       <entry entity="level11Minotaur" size="1" minimum="3" maximum="3" />
       <bounds region="225">
         <inclusion left="14" top="3" right="20" bottom="12" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="GroveHeartEntire">
+      <minimumDelay>1500</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>52</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="Level16Defender" size="2" minimum="15" maximum="15" />
+      <entry entity="level16Troll" size="4" minimum="27" maximum="27" />
+      <entry entity="level16Dryad" size="1" minimum="10" maximum="10" />
+      <bounds region="236">
+        <inclusion left="40" top="31" right="82" bottom="37" />
+        <inclusion left="38" top="26" right="81" bottom="30" />
+        <inclusion left="42" top="38" right="81" bottom="41" />
+        <inclusion left="46" top="42" right="80" bottom="45" />
+        <inclusion left="54" top="46" right="79" bottom="48" />
+        <inclusion left="62" top="49" right="77" bottom="49" />
+        <inclusion left="39" top="22" right="80" bottom="25" />
+        <inclusion left="40" top="18" right="78" bottom="21" />
+        <inclusion left="41" top="14" right="58" bottom="17" />
+        <inclusion left="42" top="11" right="57" bottom="13" />
+        <inclusion left="43" top="8" right="57" bottom="10" />
+        <inclusion left="42" top="3" right="61" bottom="7" />
+        <inclusion left="44" top="-2" right="80" bottom="2" />
+        <inclusion left="43" top="-11" right="62" bottom="-3" />
+        <inclusion left="46" top="-15" right="58" bottom="-12" />
+        <inclusion left="45" top="-17" right="47" bottom="-16" />
+        <inclusion left="51" top="-18" right="53" bottom="-16" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="GroveHeartSW">
+      <minimumDelay>1500</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>18</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="Level16Defender" size="2" minimum="6" maximum="6" />
+      <entry entity="level16Troll" size="4" minimum="8" maximum="8" />
+      <entry entity="level16Dryad" size="1" minimum="4" maximum="4" />
+      <bounds region="236">
+        <inclusion left="40" top="31" right="63" bottom="37" />
+        <inclusion left="38" top="26" right="63" bottom="30" />
+        <inclusion left="42" top="38" right="63" bottom="41" />
+        <inclusion left="46" top="42" right="63" bottom="45" />
+        <inclusion left="54" top="46" right="63" bottom="48" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="GroveHeartSE">
+      <minimumDelay>1500</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>17</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="Level16Defender" size="2" minimum="6" maximum="6" />
+      <entry entity="level16Troll" size="4" minimum="8" maximum="8" />
+      <entry entity="level16Dryad" size="1" minimum="3" maximum="3" />
+      <bounds region="236">
+        <inclusion left="64" top="31" right="82" bottom="37" />
+        <inclusion left="64" top="26" right="81" bottom="30" />
+        <inclusion left="64" top="38" right="81" bottom="41" />
+        <inclusion left="64" top="42" right="80" bottom="45" />
+        <inclusion left="64" top="46" right="79" bottom="48" />
+        <inclusion left="64" top="49" right="77" bottom="49" />
+        <inclusion left="64" top="22" right="80" bottom="25" />
+        <inclusion left="64" top="18" right="78" bottom="21" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="GroveHeartNorth">
+      <minimumDelay>1500</minimumDelay>
+      <maximumDelay>1800</maximumDelay>
+      <maximum>18</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="Level16Defender" size="2" minimum="5" maximum="5" />
+      <entry entity="level16Troll" size="4" minimum="10" maximum="10" />
+      <entry entity="level16Dryad" size="1" minimum="3" maximum="3" />
+      <bounds region="236">
+        <inclusion left="41" top="14" right="58" bottom="17" />
+        <inclusion left="42" top="11" right="57" bottom="13" />
+        <inclusion left="43" top="8" right="57" bottom="10" />
+        <inclusion left="42" top="3" right="61" bottom="7" />
+        <inclusion left="44" top="-2" right="80" bottom="2" />
+        <inclusion left="43" top="-11" right="62" bottom="-3" />
+        <inclusion left="46" top="-15" right="58" bottom="-12" />
+        <inclusion left="45" top="-17" right="47" bottom="-16" />
+        <inclusion left="51" top="-18" right="53" bottom="-16" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="GroveHeartVeins">
+      <minimumDelay>2700</minimumDelay>
+      <maximumDelay>3000</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="BossNotableLevel16Necrotroph" size="1" minimum="5" maximum="5" />
+      <bounds region="236">
+        <inclusion left="71" top="8" right="82" bottom="11" />
+        <inclusion left="77" top="14" right="84" bottom="17" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -103309,6 +118683,35 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new LargeEmerald(17000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+    </treasure>
+    <treasure name="oakHeartGems">
+      <entry weight="15">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new SmallRuby(8000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="10">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new BloodRuby(40000u);
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new LargeEmerald(100000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -117274,7 +117274,7 @@
         <exclusion left="12" top="4" right="17" bottom="5" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="grovepiranhas">
+    <spawn type="RegionSpawner" name="groveEntranceFish">
       <minimumDelay>300</minimumDelay>
       <maximumDelay>900</maximumDelay>
       <maximum>3</maximum>
@@ -117298,7 +117298,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="groveDefenders">
+    <spawn type="RegionSpawner" name="groveEntrance">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1500</maximumDelay>
       <maximum>12</maximum>
@@ -117328,7 +117328,7 @@
         <inclusion left="1" top="1" right="8" bottom="1" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="groveVipers">
+    <spawn type="RegionSpawner" name="groveEntranceVipers">
       <minimumDelay>1200</minimumDelay>
       <maximumDelay>1800</maximumDelay>
       <maximum>1</maximum>
@@ -117352,7 +117352,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="groveWildlife">
+    <spawn type="RegionSpawner" name="groveEntranceWildlife">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
       <maximum>16</maximum>
@@ -117386,7 +117386,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeartPond">
+    <spawn type="RegionSpawner" name="groveHeartPond">
       <minimumDelay>1500</minimumDelay>
       <maximumDelay>1800</maximumDelay>
       <maximum>7</maximum>
@@ -117713,7 +117713,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeartEntire">
+    <spawn type="RegionSpawner" name="groveHeartEntire">
       <minimumDelay>1500</minimumDelay>
       <maximumDelay>1800</maximumDelay>
       <maximum>52</maximum>
@@ -117755,7 +117755,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeartSW">
+    <spawn type="RegionSpawner" name="groveHeartSW">
       <minimumDelay>1500</minimumDelay>
       <maximumDelay>1800</maximumDelay>
       <maximum>18</maximum>
@@ -117785,7 +117785,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeartSE">
+    <spawn type="RegionSpawner" name="groveHeartSE">
       <minimumDelay>1500</minimumDelay>
       <maximumDelay>1800</maximumDelay>
       <maximum>17</maximum>
@@ -117818,7 +117818,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeartNorth">
+    <spawn type="RegionSpawner" name="groveHeartNorth">
       <minimumDelay>1500</minimumDelay>
       <maximumDelay>1800</maximumDelay>
       <maximum>18</maximum>
@@ -117852,7 +117852,7 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="GroveHeartVeins">
+    <spawn type="RegionSpawner" name="groveHeartVeins">
       <minimumDelay>2700</minimumDelay>
       <maximumDelay>3000</maximumDelay>
       <script name="OnAfterSpawn" enabled="false">


### PR DESCRIPTION
Turned grove from sloppy shield shape to actual heart shape

Evened out spawns with a <.20 density and 25-30 minute respawn (pre-adjustment)

Removed the random cat demons that prevented the zone from being particularly farmable.

Increased gems to be equivalent to axe undead - difficulty should be similar.

Revamped escort quest - just one cat demon resides in the aorta passage, killing it will despawn the obstacles and begin the escort but the escort is farther now. 

Upon finish of the escort quest a boss is released from behind the blocked pulmonary veins.