### PR TITLE
Oak -2 polish

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -111299,37 +111299,37 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level7Hobgoblin">
+    <entity name="level8Hobgoblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var hobgoblin = new Hobgoblin()
     {
-        MaxHealth = 70, Health = 70,
-        BaseDodge = 15,
-        HideDetection = 21,
-        Experience = 2015,
+        MaxHealth = 80, Health = 80,
+        BaseDodge = 16,
+        HideDetection = 23,
+        Experience = 2485,
         BasePenetration = ShieldPenetration.VeryLight,
-
-        Movement = 2,
+        
     };
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(7)
+        new CreatureBasicAttack(8)
     };
 
     hobgoblin.Wield(new Longsword());
     hobgoblin.Equip(new LeatherArmor());    
 
-    hobgoblin.AddGold(77);
+    hobgoblin.AddGold(87);
     hobgoblin.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakMidLevelGems, 11.6, gemsPriceMutatorAboveAverage), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
             new LootPackEntry(true, dungeon2Treasure, 0.5), 
             new LootPackEntry(true, dungeon2Rings, 0.5), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, oakvaelPotions, 0.05),
+            new LootPackEntry(true, utilityOrbs,    0.5)
         ));
 
     return hobgoblin;
@@ -111349,22 +111349,22 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level7Goblin">
+    <entity name="level8Goblin">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var goblin = new Goblin()
     {
-        MaxHealth = 50, Health = 60,
-        BaseDodge = 14,
-        HideDetection = 21,
-        Experience = 1567,
+        MaxHealth = 69, Health = 69,
+        BaseDodge = 16,
+        HideDetection = 20,
+        Experience = 1907,
         BasePenetration = ShieldPenetration.VeryLight,
     };
     
     goblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(6)
+        new CreatureBasicAttack(7)
     };
 
     goblin.Wield(new Longsword());
@@ -111373,11 +111373,11 @@
     goblin.AddGold(66);
     goblin.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorMedium), 
+            new LootPackEntry(true, oakMidLevelGems, 11.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
             new LootPackEntry(true, dungeon2Treasure, 0.37), 
             new LootPackEntry(true, dungeon2Rings, 0.37), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, oakvaelPotions, 0.1)
         ));
 
     return goblin;
@@ -111403,10 +111403,10 @@
         <block><![CDATA[
 	var goblin = new Goblin()
     {
-        MaxHealth = 45, Health = 45,
+        MaxHealth = 52, Health = 52,
         BaseDodge = 14,
         HideDetection = 21,
-        Experience = 1567,
+        Experience = 1507,
         BasePenetration = ShieldPenetration.VeryLight,
     };
     
@@ -111423,11 +111423,11 @@
     goblin.AddGold(66);
     goblin.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorMedium), 
+            new LootPackEntry(true, oakMidLevelGems, 11.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
             new LootPackEntry(true, dungeon2Treasure, 0.37), 
             new LootPackEntry(true, dungeon2Rings, 0.37), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, oakvaelPotions, 0.1)
         ));
 
     return goblin;
@@ -111447,17 +111447,17 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level7Troll">
+    <entity name="level8Troll">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var troll = new Troll()
     {
-        MaxHealth = 77, Health = 77,
+        MaxHealth = 87, Health = 87,
         BaseDodge = 16,
 
-        Experience = 2164,
-        HideDetection = 21,
+        Experience = 2764,
+        HideDetection = 23,
         Movement = 2,
         BasePenetration = ShieldPenetration.VeryLight,
 
@@ -111474,10 +111474,10 @@
     troll.Wield(new Greatsword());
     troll.Equip(new ChainmailArmor());    
 
-    troll.AddGold(98);
+    troll.AddGold(88);
     troll.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorAboveAverage), 
+            new LootPackEntry(true, oakMidLevelGems, 11.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
             new LootPackEntry(true, dungeon2Treasure, 0.55), 
             new LootPackEntry(true, dungeon2Rings, 0.55), 
@@ -111501,37 +111501,37 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="level7Orc">
+    <entity name="level8Orc">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 50, Health = 50,
-        BaseDodge = 14,
-        HideDetection = 21,
-        Experience = 2015,
+        MaxHealth = 80, Health = 80,
+        BaseDodge = 15,
+        HideDetection = 23,
+        Experience = 2415,
         BasePenetration = ShieldPenetration.VeryLight,
-        
         CanFlee = true,
     };
     
     orc.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(7)
+        new CreatureBasicAttack(8)
     };
 
     orc.Wield(new Katana());
     orc.Equip(new LeatherArmor());    
 
-    orc.AddGold(79);
+    orc.AddGold(89);
     orc.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakMidLevelGems, 12.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
             new LootPackEntry(true, dungeon2Treasure, 0.5), 
             new LootPackEntry(true, dungeon2Rings, 0.5), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, oakvaelPotions, 0.1),
+            new LootPackEntry(true, utilityOrbs,    0.5)
         ));
 
     return orc;
@@ -111557,12 +111557,11 @@
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 45, Health = 45,
+        MaxHealth = 57, Health = 57,
         BaseDodge = 14,
         HideDetection = 21,
-        Experience = 2015,
+        Experience = 1755,
         BasePenetration = ShieldPenetration.VeryLight,
-
         CanFlee = true,
     };
     
@@ -111579,11 +111578,12 @@
     orc.AddGold(79);
     orc.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakMidLevelGems, 11.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
-            new LootPackEntry(true, dungeon2Treasure, 0.5), 
-            new LootPackEntry(true, dungeon2Rings, 0.5), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, dungeon2Treasure, 0.37), 
+            new LootPackEntry(true, dungeon2Rings, 0.37), 
+            new LootPackEntry(true, oakvaelPotions, 0.1),
+            new LootPackEntry(true, utilityOrbs,    1)
         ));
 
     return orc;
@@ -111609,10 +111609,10 @@
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 40, Health = 40,
+        MaxHealth = 60, Health = 60,
         MaxMana = 12, Mana = 12,
-        BaseDodge = 14,
-        HideDetection = 21,
+        BaseDodge = 16,
+        HideDetection = 23,
         Experience = 2015,
         BasePenetration = ShieldPenetration.VeryLight,
         
@@ -111630,18 +111630,19 @@
             skillLevel: 7, cost: 6,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 6, cost: 5,
+            skillLevel: 5, cost: 5,
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
 
     orc.AddGold(77);
     orc.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakMidLevelGems, 11.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
-            new LootPackEntry(true, dungeon2Treasure, 0.5), 
-            new LootPackEntry(true, dungeon2Rings, 0.5), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, dungeon2Treasure, 0.37), 
+            new LootPackEntry(true, dungeon2Rings, 0.37), 
+            new LootPackEntry(true, oakvaelPotions, 0.1),
+            new LootPackEntry(true, utilityOrbs,    2)
         ));
 
     return orc;
@@ -111668,10 +111669,10 @@
 	var spectre = new Spectre()
     {
         MaxHealth = 70, Health = 70,
-        MaxMana = 17, Mana = 17,
+        MaxMana = 15, Mana = 15,
         BaseDodge = 16,
         HideDetection = 21,
-        Experience = 2538,
+        Experience = 2498,
         BasePenetration = ShieldPenetration.VeryLight,
 
         VisibilityDistance = 1,
@@ -111689,7 +111690,7 @@
             skillLevel: 7, cost: 4,
             mantra: SpellHelper.GenerateMantra(), instantCast: false),
         new CreatureSpell<DeathSpell>(
-            skillLevel: 2, cost: 6, 
+            skillLevel: 3, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
 
@@ -111698,11 +111699,12 @@
     spectre.AddGold(66);
     spectre.AddLoot(
         new LootPack(
-            new LootPackEntry(true, oakMidLevelGems, 21.6, gemsPriceMutatorNormal), 
+            new LootPackEntry(true, oakMidLevelGems, 15.6, gemsPriceMutatorNormal), 
             new LootPackEntry(true, oakGenericBottles, 20.0),
             new LootPackEntry(true, dungeon2Treasure, 0.5), 
             new LootPackEntry(true, dungeon2Rings, 0.5), 
-            new LootPackEntry(true, oakvaelPotions, 0.05)
+            new LootPackEntry(true, oakvaelPotions, 0.1),
+            new LootPackEntry(true, utilityOrbs,    0.5)
         ));
 
     return spectre;
@@ -115623,6 +115625,58 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
+    <entity name="level7Spider">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var spider = new Spider()
+    {
+        MaxHealth = 52, Health = 52,
+        BaseDodge = 18,
+
+        Experience = 1972,
+
+        Movement = 0,
+        
+        VisibilityDistance = 0,
+        RangePerception = 0,
+    };
+    
+    spider.Attacks = new CreatureAttackCollection
+    {
+        new CreatureAttack(7, 7, 14, "The spider bites you.",
+                            new AttackPoisonComponent(5))
+    };
+    
+    spider.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(1, "the fur")
+    };
+
+    spider.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, oakLowLevelGems, 13.6, gemsPriceMutatorMedium), 
+            new LootPackEntry(true, oakGenericBottles, 20.0), 
+            new LootPackEntry(true, dungeon1Treasure, 0.37)
+        ));
+
+    return spider;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
   </entities>
   <spawns>
     <spawn type="LocationSpawner" name="oakSheriff">
@@ -116426,7 +116480,7 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level3Spider" size="1" minimum="1" maximum="1" />
+      <entry entity="level7Spider" size="1" minimum="1" maximum="1" />
       <location x="10" y="8" region="239" />
     </spawn>
     <spawn type="LocationSpawner" name="dungeon3Serpent">
@@ -117131,7 +117185,7 @@
       </script>
       <entry entity="surfaceOrc" size="3" minimum="2" maximum="2" />
       <entry entity="level3OrcSentry" size="1" minimum="2" maximum="2" />
-      <entry entity="level7Goblin" size="3" minimum="2" maximum="2" />
+      <entry entity="level8Goblin" size="3" minimum="2" maximum="2" />
       <bounds region="241">
         <inclusion left="2" top="2" right="13" bottom="21" />
         <exclusion left="4" top="8" right="6" bottom="21" />
@@ -117186,17 +117240,19 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level7Hobgoblin" size="3" minimum="6" maximum="8" />
-      <entry entity="level7Goblin" size="3" minimum="3" maximum="5" />
-      <entry entity="level7GoblinSentry" size="2" minimum="2" maximum="3" />
-      <entry entity="level7Orc" size="3" minimum="3" maximum="5" />
-      <entry entity="level7OrcSentry" size="1" minimum="2" maximum="3" />
-      <entry entity="level7Troll" size="2" minimum="3" maximum="4" />
-      <entry entity="level7OrcTrapper" size="1" minimum="2" maximum="3" />
-      <entry entity="level7Spectre" size="1" minimum="2" maximum="3" />
+      <entry entity="level8Hobgoblin" size="3" minimum="1" maximum="5" />
+      <entry entity="level8Goblin" size="3" minimum="0" maximum="3" />
+      <entry entity="level7GoblinSentry" size="2" minimum="1" maximum="1" />
+      <entry entity="level8Orc" size="3" minimum="0" maximum="2" />
+      <entry entity="level7OrcSentry" size="2" minimum="1" maximum="1" />
+      <entry entity="level8Troll" size="2" minimum="0" maximum="3" />
+      <entry entity="level7OrcTrapper" size="1" minimum="0" maximum="1" />
+      <entry entity="level7Spectre" size="1" minimum="0" maximum="1" />
       <bounds region="239">
-        <inclusion left="1" top="0" right="21" bottom="17" />
-        <exclusion left="0" top="0" right="0" bottom="0" />
+        <inclusion left="1" top="1" right="21" bottom="17" />
+        <inclusion left="0" top="0" right="0" bottom="0" />
+        <exclusion left="1" top="1" right="6" bottom="7" />
+        <exclusion left="7" top="1" right="7" bottom="1" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="serpentsSeaSpawner">
@@ -117414,10 +117470,10 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="hobgoblinCavesNorth">
+    <spawn type="RegionSpawner" name="hobgoblinCavesNorthEast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>6</maximum>
+      <maximum>7</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117432,23 +117488,24 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level7Hobgoblin" size="3" minimum="6" maximum="8" />
-      <entry entity="level7Goblin" size="3" minimum="3" maximum="5" />
-      <entry entity="level7GoblinSentry" size="2" minimum="2" maximum="3" />
-      <entry entity="level7Orc" size="3" minimum="3" maximum="5" />
-      <entry entity="level7OrcSentry" size="1" minimum="2" maximum="3" />
-      <entry entity="level7Troll" size="2" minimum="3" maximum="4" />
-      <entry entity="level7OrcTrapper" size="1" minimum="2" maximum="3" />
-      <entry entity="level7Spectre" size="1" minimum="2" maximum="3" />
+      <entry entity="level8Hobgoblin" size="3" minimum="2" maximum="2" />
+      <entry entity="level8Goblin" size="3" minimum="0" maximum="2" />
+      <entry entity="level7GoblinSentry" size="2" minimum="0" maximum="1" />
+      <entry entity="level8Orc" size="3" minimum="0" maximum="2" />
+      <entry entity="level7OrcSentry" size="2" minimum="0" maximum="1" />
+      <entry entity="level8Troll" size="2" minimum="0" maximum="2" />
+      <entry entity="level7OrcTrapper" size="1" minimum="0" maximum="1" />
+      <entry entity="level7Spectre" size="1" minimum="1" maximum="1" />
       <bounds region="239">
-        <inclusion left="1" top="0" right="21" bottom="7" />
-        <exclusion left="0" top="0" right="0" bottom="0" />
+        <inclusion left="9" top="1" right="21" bottom="9" />
+        <inclusion left="14" top="10" right="19" bottom="14" />
+        <exclusion left="9" top="4" right="10" bottom="4" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="hobgoblinCavesSouth">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>6</maximum>
+      <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117463,17 +117520,18 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="level7Hobgoblin" size="3" minimum="6" maximum="8" />
-      <entry entity="level7Goblin" size="3" minimum="3" maximum="5" />
-      <entry entity="level7GoblinSentry" size="2" minimum="2" maximum="3" />
-      <entry entity="level7Orc" size="3" minimum="3" maximum="5" />
-      <entry entity="level7OrcSentry" size="1" minimum="2" maximum="3" />
-      <entry entity="level7Troll" size="2" minimum="3" maximum="4" />
-      <entry entity="level7OrcTrapper" size="1" minimum="2" maximum="3" />
-      <entry entity="level7Spectre" size="1" minimum="2" maximum="3" />
+      <entry entity="level8Hobgoblin" size="3" minimum="2" maximum="4" />
+      <entry entity="level8Goblin" size="3" minimum="0" maximum="2" />
+      <entry entity="level7GoblinSentry" size="2" minimum="0" maximum="2" />
+      <entry entity="level8Orc" size="3" minimum="1" maximum="2" />
+      <entry entity="level7OrcSentry" size="2" minimum="0" maximum="1" />
+      <entry entity="level8Troll" size="2" minimum="0" maximum="2" />
+      <entry entity="level7OrcTrapper" size="1" minimum="0" maximum="1" />
+      <entry entity="level7Spectre" size="1" minimum="0" maximum="1" />
       <bounds region="239">
         <inclusion left="1" top="9" right="19" bottom="17" />
-        <exclusion left="0" top="0" right="0" bottom="0" />
+        <exclusion left="14" top="9" right="19" bottom="14" />
+        <exclusion left="3" top="11" right="7" bottom="15" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="serpentsSeaNorthwest">
@@ -117876,6 +117934,37 @@
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
+    <spawn type="RegionSpawner" name="hobgoblinCavesNorthWest">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
+      <maximum>4</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="level8Hobgoblin" size="3" minimum="1" maximum="2" />
+      <entry entity="level8Goblin" size="3" minimum="0" maximum="2" />
+      <entry entity="level7GoblinSentry" size="2" minimum="0" maximum="1" />
+      <entry entity="level8Orc" size="3" minimum="0" maximum="2" />
+      <entry entity="level7OrcSentry" size="2" minimum="0" maximum="1" />
+      <entry entity="level8Troll" size="2" minimum="0" maximum="2" />
+      <entry entity="level7OrcTrapper" size="1" minimum="0" maximum="1" />
+      <entry entity="level7Spectre" size="1" minimum="1" maximum="1" />
+      <bounds region="239">
+        <inclusion left="1" top="1" right="8" bottom="7" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
   </spawns>
   <treasures>
     <treasure name="oakvaelPotions">
@@ -118020,7 +118109,7 @@
       </entry>
     </treasure>
     <treasure name="dungeon2Rings">
-      <entry weight="2">
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -118029,7 +118118,7 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="2">
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -118042,12 +118131,12 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new VermeilRing();
+	return new ShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="1">
+      <entry weight="3">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -118682,7 +118771,7 @@
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new LargeEmerald(17000u);
+	return new LargeEmerald(19000u);
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -117225,7 +117225,7 @@
     <spawn type="RegionSpawner" name="hobgoblinCavesSpawn">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>12</maximum>
+      <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117250,7 +117250,6 @@
       <entry entity="level7Spectre" size="1" minimum="0" maximum="1" />
       <bounds region="239">
         <inclusion left="1" top="1" right="21" bottom="17" />
-        <inclusion left="0" top="0" right="0" bottom="0" />
         <exclusion left="1" top="1" right="6" bottom="7" />
         <exclusion left="7" top="1" right="7" bottom="1" />
       </bounds>

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -118106,6 +118106,15 @@
           <block><![CDATA[]]></block>
         </script>
       </entry>
+      <entry weight="1">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StunResistanceBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
     </treasure>
     <treasure name="dungeon2Rings">
       <entry weight="3">
@@ -118122,15 +118131,6 @@
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new WeakShieldRing();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="1">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new ShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
**Overall Goal:**
Current difficulty:
-1 oak = -2 Kes
-2 oak = between -3 and -4 Kes probably similar to Axe cave.
-3 serp = just harder than -4 kes
-4 TT = slightly harder than serp
-5 UD is a lot harder than TT

Im thinking.....
make -1 more useful .. about difficulty of axe cave/-3 kes
**-2 very slightly harder (between new oak -1 and -3)**
-3 leave
-4 make a little harder between serp and ud difficulty
-5 leave

**What I have done on this PR:**
I have slightly bumped -2 up in difficult and moved the spawns around to try to provide nice movement of creatures but also not create a Massive zoo when coming up for the Konran quest or coming down from -1

I have levelled up all except archers (left 1 level lower) and the MUs are also 1 level lower.

**some stats**
For the whole level, taken average mobs from 48 to 55 so 7 extra. average density though should be between 0.21 and 0.30... for comparison Axe Doom is 0.34. Axe cave is 0.26.

**Spawn regions:*
![image](https://user-images.githubusercontent.com/43160559/169712040-ad60b68a-ed5c-44d0-8c43-20caaaef03c8.png)
![image](https://user-images.githubusercontent.com/43160559/169712084-22953427-03f8-4f5b-99af-ec9a09c93734.png)
Small controlled spawn for coming up from -3
![image](https://user-images.githubusercontent.com/43160559/169712057-b6e1533d-4752-455b-ac36-5b7426111f5b.png)
An almost full area spawner on top for more roamable areas + some will get stuck in the SE secret room
![image](https://user-images.githubusercontent.com/43160559/169712254-44cf5561-9923-450b-8052-e20ee152476e.png)


