### PR TITLE
Feature/oak adjustments

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -102268,7 +102268,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaNorthwest">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>42</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102300,7 +102300,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaNortheast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>42</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102333,7 +102333,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSouthwest">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>42</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102365,7 +102365,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSoutheast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>42</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -102268,7 +102268,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaNorthwest">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>8</maximum>
+      <maximum>42</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102283,16 +102283,16 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
-      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
-      <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
-      <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
-      <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
+      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="9" />
+      <entry entity="level9Orc" size="3" minimum="9" maximum="9" />
+      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="4" />
+      <entry entity="level9OrcTrapper" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Thaum" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Minotaur" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Salamander" size="1" minimum="2" maximum="2" />
+      <entry entity="level9Troll" size="2" minimum="4" maximum="4" />
+      <entry entity="level9Gargoyle" size="1" minimum="2" maximum="2" />
       <bounds region="235">
         <inclusion left="-4" top="-9" right="9" bottom="7" />
       </bounds>
@@ -102300,7 +102300,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaNortheast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>16</maximum>
+      <maximum>42</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102315,16 +102315,16 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
-      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
-      <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
-      <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
-      <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
+      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="9" />
+      <entry entity="level9Orc" size="3" minimum="9" maximum="9" />
+      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="4" />
+      <entry entity="level9OrcTrapper" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Thaum" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Minotaur" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Salamander" size="1" minimum="2" maximum="2" />
+      <entry entity="level9Troll" size="2" minimum="4" maximum="4" />
+      <entry entity="level9Gargoyle" size="1" minimum="2" maximum="2" />
       <bounds region="235">
         <inclusion left="23" top="-8" right="41" bottom="7" />
         <inclusion left="29" top="8" right="46" bottom="14" />
@@ -102333,7 +102333,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSouthwest">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>12</maximum>
+      <maximum>42</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102348,16 +102348,16 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
-      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
-      <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
-      <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
-      <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
+      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="9" />
+      <entry entity="level9Orc" size="3" minimum="9" maximum="9" />
+      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="4" />
+      <entry entity="level9OrcTrapper" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Thaum" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Minotaur" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Salamander" size="1" minimum="2" maximum="2" />
+      <entry entity="level9Troll" size="2" minimum="4" maximum="4" />
+      <entry entity="level9Gargoyle" size="1" minimum="2" maximum="2" />
       <bounds region="235">
         <inclusion left="2" top="13" right="23" bottom="37" />
       </bounds>
@@ -102365,7 +102365,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSoutheast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>7</maximum>
+      <maximum>42</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -102380,16 +102380,16 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level9Hobgoblin" size="3" minimum="12" maximum="15" />
-      <entry entity="level9Orc" size="3" minimum="12" maximum="15" />
-      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="6" />
-      <entry entity="level9OrcTrapper" size="1" minimum="4" maximum="6" />
-      <entry entity="level9Thaum" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Wizard" size="1" minimum="2" maximum="3" />
-      <entry entity="level9Minotaur" size="1" minimum="6" maximum="8" />
-      <entry entity="level9Salamander" size="1" minimum="1" maximum="2" />
-      <entry entity="level9Troll" size="1" minimum="7" maximum="10" />
-      <entry entity="level9Gargoyle" size="1" minimum="6" maximum="9" />
+      <entry entity="level9Hobgoblin" size="3" minimum="9" maximum="9" />
+      <entry entity="level9Orc" size="3" minimum="9" maximum="9" />
+      <entry entity="level9OrcSentry" size="2" minimum="4" maximum="4" />
+      <entry entity="level9OrcTrapper" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Thaum" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Wizard" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Minotaur" size="1" minimum="3" maximum="3" />
+      <entry entity="level9Salamander" size="1" minimum="2" maximum="2" />
+      <entry entity="level9Troll" size="2" minimum="4" maximum="4" />
+      <entry entity="level9Gargoyle" size="1" minimum="2" maximum="2" />
       <bounds region="235">
         <inclusion left="24" top="18" right="50" bottom="32" />
       </bounds>


### PR DESCRIPTION
Serp Area Changed
* Add correct max capacity per area
* Synced the rest of the crits to be in line. 

25 crits per area SE/SW/NE/NW spawns. 