### PR TITLE
Oak -1 polish

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -110887,40 +110887,38 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Rat">
+    <entity name="level6Rat">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var rat = new BlackRat()
     {
-        MaxHealth = 18, Health = 18,
-        BaseDodge = 14,
-
-        Experience = 482,
-
+        MaxHealth = 30, Health = 30,
+        BaseDodge = 18,
+        HideDetection = 18,
+        Experience = 810,
         VisibilityDistance = 1,
         Movement = 2,
-        
         BasePenetration = ShieldPenetration.Light,
     };
     
     rat.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(3, 1, 5, "The rat rakes you with its claws"), 50 
+            new CreatureAttack(6, 3, 12, "The rat rakes you with its claws"), 50 
         }, 
         {
-            new CreatureAttack(3, 1, 5, "The rat bites you"), 30
+            new CreatureAttack(6, 4, 10, "The rat bites you"), 30
         },
         {
-            new CreatureAttack(3, 1, 5, "The rat whips you with its tail"), 20 
+            new CreatureAttack(6, 2, 8, "The rat whips you with its tail"), 20 
         },
     };
     
     rat.Blocks = new CreatureBlockCollection
     {
         {
-            new CreatureBlock(6, "the armor") 
+            new CreatureBlock(6, "the fur") 
         }, 
         {
             new CreatureBlock(3, "a claw") 
@@ -110930,8 +110928,6 @@
         }, 
     };
 
-    rat.AddGold(30);
-    
     return rat;
 ]]></block>
         <block><![CDATA[]]></block>
@@ -110949,7 +110945,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Viper">
+    <entity name="level6Viper">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -110957,27 +110953,26 @@
     {
         Name = "viper",
         
-        MaxHealth = 22, Health = 22,
-        BaseDodge = 13,
+        MaxHealth = 46, Health = 46,
+        BaseDodge = 16,
 
-        Experience = 1044,
+        Experience = 1594,
 
         Movement = 2,
     };
     
     viper.Attacks = new CreatureAttackCollection
     {
-        new CreatureAttack(3, 1, 8, "The viper strikes you.",
-                            new AttackPoisonComponent(5, 30),
-                            new AttackStunComponent(5))
+        new CreatureAttack(6, 3, 10, "The viper strikes you.",
+                            new AttackPoisonComponent(8, 30),
+                            new AttackStunComponent(10))
     };
     
     viper.Blocks = new CreatureBlockCollection
     {
-        new CreatureBlock(1, "the armor")
+        new CreatureBlock(1, "the scales")
     };
 
-    viper.AddGold(42);
     
     return viper;
 ]]></block>
@@ -110996,16 +110991,16 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Scorpion">
+    <entity name="level6Scorpion">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var scorpion = new Scorpion()
     {
-        MaxHealth = 30, Health = 30,
+        MaxHealth = 50, Health = 50,
         BaseDodge = 13,
 
-        Experience = 1044,
+        Experience = 1694,
 
         Movement = 2,
     };    
@@ -111013,29 +111008,21 @@
     scorpion.Attacks = new CreatureAttackCollection
     {
         { 
-            new CreatureAttack(3, 3, 10, "The scorpion crushes you with its claws."), 60 
+            new CreatureAttack(6, 7, 20, "The scorpion crushes you with its claws."), 60 
         }, 
         {
-            new CreatureAttack(3, 4, 8, "The scorpion stings you with its tail.",
-                    new AttackPoisonComponent(3),
+            new CreatureAttack(6, 4, 8, "The scorpion stings you with its tail.",
+                    new AttackPoisonComponent(6),
                     new AttackStunComponent(10)),                                    40 
         }, 
     };
     
     scorpion.Blocks = new CreatureBlockCollection
     {
-            new CreatureBlock(6, "the armor"),
+            new CreatureBlock(6, "the carapace"),
             new CreatureBlock(3, "a claw"),
             new CreatureBlock(1, "a tail") 
     };
-
-    scorpion.AddGold(65);
-    scorpion.AddLoot(
-        new LootPack(
-            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorNormal), 
-            new LootPackEntry(true, oakGenericBottles, 20.0), 
-            new LootPackEntry(true, dungeon1Treasure, 0.5)
-        ));
 
     return scorpion;
 ]]></block>
@@ -111054,34 +111041,34 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Kobold">
+    <entity name="level6Kobold">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var kobold = new Kobold()
     {
-        MaxHealth = 18, Health = 18,
-        BaseDodge = 10,
-
-        Experience = 482,
-
-        Movement = 2,
+        MaxHealth = 45, Health = 45,
+        BaseDodge = 15,
+        HideDetection = 17,
+        Experience = 990,
     };
     
     kobold.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(3)
+        new CreatureBasicAttack(5)
     };
 
     kobold.Wield(new SteelMace());
     kobold.Equip(new LeatherArmor());    
 
-    kobold.AddGold(30);
+    kobold.AddGold(60);
     kobold.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorAboveAverage), 
+            new LootPackEntry(true, oakLowLevelGems, 12, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0), 
-            new LootPackEntry(true, dungeon1Treasure, 0.63)
+            new LootPackEntry(true, oakvaelPotions,     0.1),
+            new LootPackEntry(true, dungeon1Treasure, 0.63),
+            new LootPackEntry(true, utilityOrbs,    0.5)
         ));
 
     return kobold;
@@ -111101,36 +111088,35 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Orc">
+    <entity name="level6Orc">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 30, Health = 30,
-        BaseDodge = 10,
-
-        Experience = 972,
-
-        Movement = 2,
-
+        MaxHealth = 60, Health = 60,
+        BaseDodge = 14,
+        HideDetection = 18,         
+        Experience = 1679,
         CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(3)
+        new CreatureBasicAttack(6)
     };
 
     orc.Wield(new Longsword());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(49);
+    orc.AddGold(70);
     orc.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakLowLevelGems, 10, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0), 
-            new LootPackEntry(true, dungeon1Treasure, 0.5)
+            new LootPackEntry(true, oakvaelPotions,     0.1),
+            new LootPackEntry(true, dungeon1Treasure, 0.5),
+            new LootPackEntry(true, utilityOrbs,    1)
         ));
 
     return orc;
@@ -111150,34 +111136,35 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3OrcSentry">
+    <entity name="level6OrcSentry">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 27, Health = 27,
-        BaseDodge = 10,
-
-        Experience = 972,
-
+        MaxHealth = 60, Health = 60,
+        BaseDodge = 14,
+        HideDetection = 18,         
+        Experience = 1779,
         CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(3)
+        new CreatureBasicAttack(5)
     };
 
     orc.Wield(new Crossbow());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(70);
+    orc.AddGold(75);
     orc.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakLowLevelGems, 10, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0), 
-            new LootPackEntry(true, dungeon1Treasure, 0.5)
+            new LootPackEntry(true, oakvaelPotions,     0.1),
+            new LootPackEntry(true, dungeon1Treasure, 0.5),
+            new LootPackEntry(true, utilityOrbs,    1)
         ));
 
     return orc;
@@ -111197,36 +111184,38 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Troll">
+    <entity name="level6Troll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var troll = new Troll()
     {
-        MaxHealth = 33, Health = 33,
-        BaseDodge = 12,
-
-        Experience = 1044,
-
+        MaxHealth = 66, Health = 66,
+        BaseDodge = 14,
+        HideDetection = 22,         
+        Experience = 1804,
+                
         Movement = 2,
-
+                
         CanFlee = true,
     };
     
     troll.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(4)
+        new CreatureBasicAttack(6)
     };
 
     troll.Wield(new Greatsword());
     troll.Equip(new ChainmailArmor());    
 
-    troll.AddGold(66);
+    troll.AddGold(96);
     troll.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorAboveAverage), 
+            new LootPackEntry(true, oakLowLevelGems, 10, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0), 
-            new LootPackEntry(true, dungeon1Treasure, 0.55)
+            new LootPackEntry(true, oakvaelPotions,     0.15),
+            new LootPackEntry(true, dungeon1Treasure, 0.5),
+            new LootPackEntry(true, utilityOrbs,    0.5)
         ));
 
     return troll;
@@ -111246,41 +111235,33 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level3Spider">
+    <entity name="level6Spider">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var spider = new Spider()
     {
-        MaxHealth = 22, Health = 22,
-        BaseDodge = 13,
+        MaxHealth = 58, Health = 58,
+        BaseDodge = 16,
 
-        Experience = 972,
+        Experience = 1824,
 
         Movement = 0,
-        
         VisibilityDistance = 0,
         RangePerception = 0,
     };
     
     spider.Attacks = new CreatureAttackCollection
     {
-        new CreatureAttack(3, 4, 8, "The spider bites you.",
-                            new AttackPoisonComponent(2))
+        new CreatureAttack(6, 4, 8, "The spider bites you.",
+                            new AttackPoisonComponent(7))
     };
     
     spider.Blocks = new CreatureBlockCollection
     {
-        new CreatureBlock(1, "the armor")
+        new CreatureBlock(6, "a leg"),
+        new CreatureBlock(2, "the fur")
     };
-
-    spider.AddGold(42);
-    spider.AddLoot(
-        new LootPack(
-            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorMedium), 
-            new LootPackEntry(true, oakGenericBottles, 20.0), 
-            new LootPackEntry(true, dungeon1Treasure, 0.37)
-        ));
 
     return spider;
 ]]></block>
@@ -116386,7 +116367,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Spider" size="1" minimum="1" maximum="1" />
+      <entry entity="level6Spider" size="1" minimum="1" maximum="1" />
       <location x="17" y="1" region="251" />
     </spawn>
     <spawn type="LocationSpawner" name="dungeon1Spider1">
@@ -116406,7 +116387,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Spider" size="1" minimum="1" maximum="1" />
+      <entry entity="level6Spider" size="1" minimum="1" maximum="1" />
       <location x="25" y="9" region="251" />
     </spawn>
     <spawn type="LocationSpawner" name="hobgoblinCavesSpider">
@@ -116426,7 +116407,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Spider" size="1" minimum="1" maximum="1" />
+      <entry entity="level6Spider" size="1" minimum="1" maximum="1" />
       <location x="10" y="8" region="239" />
     </spawn>
     <spawn type="LocationSpawner" name="dungeon3Serpent">
@@ -117130,7 +117111,7 @@
         <block><![CDATA[]]></block>
       </script>
       <entry entity="surfaceOrc" size="3" minimum="2" maximum="2" />
-      <entry entity="level3OrcSentry" size="1" minimum="2" maximum="2" />
+      <entry entity="level6OrcSentry" size="1" minimum="2" maximum="2" />
       <entry entity="level7Goblin" size="3" minimum="2" maximum="2" />
       <bounds region="241">
         <inclusion left="2" top="2" right="13" bottom="21" />
@@ -117141,7 +117122,7 @@
     <spawn type="RegionSpawner" name="spiderCavesSpawner">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>16</maximum>
+      <maximum>24</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117156,16 +117137,16 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Rat" size="1" minimum="3" maximum="6" />
-      <entry entity="level3Kobold" size="1" minimum="3" maximum="5" />
-      <entry entity="level3Viper" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Scorpion" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Orc" size="1" minimum="4" maximum="7" />
-      <entry entity="level3OrcSentry" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Troll" size="1" minimum="4" maximum="6" />
+      <entry entity="level6Rat" size="1" minimum="6" maximum="6" />
+      <entry entity="level6Kobold" size="2" minimum="3" maximum="3" />
+      <entry entity="level6Viper" size="1" minimum="2" maximum="2" />
+      <entry entity="level6Scorpion" size="1" minimum="2" maximum="2" />
+      <entry entity="level6Orc" size="3" minimum="4" maximum="4" />
+      <entry entity="level6OrcSentry" size="2" minimum="2" maximum="2" />
+      <entry entity="level6Troll" size="2" minimum="4" maximum="4" />
       <bounds region="251">
         <inclusion left="1" top="1" right="49" bottom="10" />
-        <exclusion left="0" top="0" right="0" bottom="0" />
+        <exclusion left="39" top="3" right="43" bottom="7" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="hobgoblinCavesSpawn">
@@ -117606,9 +117587,9 @@
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="spiderCavesWest">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
-      <maximum>8</maximum>
+      <minimumDelay>600</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <maximum>11</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117623,22 +117604,22 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Rat" size="1" minimum="3" maximum="6" />
-      <entry entity="level3Kobold" size="1" minimum="3" maximum="5" />
-      <entry entity="level3Viper" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Scorpion" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Orc" size="1" minimum="4" maximum="7" />
-      <entry entity="level3OrcSentry" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Troll" size="1" minimum="4" maximum="6" />
+      <entry entity="level6Rat" size="1" minimum="1" maximum="6" />
+      <entry entity="level6Kobold" size="1" minimum="1" maximum="5" />
+      <entry entity="level6Viper" size="1" minimum="1" maximum="3" />
+      <entry entity="level6Scorpion" size="1" minimum="1" maximum="2" />
+      <entry entity="level6Orc" size="1" minimum="1" maximum="2" />
+      <entry entity="level6OrcSentry" size="1" minimum="1" maximum="2" />
+      <entry entity="level6Troll" size="1" minimum="1" maximum="3" />
       <bounds region="251">
-        <inclusion left="1" top="1" right="23" bottom="10" />
+        <inclusion left="1" top="2" right="17" bottom="9" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="spiderCavesEast">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
-      <maximum>8</maximum>
+      <minimumDelay>600</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117653,15 +117634,17 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Rat" size="1" minimum="3" maximum="6" />
-      <entry entity="level3Kobold" size="1" minimum="3" maximum="5" />
-      <entry entity="level3Viper" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Scorpion" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Orc" size="1" minimum="4" maximum="7" />
-      <entry entity="level3OrcSentry" size="1" minimum="2" maximum="3" />
-      <entry entity="level3Troll" size="1" minimum="4" maximum="6" />
+      <entry entity="level6Rat" size="1" minimum="1" maximum="4" />
+      <entry entity="level6Kobold" size="1" minimum="1" maximum="4" />
+      <entry entity="level6Viper" size="1" minimum="1" maximum="3" />
+      <entry entity="level6Scorpion" size="1" minimum="1" maximum="1" />
+      <entry entity="level6Orc" size="3" minimum="1" maximum="4" />
+      <entry entity="level6OrcSentry" size="2" minimum="1" maximum="3" />
+      <entry entity="level6Troll" size="2" minimum="1" maximum="4" />
       <bounds region="251">
-        <inclusion left="24" top="1" right="49" bottom="9" />
+        <inclusion left="19" top="1" right="37" bottom="7" />
+        <inclusion left="38" top="1" right="47" bottom="2" />
+        <inclusion left="44" top="3" right="45" bottom="5" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -118617,7 +118600,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new TigerEye(750u);
+	return new TigerEye(1450u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -118626,7 +118609,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new SmallRuby(1200u);
+	return new SmallRuby(3200u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -118635,7 +118618,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new BloodRuby(3000u);
+	return new BloodRuby(4000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
@@ -118644,7 +118627,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new LargeEmerald(15000u);
+	return new LargeEmerald(19000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
**Overall Goal:**
_Current difficulty:_
-1 oak  = -2 Kes
-2 oak =  between -3 and -4 Kes probably similar to Axe cave.
-3 serp = just harder than -4 kes 
-4 TT = slightly harder than serp
-5 UD is a lot harder than TT

_Im thinking....._
make -1 more useful .. about difficulty of axe cave/-3 kes
-2 very slightly harder (between new oak -1 and -3)
-3 leave
-4 make a little harder between serp and ud difficulty
-5 leave

**What I have done:**
I have tired to make -1 Oak more useful to players that could reach it. On par with Axe caves, but different due to different mobs.

I have deliberately left a path though that has a chance of slightly less density so as to try to reduce impact on Konran quest. basically the E and W spawns avoid this path (but do over see it) and there is a whole area spawner what does cover the path.

This is going to be something we need to feel if its right.

