### PR TITLE
Hummingbird Sword Tweak Idea

### DIFF
--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Player/PlayerEntity.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Player/PlayerEntity.cs
@@ -55,6 +55,18 @@ namespace Kesmai.Server.Game
 			{
 				if (item is Weapon weapon)
 				{
+					if (item is HummingbirdSword hummingbirdword)
+					{
+						baseMinimumDamage = (int)((baseMinimumDamage + (hitAdds/2)) * skillMultiplier);
+						baseMaximumDamage = (int)((baseMaximumDamage + (hitAdds/2)) * skillMultiplier);
+				
+						hitAdds += (int)weapon.GetAttackBonus(this, defender);
+
+						skill = weapon.Skill;
+						skillFactor = 10.0;
+					}
+					else
+					{
 					baseMinimumDamage = weapon.MinimumDamage;
 					baseMaximumDamage = weapon.MaximumDamage;
 				
@@ -62,6 +74,7 @@ namespace Kesmai.Server.Game
 
 					skill = weapon.Skill;
 					skillFactor = 10.0;
+					}
 				}
 				else if (item is Gauntlets gauntlets)
 				{


### PR DESCRIPTION
Just as a preface, my coding ability is borderline non-existent so I'm not even sure if this will work the way I wrote it. This is more or less an illustration of an idea (unless it works fine, then go for it)

Credit goes to Kajoq for this idea:

The problem with the hummingbird sword is the hitadds contribution to damage. Even though the weapon damage is basically base, as the wielder gets bigger the damage scales up. When you account for the half-round timer no other weapon can keep up unless we scale the weapon damage up into the crazy end (like the peaks weapons). 

Original:

var minimumDamage = (int)((baseMinimumDamage + hitAdds) * skillMultiplier);
var maximumDamage = (int)((baseMaximumDamage + hitAdds) * skillMultiplier);

New:

var minimumDamage = (int)((baseMinimumDamage + (hitAdds/2)) * skillMultiplier);
var maximumDamage = (int)((baseMaximumDamage + (hitAdds/2)) * skillMultiplier);

If we halve the hit adds contribution to min/max damage, then the same amount of damage would be distributed across an entire round. It would lower the damage per swing of the hummer, allow it to retain its half round advantages for curing, etc... but it would bring the damage back in line with other weapons. I think it would still be a very powerful weapon due to the increased opportunity for critical strikes. 

Just assuming 14 skill, and 7 hitadds:

1 theoretical max round of hummer damage would equal: ((6 + 7) * 2.4)* 2rounds =  62.4 damage per round

1 theoretical max round of BBS damage is ((12+7)*2.4) = 45.6 damage per round

1 theoretical max round of Hummer damage after the change is = ((6 + 3.5)*2.4)*2 = 45.6 damage per round

So it might be warranted to up the damage of the hummer a little depending on how it plays out, but at least it tones it down within a standard deviation of the other weapons. 

Let me know what you think.