### PR TITLE
Fix Oak Ropes for Oakvael Grove Escort Quest

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -93001,7 +93001,7 @@
         </component>
         <component type="StaircaseComponent">
           <destinationX>113</destinationX>
-          <destinationY>38</destinationY>
+          <destinationY>39</destinationY>
           <destinationRegion>236</destinationRegion>
           <teleporterId>181</teleporterId>
         </component>
@@ -97089,7 +97089,7 @@
           <ground>23</ground>
         </component>
         <component type="StaircaseComponent">
-          <destinationX>121</destinationX>
+          <destinationX>120</destinationX>
           <destinationY>46</destinationY>
           <destinationRegion>236</destinationRegion>
           <teleporterId>181</teleporterId>


### PR DESCRIPTION
Entrances to Oak Grove Boss have changed to not allow user to drop into wall. 