### PR TITLE
Fixed undead monsters according to monster manual

### DIFF
--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Banshee.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Banshee.cs
@@ -6,6 +6,13 @@ namespace Kesmai.Server.Game
 {
 	public partial class Banshee : CreatureEntity, IUndead
 	{
+
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Banshee"/> class.
 		/// </summary>
@@ -13,18 +20,27 @@ namespace Kesmai.Server.Game
 		{
 			Name = "banshee";
 			Body = 12;
-
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			CanFly = true;
+
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		/// <inheritdoc/>
 		public override void OnSpawn()
 		{
 			base.OnSpawn();
-			
+
 			if (_brain != null)
 				return;
-			
+
 			if (RightHand is ProjectileWeapon)
 				_brain = new RangedAI(this);
 			else

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Banshee.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Banshee.cs
@@ -6,12 +6,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Banshee : CreatureEntity, IUndead
 	{
-
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Banshee"/> class.
@@ -21,7 +16,6 @@ namespace Kesmai.Server.Game
 			Name = "banshee";
 			Body = 12;
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -30,6 +24,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Ghoul.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Ghoul.cs
@@ -16,13 +16,13 @@ namespace Kesmai.Server.Game
 			Body = 77;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Ghoul.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Ghoul.cs
@@ -6,6 +6,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Ghoul : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Ghoul"/> class.
 		/// </summary>
@@ -15,6 +16,14 @@ namespace Kesmai.Server.Game
 			Body = 77;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		/// <inheritdoc/>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Lich.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Lich.cs
@@ -9,6 +9,12 @@ namespace Kesmai.Server.Game
 {
 	public partial class Lich : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Lich"/> class.
 		/// </summary>
@@ -18,6 +24,14 @@ namespace Kesmai.Server.Game
 			Body = 83;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		/// <inheritdoc/>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Lich.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Lich.cs
@@ -9,11 +9,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Lich : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Lich"/> class.
@@ -24,13 +20,13 @@ namespace Kesmai.Server.Game
 			Body = 83;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Mummy.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Mummy.cs
@@ -5,11 +5,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Mummy : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mummy"/> class.
@@ -20,13 +16,13 @@ namespace Kesmai.Server.Game
 			Body = 146;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 		

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Mummy.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Mummy.cs
@@ -5,6 +5,12 @@ namespace Kesmai.Server.Game
 {
 	public partial class Mummy : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mummy"/> class.
 		/// </summary>
@@ -14,6 +20,14 @@ namespace Kesmai.Server.Game
 			Body = 146;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 		
 		/// <inheritdoc/>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Overlord.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Overlord.cs
@@ -5,6 +5,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Overlord : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison || CreatureImmunity.Magic;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Overlord"/> class.
 		/// </summary>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Presence.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Presence.cs
@@ -5,6 +5,12 @@ namespace Kesmai.Server.Game
 {
 	public partial class Presence : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Presence"/> class.
 		/// </summary>
@@ -14,6 +20,16 @@ namespace Kesmai.Server.Game
 			Body = 41;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			VisibilityDistance = 1;
+			CanFly = true;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		public override void OnSpawn()

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Presence.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Presence.cs
@@ -5,11 +5,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Presence : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Presence"/> class.
@@ -20,7 +16,6 @@ namespace Kesmai.Server.Game
 			Body = 41;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -29,6 +24,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Skeleton.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Skeleton.cs
@@ -9,8 +9,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Skeleton : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		
 		/// <summary>
@@ -22,7 +21,6 @@ namespace Kesmai.Server.Game
 			Body = 51;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -30,6 +28,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Skeleton.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Skeleton.cs
@@ -10,6 +10,7 @@ namespace Kesmai.Server.Game
 	public partial class Skeleton : CreatureEntity, IUndead
 	{
 		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		
 		/// <summary>
@@ -21,6 +22,15 @@ namespace Kesmai.Server.Game
 			Body = 51;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		public override void OnSpawn()

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Spectre.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Spectre.cs
@@ -6,12 +6,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Spectre : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Magic;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison || CreatureImmunity.Magic;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Spectre"/> class.
@@ -29,6 +24,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Spectre.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Spectre.cs
@@ -6,6 +6,13 @@ namespace Kesmai.Server.Game
 {
 	public partial class Spectre : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Magic;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Spectre"/> class.
 		/// </summary>
@@ -15,6 +22,14 @@ namespace Kesmai.Server.Game
 			Body = 62;
 
 			Alignment = Alignment.Chaotic;
+			StunProtection = 100;
+			VisibilityDistance = 0;
+			HideDetection = 100;
+			CanFly = true;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		/// <inheritdoc/>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Stalker.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Stalker.cs
@@ -7,12 +7,8 @@ namespace Kesmai.Server.Game
 
 	public partial class Stalker : CreatureEntity, IUndead
 	{
-	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
-	public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Stalker"/> class.
@@ -23,7 +19,6 @@ namespace Kesmai.Server.Game
 			Body = 57;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -31,6 +26,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Stalker.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Stalker.cs
@@ -4,8 +4,16 @@ using Kesmai.Server.Items;
 
 namespace Kesmai.Server.Game
 {
+
 	public partial class Stalker : CreatureEntity, IUndead
 	{
+	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+	public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+	public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.BlueGlowing;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Stalker"/> class.
 		/// </summary>
@@ -15,6 +23,15 @@ namespace Kesmai.Server.Game
 			Body = 57;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			VisibilityDistance = 0;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		/// <inheritdoc/>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Swordmaster.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Swordmaster.cs
@@ -9,11 +9,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Swordmaster : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 
 		/// <summary>
@@ -25,8 +21,16 @@ namespace Kesmai.Server.Game
 			Body = 163;
 
 			Alignment = Alignment.Chaotic;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
-		
+
 		public override void OnSpawn()
 		{
 			base.OnSpawn();

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Swordmaster.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Swordmaster.cs
@@ -10,6 +10,10 @@ namespace Kesmai.Server.Game
 	public partial class Swordmaster : CreatureEntity, IUndead
 	{
 		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 
 		/// <summary>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Vampire.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Vampire.cs
@@ -5,11 +5,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Vampire : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Vampire"/> class.
@@ -20,7 +16,6 @@ namespace Kesmai.Server.Game
 			Body = 80;
 			CanLoot = false;
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -29,6 +24,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Vampire.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Vampire.cs
@@ -5,6 +5,12 @@ namespace Kesmai.Server.Game
 {
 	public partial class Vampire : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Vampire"/> class.
 		/// </summary>
@@ -14,6 +20,16 @@ namespace Kesmai.Server.Game
 			Body = 80;
 			CanLoot = false;
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			VisibilityDistance = 0;
+			CanFly = true;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		/// <inheritdoc/>

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Waft.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Waft.cs
@@ -5,11 +5,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Waft : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Waft"/> class.
@@ -20,7 +16,6 @@ namespace Kesmai.Server.Game
 			Body = 41;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -29,6 +24,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Waft.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Waft.cs
@@ -5,6 +5,12 @@ namespace Kesmai.Server.Game
 {
 	public partial class Waft : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Waft"/> class.
 		/// </summary>
@@ -14,6 +20,16 @@ namespace Kesmai.Server.Game
 			Body = 41;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			VisibilityDistance = 2;
+			CanFly = true;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		public override void OnSpawn()

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wight.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wight.cs
@@ -6,6 +6,12 @@ namespace Kesmai.Server.Game
 {
 	public partial class Wight : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Wight"/> class.
 		/// </summary>
@@ -15,6 +21,15 @@ namespace Kesmai.Server.Game
 			Body = 61;
 
 			Alignment = Alignment.Chaotic;
+			DeathResistance = 100;
+			IceProtection = 100;
+			HideDetection = 100;
+			StunProtection = 100;
+			VisibilityDistance = 1;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		public override void OnSpawn()

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wight.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wight.cs
@@ -6,11 +6,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Wight : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Wight"/> class.
@@ -21,7 +17,6 @@ namespace Kesmai.Server.Game
 			Body = 61;
 
 			Alignment = Alignment.Chaotic;
-			DeathResistance = 100;
 			IceProtection = 100;
 			HideDetection = 100;
 			StunProtection = 100;
@@ -29,6 +24,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wraith.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wraith.cs
@@ -5,6 +5,13 @@ namespace Kesmai.Server.Game
 {
 	public partial class Wraith : CreatureEntity, IUndead
 	{
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Magic;
+		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Wraith"/> class.
 		/// </summary>
@@ -14,6 +21,14 @@ namespace Kesmai.Server.Game
 			Body = 50;
 
 			Alignment = Alignment.Chaotic;
+			StunProtection = 100;
+			VisibilityDistance = 0;
+			HideDetection = 100;
+			CanFly = true;
+			AddStatus(new BreatheWaterStatus(this));
+			AddStatus(new BlindFearProtectionStatus(this));
+			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(PoisonCloudSpell));
 		}
 
 		public override void OnSpawn()

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wraith.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Undead/Wraith.cs
@@ -5,12 +5,7 @@ namespace Kesmai.Server.Game
 {
 	public partial class Wraith : CreatureEntity, IUndead
 	{
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Slashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Bashing;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Projectile;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Poison;
-		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Magic;
+		public override CreatureImmunity Immunity { get; set; } = CreatureImmunity.Piercing || CreatureImmunity.Slashing || CreatureImmunity.Bashing || CreatureImmunity.Projectile || CreatureImmunity.Poison;
 		public override CreatureWeakness Weakness { get; set; } = CreatureWeakness.Silver;
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Wraith"/> class.
@@ -28,6 +23,7 @@ namespace Kesmai.Server.Game
 			AddStatus(new BreatheWaterStatus(this));
 			AddStatus(new BlindFearProtectionStatus(this));
 			AddImmunity(typeof(StunSpell));
+			AddImmunity(typeof(DeathSpell));
 			AddImmunity(typeof(PoisonCloudSpell));
 		}
 


### PR DESCRIPTION
Source: https://www.dndbeyond.com/monsters

We can't access damage reduction for some types so had to add some permanent resists to make it match. It's closer this way to manual accurate.