### PR TITLE
Boss Properties - Set Defaults of boss weaknesses and immunities based on Boss Type

### DIFF
--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/CreatureEntity.BossProps.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/CreatureEntity.BossProps.cs
@@ -1,0 +1,88 @@
+using System.IO;
+
+using Kesmai.Server.Accounting;
+using Kesmai.Server.Engines.Commands;
+using Kesmai.Server.Items;
+using Kesmai.Server.Miscellaneous;
+
+namespace Kesmai.Server.Game
+{
+    public class CreatureEntityBossProps
+    {
+        private CreatureEntity _creatureEntity;
+
+        public CreatureEntityBossProps(CreatureEntity creatureEntity)
+        {
+            _creatureEntity = creatureEntity;
+        }
+
+        /* This needs a look from Lux. 
+                I don't know if the implementation is right due to access of source code is limited. 
+                Overall this is to clean up the Bosses and to establish Default Props using a c# file. 
+
+                To what extent this could be used would be determined by the person implementing the bosses. 
+            */
+        public CreatureEntity SetBossProperties(BossType bossType)
+        {
+            
+            switch(bossType)
+            {
+                case BossType.Minor:
+                    _creatureEntity.CreatureImmunity = setMinorBossProps().Immunity;
+                    _creatureEntity.CreatureWeaknesss = setMinorBossProps().Weakness;
+                case BossType.Major:
+                    _creatureEntity.CreatureImmunity = setMajorBossProps().Immunity;
+                    _creatureEntity.CreatureWeaknesss = setMajorBossProps().Weakness;
+                case BossType.Notable:
+                    _creatureEntity.CreatureImmunity = setNotableBossProps().Immunity;
+                    _creatureEntity.CreatureWeaknesss = setNotableBossProps().Weakness;
+            }
+
+            return _creatureEntity;
+        }
+
+        private BossProperties setMajorBossProps()
+        {
+            var majorBossProps = new BossProperties(){
+                // Modeled off of Axe Drake
+                Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
+                   CreatureImmunity.Projectile | CreatureImmunity.Magic | CreatureImmunity.Poison,
+                Weakness = CreatureWeakness.Silver | CreatureWeakness.BlueGlowing | CreatureWeakness.DeathSpell | CreatureWeakness.IceSpearSpell
+            };
+
+            return majorBossProps;
+        }
+
+        private BossProperties setMinorBossProps()
+        {
+            var minorBossProps = new BossProperties(){
+
+              // To be implemented. 
+
+            };
+            return minorBossProps;
+        }
+
+        private BossProperties setNotableBossProps()
+        {
+            var notableBossProps = new BossProperties()
+            {
+                // To be implemented. 
+            };
+        }
+
+        internal class BossProperties 
+        {
+            public CreatureImmunity Immunity { get; set; }
+            public CreatureWeakness Weakness {get;set;}
+            
+        }
+
+        public enum BossType
+        {
+            Minor,
+            Major,
+            Notable
+        }
+    }
+}

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/CreatureEntity.BossProps.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/CreatureEntity.BossProps.cs
@@ -39,12 +39,19 @@ namespace Kesmai.Server.Game
                 case BossType.Minor:
                     _creatureEntity.CreatureImmunity = setMinorBossProps().Immunity;
                     _creatureEntity.CreatureWeaknesss = setMinorBossProps().Weakness;
+                    break;
                 case BossType.Major:
                     _creatureEntity.CreatureImmunity = setMajorBossProps().Immunity;
                     _creatureEntity.CreatureWeaknesss = setMajorBossProps().Weakness;
+                    break;
                 case BossType.Notable:
                     _creatureEntity.CreatureImmunity = setNotableBossProps().Immunity;
                     _creatureEntity.CreatureWeaknesss = setNotableBossProps().Weakness;
+                    break;
+                default: 
+                    _creatureEntity.CreatureImmunity = setMinorBossProps().Immunity;
+                    _creatureEntity.CreatureWeaknesss = setMinorBossProps().Weakness;
+                    break;
             }
 
             return _creatureEntity;

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/CreatureEntity.BossProps.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/CreatureEntity.BossProps.cs
@@ -22,9 +22,18 @@ namespace Kesmai.Server.Game
 
                 To what extent this could be used would be determined by the person implementing the bosses. 
             */
-        public CreatureEntity SetBossProperties(BossType bossType)
+        public CreatureEntity SetBossProperties(BossType bossType, CreatureImmunity immunities = null, CreatureWeakness weakness = null)
         {
-            
+            if (immunities != null)
+            {
+                _creatureEntity.CreatureImmunity = immunities;
+            }
+
+            if (weakness != null)
+            {
+                _creatureEntity.CreatureWeakness = weakness;
+            }
+
             switch(bossType)
             {
                 case BossType.Minor:


### PR DESCRIPTION
A new idea to standardize properties for Bosses. This will set defaults up front and then the designer can then abstract the properties even more in the map proj file. 

Boss Types = Major, Notable, Minor

@jkachhad  let me know if this would be a good quality of life improvement. Could clean up the mapproj files up a good bit where we are having to keep setting properties. 