### PR TITLE
Kesmai -5: Flip flop the stairs to allow UP

### DIFF
--- a/Segments/Kesmai.mapproj
+++ b/Segments/Kesmai.mapproj
@@ -76936,7 +76936,7 @@
           <destinationX>31</destinationX>
           <destinationY>37</destinationY>
           <destinationRegion>71</destinationRegion>
-          <teleporterId>126</teleporterId>
+          <teleporterId>123</teleporterId>
         </component>
       </tile>
       <tile x="15" y="2">


### PR DESCRIPTION
Helping out Midgit one more time before he takes on the population piece. 

Currently this:

![image](https://user-images.githubusercontent.com/90510109/168055108-eb40bd38-cf87-4a62-a81b-9db5bed337e0.png)

is not behaving with this: 

![image](https://user-images.githubusercontent.com/90510109/168055266-2ad6651c-b2c2-4c4d-9836-0268c6961383.png)

Issue: User can not type up on the stairs below. They can type down on the stairs above. I wouldn't imagine the stairs to correspond to each other, but attempting one small fix to see if it works. 

Attempting to flip flop the stairs down to fix it. 

