### PR TITLE
Blackburrow Changes

### DIFF
--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -19992,6 +19992,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="3">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -40140,6 +40140,10 @@ return elemental;
 dragon.AddStatus(new NightVisionStatus(dragon));
 dragon.AddStatus(new BreatheWaterStatus(dragon));
 
+dragon.AddImmunity(typeof(BlindSpell));
+dragon.AddImmunity(typeof(FearSpell));
+dragon.AddImmunity(typeof(StunSpell));
+
 dragon.CombatantChangeInterval = TimeSpan.FromSeconds(7.0);
 
 dragon.Attacks = new CreatureAttackCollection
@@ -41051,7 +41055,7 @@ return skeleton;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="NPCTownPriest" size="1" minimum="0" maximum="0" />
+      <entry entity="NPCTownPriest" size="1" minimum="1" maximum="1" />
       <location x="2" y="-37" region="1" />
     </spawn>
     <spawn type="LocationSpawner" name="EntranceFippy">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -2697,14 +2697,14 @@
         </component>
       </tile>
       <tile x="35" y="-30">
+        <component type="FloorComponent">
+          <ground>13</ground>
+        </component>
         <component type="WallComponent">
           <wall>33</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
           <indestructible>true</indestructible>
-        </component>
-        <component type="FloorComponent">
-          <ground>13</ground>
         </component>
       </tile>
       <tile x="36" y="-30">
@@ -2712,6 +2712,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -2722,6 +2723,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -2736,6 +2738,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -2750,6 +2753,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -3011,6 +3015,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="-29">
@@ -3036,6 +3041,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-29">
@@ -3344,6 +3350,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -3372,6 +3379,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-28">
@@ -3416,9 +3424,9 @@
       <tile x="51" y="-28" />
       <tile x="53" y="-28">
         <component type="WallComponent">
-          <wall>355</wall>
-          <destroyed>356</destroyed>
-          <ruins>44</ruins>
+          <wall>33</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
@@ -3427,6 +3435,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="55" y="-28">
@@ -3434,6 +3443,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="56" y="-28">
@@ -3441,6 +3451,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="57" y="-28">
@@ -3448,6 +3459,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="58" y="-28">
@@ -3455,6 +3467,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="59" y="-28">
@@ -3462,6 +3475,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="60" y="-28" />
@@ -3660,6 +3674,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -3688,6 +3703,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-27">
@@ -3735,6 +3751,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-27">
@@ -3779,6 +3796,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-26">
@@ -3964,6 +3982,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -3995,6 +4014,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-26">
@@ -4042,6 +4062,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-26">
@@ -4054,9 +4075,9 @@
           <ground>179</ground>
         </component>
         <component type="WallComponent">
-          <wall>355</wall>
-          <destroyed>356</destroyed>
-          <ruins>44</ruins>
+          <wall>33</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
@@ -4068,6 +4089,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="57" y="-26">
@@ -4078,6 +4100,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="58" y="-26">
@@ -4088,6 +4111,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="59" y="-26">
@@ -4098,11 +4122,13 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-25">
@@ -4353,6 +4379,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -4381,6 +4408,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-25">
@@ -4428,6 +4456,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-25">
@@ -4443,6 +4472,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-24">
@@ -4663,6 +4693,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -4691,6 +4722,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-24">
@@ -4740,6 +4772,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-24">
@@ -4755,6 +4788,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-23">
@@ -4974,6 +5008,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -4998,6 +5033,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="-23">
@@ -5008,6 +5044,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="-23">
@@ -5018,11 +5055,13 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="-23">
@@ -5066,6 +5105,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-23">
@@ -5081,6 +5121,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-22">
@@ -5357,6 +5398,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-22">
@@ -5372,6 +5414,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="56" y="-22">
@@ -5379,6 +5422,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-21">
@@ -5684,6 +5728,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-21">
@@ -5710,6 +5755,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-20">
@@ -5959,6 +6005,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="54" y="-20">
@@ -5969,6 +6016,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="55" y="-20">
@@ -5979,6 +6027,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="56" y="-20">
@@ -5989,11 +6038,13 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="-19">
@@ -10621,6 +10672,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="0" />
@@ -10862,6 +10914,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="1" />
@@ -11105,6 +11158,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="2" />

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<segment name="Blackburrow" version="0.95.0.0">
+<segment name="Blackburrow" version="0.96.0.0">
   <script name="Internal" enabled="true">
     <block><![CDATA[]]></block>
     <block><![CDATA[
@@ -16284,8 +16284,8 @@
           <ground>1003</ground>
         </component>
         <component type="StaircaseComponent">
-          <destinationX>9</destinationX>
-          <destinationY>18</destinationY>
+          <destinationX>12</destinationX>
+          <destinationY>19</destinationY>
           <destinationRegion>3</destinationRegion>
           <teleporterId>125</teleporterId>
         </component>
@@ -20083,9 +20083,177 @@
         </component>
       </tile>
       <tile x="17" y="3" />
+      <tile x="-24" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-23" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-22" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-21" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-20" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-19" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-18" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-17" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-16" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-15" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-14" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-13" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-12" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-11" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-10" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-9" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-8" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-7" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-6" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-5" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-4" y="4">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="-3" y="4">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
@@ -20205,7 +20373,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="11" y="4">
@@ -20253,42 +20420,189 @@
         </component>
       </tile>
       <tile x="17" y="4" />
-      <tile x="-3" y="5">
+      <tile x="-24" y="5">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="-23" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-22" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-20" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-18" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-15" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>149</wall>
+          <destroyed>150</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-11" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-10" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-9" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-8" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-7" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-6" y="5">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="5">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="5">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="5">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
       <tile x="-2" y="5">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-1" y="5">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="5">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="1" y="5">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="5">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="5">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="5">
@@ -20312,7 +20626,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="8" y="5">
@@ -20342,7 +20655,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="12" y="5">
@@ -20381,51 +20693,163 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="6">
+      <tile x="-24" y="6">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="-23" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-22" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-20" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-18" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-15" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-11" y="6">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="TrashComponent">
+          <static>88</static>
+        </component>
+      </tile>
+      <tile x="-10" y="6">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-9" y="6">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="6">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="TrashComponent">
+          <static>88</static>
+        </component>
+      </tile>
+      <tile x="-7" y="6">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="6">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="6">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
       <tile x="-2" y="6">
         <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>270</static>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-1" y="6">
         <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>236</static>
-        </component>
-        <component type="StaticComponent">
-          <static>174</static>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="6">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="1" y="6">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="6">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="6">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="6">
@@ -20457,7 +20881,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="9" y="6">
@@ -20474,7 +20897,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="11" y="6">
@@ -20499,7 +20921,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="14" y="6">
@@ -20528,51 +20949,203 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="7">
+      <tile x="-24" y="7">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
-        <component type="StaticComponent">
-          <static>212</static>
+      </tile>
+      <tile x="-23" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-22" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-21" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-20" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>149</wall>
+          <destroyed>150</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-18" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-17" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-16" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-15" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-14" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-13" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-12" y="7">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-11" y="7">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-10" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-9" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="7">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="7">
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-2" y="7">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-1" y="7">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="7">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="1" y="7">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="7">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="7">
         <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>371</wall>
-          <destroyed>0</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="7">
@@ -20612,7 +21185,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="10" y="7">
@@ -20621,7 +21193,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="11" y="7">
@@ -20638,7 +21209,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="13" y="7">
@@ -20669,48 +21239,173 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="8">
+      <tile x="-24" y="8">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
-        <component type="StaticComponent">
-          <static>212</static>
-        </component>
       </tile>
-      <tile x="-2" y="8">
+      <tile x="-23" y="8">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>6</ground>
         </component>
-      </tile>
-      <tile x="-1" y="8">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="0" y="8">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="1" y="8">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="2" y="8">
         <component type="StaircaseComponent">
           <destinationX>-27</destinationX>
           <destinationY>8</destinationY>
           <destinationRegion>4</destinationRegion>
-          <teleporterId>124</teleporterId>
+          <teleporterId>125</teleporterId>
+        </component>
+      </tile>
+      <tile x="-22" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-20" y="8">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-19" y="8">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-18" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-15" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-11" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-10" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-9" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="8">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-2" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-1" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="0" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="1" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="2" y="8">
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="8">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="8">
@@ -20747,7 +21442,6 @@
       <tile x="9" y="8">
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>9</ground>
@@ -20767,7 +21461,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="12" y="8">
@@ -20806,48 +21499,153 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="9">
+      <tile x="-24" y="9">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+      </tile>
+      <tile x="-23" y="9">
         <component type="StaticComponent">
-          <static>212</static>
+          <static>4</static>
         </component>
-      </tile>
-      <tile x="-2" y="9">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="-1" y="9">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="0" y="9">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="1" y="9">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="2" y="9">
         <component type="StaircaseComponent">
           <destinationX>-27</destinationX>
           <destinationY>9</destinationY>
           <destinationRegion>4</destinationRegion>
-          <teleporterId>124</teleporterId>
+          <teleporterId>125</teleporterId>
+        </component>
+      </tile>
+      <tile x="-22" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-20" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-18" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-15" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-11" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-10" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-9" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="9">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-2" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-1" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="0" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="1" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="2" y="9">
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="9">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="9">
@@ -20887,7 +21685,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="10" y="9">
@@ -20904,7 +21701,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="12" y="9">
@@ -20955,54 +21751,184 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="10">
+      <tile x="-24" y="10">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
-        <component type="StaticComponent">
-          <static>212</static>
-        </component>
       </tile>
-      <tile x="-2" y="10">
+      <tile x="-23" y="10">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>6</ground>
         </component>
-      </tile>
-      <tile x="-1" y="10">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="0" y="10">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-      </tile>
-      <tile x="1" y="10">
-        <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>371</wall>
-          <destroyed>0</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="2" y="10">
         <component type="StaircaseComponent">
           <destinationX>-27</destinationX>
           <destinationY>10</destinationY>
           <destinationRegion>4</destinationRegion>
-          <teleporterId>124</teleporterId>
+          <teleporterId>125</teleporterId>
+        </component>
+      </tile>
+      <tile x="-22" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-20" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-18" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>149</wall>
+          <destroyed>150</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-15" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-14" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-13" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-12" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-11" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-10" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-9" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="10">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-2" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-1" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="0" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="1" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="2" y="10">
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="10">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="10">
@@ -21042,7 +21968,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="10" y="10">
@@ -21059,7 +21984,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="12" y="10">
@@ -21110,42 +22034,200 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="11">
+      <tile x="-24" y="11">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="-23" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-22" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-21" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-20" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-19" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-18" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-17" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-16" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-15" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-11" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-10" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="TrashComponent">
+          <static>88</static>
+        </component>
+      </tile>
+      <tile x="-9" y="11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="11">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="11">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
       <tile x="-2" y="11">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-1" y="11">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="11">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="1" y="11">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="11">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="11">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="11">
@@ -21193,7 +22275,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="11" y="11">
@@ -21210,7 +22291,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="13" y="11">
@@ -21241,51 +22321,158 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="12">
+      <tile x="-24" y="12">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="-2" y="12">
+      <tile x="-23" y="12">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-22" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-20" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-18" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-15" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-11" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-10" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="TrashComponent">
+          <static>88</static>
+        </component>
+      </tile>
+      <tile x="-9" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
         <component type="StaticComponent">
-          <static>270</static>
+          <static>766</static>
+        </component>
+      </tile>
+      <tile x="-8" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="12">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="12">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-2" y="12">
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-1" y="12">
         <component type="FloorComponent">
-          <ground>4</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>174</static>
-        </component>
-        <component type="StaticComponent">
-          <static>236</static>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="12">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="1" y="12">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="12">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="12">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="12">
@@ -21333,7 +22520,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="11" y="12">
@@ -21358,7 +22544,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="14" y="12">
@@ -21381,42 +22566,152 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="13">
+      <tile x="-24" y="13">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="-23" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-22" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-21" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-20" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-19" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-18" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-17" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-16" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-15" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-14" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-13" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-12" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-11" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="-10" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-9" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-8" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-7" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="-6" y="13">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-5" y="13">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="-4" y="13">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
+      <tile x="-3" y="13">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+      </tile>
       <tile x="-2" y="13">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="-1" y="13">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="13">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="1" y="13">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="13">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="3" y="13">
         <component type="FloorComponent">
-          <ground>4</ground>
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="4" y="13">
@@ -21464,7 +22759,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="11" y="13">
@@ -21511,9 +22805,240 @@
           <ruins>398</ruins>
         </component>
       </tile>
-      <tile x="-3" y="14">
+      <tile x="-24" y="14">
         <component type="WallComponent">
-          <wall>447</wall>
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-23" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-22" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-21" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-20" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-19" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-18" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-17" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-16" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-15" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-14" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-13" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-12" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-11" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-10" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-9" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-8" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-7" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-6" y="14">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-5" y="14">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-4" y="14">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="-3" y="14">
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
@@ -21526,6 +23051,9 @@
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
       </tile>
       <tile x="-1" y="14">
         <component type="WallComponent">
@@ -21533,6 +23061,9 @@
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="0" y="14">
@@ -21542,6 +23073,9 @@
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="FloorComponent">
+          <ground>369</ground>
+        </component>
       </tile>
       <tile x="1" y="14">
         <component type="WallComponent">
@@ -21549,6 +23083,9 @@
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>369</ground>
         </component>
       </tile>
       <tile x="2" y="14">
@@ -21622,7 +23159,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="10" y="14">
@@ -21639,7 +23175,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="12" y="14">
@@ -21684,6 +23219,10 @@
           <ruins>398</ruins>
         </component>
       </tile>
+      <tile x="-12" y="15" />
+      <tile x="-11" y="15" />
+      <tile x="-10" y="15" />
+      <tile x="-9" y="15" />
       <tile x="3" y="15">
         <component type="WallComponent">
           <wall>414</wall>
@@ -21720,7 +23259,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="9" y="15">
@@ -21753,7 +23291,6 @@
         </component>
         <component type="Web">
           <static>131</static>
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="13" y="15">
@@ -21914,15 +23451,15 @@
         <component type="FloorComponent">
           <ground>1003</ground>
         </component>
-        <component type="WallComponent">
-          <wall>414</wall>
-          <destroyed>416</destroyed>
-          <ruins>398</ruins>
-        </component>
       </tile>
       <tile x="11" y="17">
         <component type="FloorComponent">
           <ground>1003</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>413</wall>
+          <destroyed>415</destroyed>
+          <ruins>398</ruins>
         </component>
       </tile>
       <tile x="12" y="17">
@@ -21930,15 +23467,19 @@
           <ground>1003</ground>
         </component>
         <component type="WallComponent">
-          <wall>371</wall>
-          <destroyed>0</destroyed>
-          <ruins>170</ruins>
-          <indestructible>true</indestructible>
+          <wall>413</wall>
+          <destroyed>415</destroyed>
+          <ruins>398</ruins>
         </component>
       </tile>
       <tile x="13" y="17">
         <component type="FloorComponent">
           <ground>1003</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>413</wall>
+          <destroyed>415</destroyed>
+          <ruins>398</ruins>
         </component>
       </tile>
       <tile x="14" y="17">
@@ -22003,21 +23544,10 @@
         <component type="FloorComponent">
           <ground>1003</ground>
         </component>
-        <component type="StaircaseComponent">
-          <destinationX>14</destinationX>
-          <destinationY>11</destinationY>
-          <destinationRegion>2</destinationRegion>
-          <teleporterId>129</teleporterId>
-        </component>
       </tile>
       <tile x="10" y="18">
         <component type="FloorComponent">
           <ground>1003</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>414</wall>
-          <destroyed>416</destroyed>
-          <ruins>398</ruins>
         </component>
       </tile>
       <tile x="11" y="18">
@@ -22033,6 +23563,11 @@
       <tile x="13" y="18">
         <component type="FloorComponent">
           <ground>1003</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>414</wall>
+          <destroyed>416</destroyed>
+          <ruins>398</ruins>
         </component>
       </tile>
       <tile x="14" y="18">
@@ -22096,11 +23631,6 @@
         <component type="FloorComponent">
           <ground>1003</ground>
         </component>
-        <component type="WallComponent">
-          <wall>414</wall>
-          <destroyed>416</destroyed>
-          <ruins>398</ruins>
-        </component>
       </tile>
       <tile x="11" y="19">
         <component type="FloorComponent">
@@ -22111,10 +23641,21 @@
         <component type="FloorComponent">
           <ground>1003</ground>
         </component>
+        <component type="StaircaseComponent">
+          <destinationX>14</destinationX>
+          <destinationY>11</destinationY>
+          <destinationRegion>2</destinationRegion>
+          <teleporterId>129</teleporterId>
+        </component>
       </tile>
       <tile x="13" y="19">
         <component type="FloorComponent">
           <ground>1003</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>414</wall>
+          <destroyed>416</destroyed>
+          <ruins>398</ruins>
         </component>
       </tile>
       <tile x="14" y="19">
@@ -22209,11 +23750,6 @@
           <ground>1003</ground>
         </component>
         <component type="WallComponent">
-          <wall>414</wall>
-          <destroyed>416</destroyed>
-          <ruins>398</ruins>
-        </component>
-        <component type="WallComponent">
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
@@ -22242,6 +23778,11 @@
       <tile x="13" y="20">
         <component type="FloorComponent">
           <ground>1003</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>414</wall>
+          <destroyed>416</destroyed>
+          <ruins>398</ruins>
         </component>
         <component type="WallComponent">
           <wall>413</wall>
@@ -35649,7 +37190,7 @@
         Name = "Gnoll Guard",
         MaxHealth = 120, Health = 120,
         BaseDodge = 21,
-                
+        Body = 383,        
         Experience = 6800,
                 
         Movement = 3,
@@ -35671,7 +37212,7 @@
     
     GnollGuard.AddGold(5000);
     GnollGuard.AddLoot(new LootPack(
-        new LootPackEntry(true, SurfaceGems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, SurfaceGems,       5,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,    0.63)
         ));
@@ -36008,6 +37549,7 @@
         Name = "Fippy Darkpaw",
         MaxHealth = 600, Health = 600,
         BaseDodge = 26,
+        Body = 383,
         HideDetection = 28,
         Experience = 32000,
         
@@ -36098,6 +37640,7 @@ if (spokeRecently(source))
         Name = "Gnoll Blacksmith",
         MaxHealth = 600, Health = 600,
         BaseDodge = 26,
+        Body = 384,
     
         Experience = 148860,
         
@@ -36140,9 +37683,9 @@ if (spokeRecently(source))
         new CreatureBlock(1, "canine reflexes"),
     };
         
-    smith.AddGold(13000);
+    smith.AddGold(5000);
     smith.AddLoot(new LootPack(
-        new LootPackEntry(true, SurfaceGems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, SurfaceGems,       5,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,    0.63),
         new LootPackEntry(true, StatPotion, 12)
@@ -36179,6 +37722,7 @@ if (spokeRecently(source))
         MaxHealth = 120, Health = 120,
         MaxMana = 12, Mana = 12,
         BaseDodge = 21,
+        Body = 394,
         BasePenetration = ShieldPenetration.Light,
         Experience = 5000,
         VisibilityDistance = 3,
@@ -36207,7 +37751,7 @@ if (spokeRecently(source))
         
     sooth.AddGold(700);
     sooth.AddLoot(new LootPack(
-        new LootPackEntry(true, SurfaceGems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, SurfaceGems,       5,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,    0.63)
         ));
@@ -36240,7 +37784,7 @@ if (spokeRecently(source))
         MaxHealth = 130, Health = 130,
         BaseDodge = 22,
         CanCharge = true,
-                
+        Body = 384,        
         Experience = 6000,
                 
         Movement = 2,
@@ -36268,7 +37812,7 @@ if (spokeRecently(source))
     
     GnollGuard.AddGold(1500);
     GnollGuard.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelonegems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, Levelonegems,       5,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   0.2),
         new LootPackEntry(true, StatPotion, 0.2)
@@ -36302,6 +37846,7 @@ if (spokeRecently(source))
         MaxMana = 15, Mana = 15,
         BaseDodge = 22,
         BasePenetration = ShieldPenetration.Light,
+        Body = 394,
         Experience = 6018,
         VisibilityDistance = 3,
         HideDetection = 31
@@ -36329,7 +37874,7 @@ if (spokeRecently(source))
         
     sooth.AddGold(2000);
     sooth.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelonegems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, Levelonegems,       5,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   0.2),
         new LootPackEntry(true, StatPotion, 0.2)
@@ -36401,7 +37946,7 @@ if (spokeRecently(source))
         BaseDodge = 24,
         HideDetection = 24,
         Experience = 7578,
-        
+        Body = 384,
         VisibilityDistance = 3,
        
         CanJumpkick = true,
@@ -36446,7 +37991,7 @@ if (spokeRecently(source))
    fippy.Equip(new ChainmailArmor());     
    fippy.AddGold(4000);
    fippy.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelonegems,       50,     gemsPriceMutator), 
+        new LootPackEntry(true, Levelonegems,       35,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   2),
         new LootPackEntry(true, StatPotion, 2)
@@ -36487,6 +38032,7 @@ if (spokeRecently(source))
         Name = "Captain of the Guard",
         MaxHealth = 1950, Health = 1950,
         BaseDodge = 27,
+        Body = 385,
         HideDetection = 24,
         Experience = 71000,
         
@@ -36607,8 +38153,8 @@ if (spokeRecently(source))
     
     shelob.AddGold(1000);
     shelob.AddLoot(new LootPack(
-        new LootPackEntry(true, Leveltwogems,       30,     gemsPriceMutator), 
-        new LootPackEntry(true, Leveltwogems,       30,     gemsPriceMutator), 
+        new LootPackEntry(true, Leveltwogems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, Leveltwogems,       15,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   1),
         new LootPackEntry(true, StatPotion, 1)
@@ -36645,6 +38191,7 @@ if (spokeRecently(source))
         HideDetection = 24,
         Experience = 32000,
         Movement = 2,
+        Body = 383,
         
         VisibilityDistance = 3,
         
@@ -36684,8 +38231,8 @@ if (spokeRecently(source))
    fippy.Equip(new ChainmailArmor());     
    fippy.AddGold(4000);
    fippy.AddLoot(new LootPack(
-        new LootPackEntry(true, Leveltwogems,       30,     gemsPriceMutator), 
-        new LootPackEntry(true, Leveltwogems,       30,     gemsPriceMutator), 
+        new LootPackEntry(true, Leveltwogems,       5,     gemsPriceMutator), 
+        new LootPackEntry(true, Leveltwogems,       5,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   1),
         new LootPackEntry(true, StatPotion, 1)
@@ -36823,8 +38370,8 @@ if (spokeRecently(source))
         new LootPackEntry(true, (from, container) => new BreatheWaterBracelet(),        50),
         new LootPackEntry(true, (from, container) => new CrocodileBoots(),        100),
         new LootPackEntry(true, GenericBottles, 40),
-        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        25),  
-        new LootPackEntry(true, Miniboss, 25)
+        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        3),  
+        new LootPackEntry(true, Miniboss, 8)
     ));
         
     return crocodile;
@@ -36881,8 +38428,8 @@ if (spokeRecently(source))
         
     banshee.AddGold(480);
     banshee.AddLoot(new LootPack(
-        new LootPackEntry(true, Leveltwogems,       30,     gemsPriceMutator), 
-        new LootPackEntry(true, Leveltwogems,       30,     gemsPriceMutator), 
+        new LootPackEntry(true, Leveltwogems,       15,     gemsPriceMutator), 
+        new LootPackEntry(true, Leveltwogems,       15,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   1),
         new LootPackEntry(true, StatPotion, 1)
@@ -37007,7 +38554,7 @@ if (spokeRecently(source))
     skeleton.AddGold(2000);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, GenericBottles, 50),
-        new LootPackEntry(true, Leveltwogems, 33)
+        new LootPackEntry(true, Leveltwogems, 16)
     ));
     
 return skeleton;
@@ -37108,7 +38655,7 @@ return skeleton;
         HideDetection = 31,
         Experience = 10913,
         Movement = 2,
-        
+        Body = 384,
         VisibilityDistance = 3,
       
         BasePenetration = ShieldPenetration.Medium,
@@ -37148,7 +38695,7 @@ return skeleton;
    fippy.Equip(new ChainmailArmor());     
    fippy.AddGold(4000);
    fippy.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelthreegems,       40,     gemsPriceMutator), 
+        new LootPackEntry(true, Levelthreegems,       20,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, Treasure,   5),
         new LootPackEntry(true, StatPotion, 5)
@@ -37236,7 +38783,7 @@ if (spokeRecently(source))
     
     worg.AddGold(2000);
     worg.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelthreegems,       75,     gemsPriceMutator),
+        new LootPackEntry(true, Levelthreegems,       25,     gemsPriceMutator),
         new LootPackEntry(true, StatPotion, 10)
     ));
     
@@ -37364,6 +38911,7 @@ if (spokeRecently(source))
         MaxHealth = 208, Health = 208,
         MaxMana = 7, Mana = 7,
         BaseDodge = 26,
+        Body = 327,
     
         Experience = 10913,
         BasePenetration = ShieldPenetration.Medium,
@@ -37390,7 +38938,7 @@ if (spokeRecently(source))
     
     stalker.AddGold(650);
     stalker.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelthreegems, 25, gemsPriceMutator), 
+        new LootPackEntry(true, Levelthreegems, 12, gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, StatPotion,    0.3), 
         new LootPackEntry(true, Treasure,    0.63)
@@ -37423,6 +38971,7 @@ if (spokeRecently(source))
         MaxHealth = 160, Health = 160,
         MaxMana = 31, Mana = 31,
         BaseDodge = 24,
+        Body = 306,
     
         Experience = 6740,
         BasePenetration = ShieldPenetration.Medium,
@@ -37451,7 +39000,7 @@ if (spokeRecently(source))
     
     spectre.AddGold(650);
     spectre.AddLoot(new LootPack(
-        new LootPackEntry(true, Levelthreegems,       25,     gemsPriceMutator), 
+        new LootPackEntry(true, Levelthreegems,       12,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33), 
         new LootPackEntry(true, StatPotion,    0.3), 
         new LootPackEntry(true, Treasure,    0.63)
@@ -37503,7 +39052,7 @@ if (spokeRecently(source))
     skeleton.AddGold(2000);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, GenericBottles, 50),
-        new LootPackEntry(true, Levelthreegems, 12)
+        new LootPackEntry(true, Levelthreegems, 6)
     ));
     
 return skeleton;
@@ -37576,7 +39125,7 @@ snake.Blocks = new CreatureBlockCollection
 
 snake.AddGold(2500);
 snake.AddLoot(new LootPack(
-    new LootPackEntry(true, Levelthreegems, 25, gemsPriceMutator),
+    new LootPackEntry(true, Levelthreegems, 12, gemsPriceMutator),
     new LootPackEntry(true, GenericBottles, 33)
 ));
 
@@ -37606,7 +39155,7 @@ return snake;
 {
 
     
-    Name = "ThiefBane",
+    Name = "Cryptkeeper",
     MaxHealth = 900, Health = 900,
     BaseDodge = 31,
     CanSwim = true,
@@ -37614,7 +39163,7 @@ return snake;
     IceProtection = 100,
     Immunity = CreatureImmunity.Poison,
     Experience = 25000,
-    HideDetection = 50,
+    HideDetection = 35,
     VisibilityDistance = 2,
  
 };
@@ -37786,6 +39335,7 @@ return dragon;
 {
     Name = "Castor",
     MaxHealth = 4500, Health = 4500,
+    Body = 380,
     BaseDodge = 35,
     HideDetection = 36,
     BasePenetration = ShieldPenetration.VeryHeavy,
@@ -37884,6 +39434,7 @@ return ogre;
 {
     Name = "Pollux",
     MaxHealth = 4500, Health = 4500,
+    Body = 381,
     BaseDodge = 35,
     HideDetection = 36,
     BasePenetration = ShieldPenetration.VeryHeavy,
@@ -38088,7 +39639,7 @@ if (spokeRecently(source))
     
     worg.AddGold(2000);
     worg.AddLoot(new LootPack(
-        new LootPackEntry(true, Leveltwogems,       75,     gemsPriceMutator),
+        new LootPackEntry(true, Leveltwogems,       15,     gemsPriceMutator),
         new LootPackEntry(true, StatPotion, 10)
     ));
     
@@ -38137,7 +39688,7 @@ if (spokeRecently(source))
     skeleton.AddGold(2000);
     skeleton.AddLoot(new LootPack(
         new LootPackEntry(true, GenericBottles, 50),
-        new LootPackEntry(true, Levelthreegems, 12)
+        new LootPackEntry(true, Levelthreegems, 6)
     ));
     
 return skeleton;
@@ -39160,7 +40711,7 @@ return skeleton;
     </spawn>
     <spawn type="RegionSpawner" name="EntranceGuards">
       <minimumDelay>900</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>14</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39185,7 +40736,7 @@ return skeleton;
     </spawn>
     <spawn type="RegionSpawner" name="Level 1 Guards">
       <minimumDelay>900</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>20</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39201,8 +40752,8 @@ return skeleton;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="Level13NormGnollGuard" size="3" minimum="6" maximum="9" />
-      <entry entity="Level13NormGnollSoothsayer" size="1" minimum="3" maximum="3" />
+      <entry entity="Level13NormGnollGuard" size="3" minimum="3" maximum="6" />
+      <entry entity="Level13NormGnollSoothsayer" size="1" minimum="1" maximum="3" />
       <bounds region="2">
         <inclusion left="6" top="-7" right="7" bottom="15" />
         <inclusion left="8" top="8" right="17" bottom="11" />
@@ -39213,7 +40764,7 @@ return skeleton;
     </spawn>
     <spawn type="RegionSpawner" name="Prison Guards">
       <minimumDelay>900</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>15</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39229,7 +40780,7 @@ return skeleton;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="Level12NormEntranceGnollGuard" size="3" minimum="7" maximum="7" />
+      <entry entity="Level12NormEntranceGnollGuard" size="3" minimum="3" maximum="4" />
       <entry entity="Level13NormWorg" size="1" minimum="3" maximum="3" />
       <bounds region="2">
         <inclusion left="-12" top="14" right="-4" bottom="32" />
@@ -39238,7 +40789,7 @@ return skeleton;
     </spawn>
     <spawn type="RegionSpawner" name="Gnoll Officer">
       <minimumDelay>900</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>3</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39254,7 +40805,7 @@ return skeleton;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="Level13HighGnollOfficer" size="1" minimum="3" maximum="3" />
+      <entry entity="Level13HighGnollOfficer" size="1" minimum="2" maximum="2" />
       <bounds region="2">
         <inclusion left="6" top="-7" right="17" bottom="11" />
         <inclusion left="6" top="12" right="7" bottom="15" />
@@ -39286,8 +40837,8 @@ return skeleton;
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Level 2 Spider">
-      <minimumDelay>300</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39316,8 +40867,8 @@ return skeleton;
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Level 2 Guards">
-      <minimumDelay>300</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>8</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39336,6 +40887,7 @@ return skeleton;
       <entry entity="Level14NormGnollGuard" size="1" minimum="6" maximum="8" />
       <bounds region="3">
         <inclusion left="4" top="1" right="15" bottom="19" />
+        <inclusion left="-10" top="6" right="3" bottom="13" />
         <exclusion left="7" top="4" right="13" bottom="15" />
       </bounds>
     </spawn>
@@ -39406,15 +40958,15 @@ return skeleton;
         <block><![CDATA[]]></block>
       </script>
       <entry entity="BossMiniLevel16Lockjaw" size="1" minimum="1" maximum="1" />
-      <entry entity="Level16NormPitCroc" size="1" minimum="8" maximum="8" />
+      <entry entity="Level16NormPitCroc" size="1" minimum="5" maximum="5" />
       <bounds region="5">
         <inclusion left="6" top="3" right="9" bottom="14" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="PitArchers">
-      <minimumDelay>0</minimumDelay>
-      <maximumDelay>0</maximumDelay>
+      <minimumDelay>300</minimumDelay>
+      <maximumDelay>600</maximumDelay>
       <maximum>6</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39488,7 +41040,7 @@ return skeleton;
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="CaveGiantJym">
-      <minimumDelay>3600</minimumDelay>
+      <minimumDelay>5400</minimumDelay>
       <maximumDelay>3600</maximumDelay>
       <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
@@ -39538,8 +41090,8 @@ return skeleton;
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Maze">
-      <minimumDelay>300</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <minimumDelay>600</minimumDelay>
+      <maximumDelay>900</maximumDelay>
       <maximum>9</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39563,8 +41115,8 @@ return skeleton;
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="SkeeltalArchers1">
-      <minimumDelay>300</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>10</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39594,8 +41146,8 @@ return skeleton;
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Snakes">
-      <minimumDelay>0</minimumDelay>
-      <maximumDelay>0</maximumDelay>
+      <minimumDelay>300</minimumDelay>
+      <maximumDelay>600</maximumDelay>
       <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39724,7 +41276,7 @@ return skeleton;
     </spawn>
     <spawn type="RegionSpawner" name="Officer 2">
       <minimumDelay>900</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>4</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39740,15 +41292,15 @@ return skeleton;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="Level13HighGnollOfficer" size="1" minimum="3" maximum="4" />
+      <entry entity="Level13HighGnollOfficer" size="1" minimum="2" maximum="4" />
       <bounds region="2">
         <inclusion left="-2" top="23" right="2" bottom="32" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="Dragonskel">
-      <minimumDelay>60</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <minimumDelay>600</minimumDelay>
+      <maximumDelay>1200</maximumDelay>
       <maximum>2</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -39994,15 +41546,6 @@ return skeleton;
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="10">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
-	return new StrongShieldBracelet();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
     </treasure>
     <treasure name="StatPotion">
       <entry weight="50">
@@ -40117,7 +41660,7 @@ return skeleton;
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="12">
+      <entry weight="6">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -40126,7 +41669,7 @@ return skeleton;
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="12">
+      <entry weight="6">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -40135,7 +41678,7 @@ return skeleton;
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="12">
+      <entry weight="6">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -40300,15 +41843,6 @@ return skeleton;
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
-	return new BrightFeather();
-]]></block>
-          <block><![CDATA[]]></block>
-        </script>
-      </entry>
-      <entry weight="20">
-        <script name="OnCreate" enabled="true">
-          <block><![CDATA[]]></block>
-          <block><![CDATA[
 	return new StrongShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
@@ -40337,6 +41871,15 @@ return skeleton;
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new PermanentManaPotion();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="20">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new DexterityRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -843,6 +843,7 @@
           <wall>140</wall>
           <destroyed>142</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-38">
@@ -863,6 +864,7 @@
           <wall>140</wall>
           <destroyed>142</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-38">
@@ -1055,6 +1057,7 @@
           <wall>140</wall>
           <destroyed>142</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-37">
@@ -1065,6 +1068,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-37">
@@ -1347,6 +1351,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-35">
@@ -1357,6 +1362,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-35">
@@ -1367,6 +1373,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-35">
@@ -1377,6 +1384,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-35">
@@ -1420,6 +1428,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-35">
@@ -1430,6 +1439,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-35">
@@ -1440,6 +1450,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-35">
@@ -1450,6 +1461,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>152</wall>
@@ -1868,7 +1880,6 @@
           <wall>33</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-32">
@@ -1885,6 +1896,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>439</static>
@@ -1895,6 +1907,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1905,6 +1918,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1915,6 +1929,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1925,6 +1940,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1956,6 +1972,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1966,6 +1983,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1976,6 +1994,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -1986,6 +2005,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -2002,6 +2022,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-32">
@@ -2202,6 +2223,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-31">
@@ -2232,6 +2254,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-31">
@@ -2253,6 +2276,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -2286,6 +2310,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-31">
@@ -2492,6 +2517,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-30">
@@ -2538,6 +2564,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-30">
@@ -2558,6 +2585,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-30">
@@ -2604,6 +2632,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-30">
@@ -2836,6 +2865,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-29">
@@ -2867,6 +2897,7 @@
           <closedId>65</closedId>
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-29">
@@ -2888,6 +2919,7 @@
           <closedId>65</closedId>
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-29">
@@ -2918,6 +2950,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-29">
@@ -3123,6 +3156,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-28">
@@ -3133,6 +3167,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-28">
@@ -3143,6 +3178,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-28">
@@ -3153,6 +3189,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-28">
@@ -3163,6 +3200,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-28">
@@ -3173,11 +3211,13 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-28">
@@ -3195,6 +3235,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -3208,6 +3249,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-28">
@@ -3218,6 +3260,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-28">
@@ -3228,6 +3271,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-28">
@@ -3238,6 +3282,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-28">
@@ -3248,11 +3293,13 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-28">
@@ -4177,6 +4224,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>245</static>
@@ -4190,6 +4238,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>439</static>
@@ -4203,6 +4252,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>245</static>
@@ -4216,6 +4266,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-25">
@@ -4247,6 +4298,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-25">
@@ -4257,6 +4309,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-25">
@@ -4267,6 +4320,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-25">
@@ -4277,6 +4331,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-25">
@@ -4510,6 +4565,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>246</static>
@@ -4542,6 +4598,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-24">
@@ -4566,6 +4623,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-24">
@@ -4591,6 +4649,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-24">
@@ -4826,6 +4885,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>244</static>
@@ -4855,6 +4915,7 @@
           <closedId>65</closedId>
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-23">
@@ -4876,6 +4937,7 @@
           <closedId>65</closedId>
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-23">
@@ -4904,6 +4966,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-23">
@@ -5159,6 +5222,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>246</static>
@@ -5192,6 +5256,7 @@
           <closedId>65</closedId>
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-22">
@@ -5213,6 +5278,7 @@
           <closedId>65</closedId>
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-22">
@@ -5238,6 +5304,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-22">
@@ -5460,6 +5527,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-21">
@@ -5470,6 +5538,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-21">
@@ -5480,6 +5549,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-21">
@@ -5490,6 +5560,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-21">
@@ -5500,11 +5571,13 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-21">
@@ -5525,6 +5598,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-21">
@@ -5535,6 +5609,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-21">
@@ -5545,6 +5620,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-21">
@@ -5555,6 +5631,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-21">
@@ -5565,11 +5642,13 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-21">
@@ -6359,6 +6438,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-18">
@@ -6370,6 +6450,7 @@
           <closedId>64</closedId>
           <secretId>27</secretId>
           <destroyedId>82</destroyedId>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-18">
@@ -6380,6 +6461,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="LockersComponent">
           <static>119</static>
@@ -6393,6 +6475,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="LockersComponent">
           <static>119</static>
@@ -6406,6 +6489,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-18">
@@ -6632,6 +6716,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-17">
@@ -6659,6 +6744,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>13</ground>
         </component>
       </tile>
       <tile x="15" y="-17">
@@ -6890,6 +6979,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-16">
@@ -6917,6 +7007,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="15" y="-16">
@@ -7036,6 +7130,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-15">
@@ -7065,6 +7160,7 @@
           <secretId>28</secretId>
           <destroyedId>83</destroyedId>
           <isSecret>true</isSecret>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -7192,6 +7288,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-14">
@@ -7199,6 +7296,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>4</ground>
@@ -7209,6 +7307,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>4</ground>
@@ -7219,6 +7318,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>4</ground>
@@ -7229,6 +7329,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>4</ground>
@@ -7239,11 +7340,16 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>13</ground>
         </component>
       </tile>
       <tile x="15" y="-14">
@@ -7942,6 +8048,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8176,6 +8283,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8207,6 +8315,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8220,6 +8329,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8233,6 +8343,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8246,6 +8357,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8256,6 +8368,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8266,6 +8379,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8434,6 +8548,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8454,6 +8569,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="26" y="-9">
@@ -8492,6 +8611,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="32" y="-9">
@@ -8653,6 +8776,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8673,9 +8797,13 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>440</static>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="26" y="-8">
@@ -8718,6 +8846,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="32" y="-8">
@@ -8874,6 +9006,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -8894,9 +9027,16 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>440</static>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="26" y="-7">
@@ -8933,6 +9073,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="32" y="-7">
@@ -9069,6 +9213,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -9089,9 +9234,13 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="26" y="-6">
@@ -9124,6 +9273,10 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>4</ground>
         </component>
       </tile>
       <tile x="32" y="-6">
@@ -9285,6 +9438,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -9308,6 +9462,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="-5">
@@ -9315,6 +9470,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="-5">
@@ -9322,6 +9478,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="28" y="-5">
@@ -9345,6 +9502,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="31" y="-5">
@@ -9352,6 +9510,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>28</static>
@@ -9506,6 +9665,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-4">
@@ -9798,6 +9958,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-3">
@@ -10079,6 +10240,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-2">
@@ -10354,6 +10516,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-1">
@@ -11374,6 +11537,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="3">
@@ -11670,6 +11834,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="4">
@@ -11953,6 +12118,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="5">
@@ -11984,6 +12150,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>439</static>
@@ -11997,6 +12164,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="28" y="5">
@@ -12029,6 +12197,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>439</static>
@@ -12042,6 +12211,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>439</static>
@@ -12055,6 +12225,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="33" y="5">
@@ -12211,6 +12382,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="6">
@@ -12228,6 +12400,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -12271,6 +12444,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -12416,6 +12590,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="7">
@@ -12433,6 +12608,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -12484,6 +12660,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -12642,6 +12819,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="8">
@@ -12659,6 +12837,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -12710,6 +12889,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -12888,6 +13068,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="9">
@@ -12905,6 +13086,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -12956,6 +13138,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13133,6 +13316,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="10">
@@ -13150,6 +13334,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -13201,6 +13386,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13388,6 +13574,10 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>13</ground>
         </component>
       </tile>
       <tile x="23" y="11">
@@ -13405,6 +13595,7 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>13</ground>
@@ -13415,6 +13606,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13425,6 +13617,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13435,6 +13628,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13445,6 +13639,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13455,6 +13650,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13465,6 +13661,7 @@
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13475,11 +13672,13 @@
           <wall>28</wall>
           <destroyed>41</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>27</wall>
           <destroyed>40</destroyed>
           <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>3</ground>
@@ -13574,6 +13773,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="12">
@@ -13799,6 +13999,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-8">
@@ -13806,6 +14007,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-8">
@@ -13813,6 +14015,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-8">
@@ -13820,6 +14023,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-8">
@@ -13827,6 +14031,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-8">
@@ -13834,6 +14039,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-8">
@@ -13841,6 +14047,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-8">
@@ -13848,6 +14055,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-8">
@@ -13855,6 +14063,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-8">
@@ -13862,6 +14071,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="-8">
@@ -13869,6 +14079,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-8">
@@ -13876,6 +14087,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-8">
@@ -13883,6 +14095,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="-8" />
@@ -13891,6 +14104,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-7">
@@ -13973,6 +14187,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-6">
@@ -13980,6 +14195,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-6">
@@ -14050,6 +14266,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-5">
@@ -14057,6 +14274,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-5">
@@ -14151,6 +14369,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-4">
@@ -14158,6 +14377,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-4">
@@ -14261,6 +14481,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-3">
@@ -14268,6 +14489,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-3">
@@ -14371,6 +14593,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-2">
@@ -14378,6 +14601,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-2">
@@ -14475,6 +14699,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="-1">
@@ -14545,6 +14770,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-1">
@@ -14552,6 +14778,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-1">
@@ -14559,6 +14786,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-1">
@@ -14566,11 +14794,13 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-1">
@@ -14668,6 +14898,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="0">
@@ -14833,6 +15064,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="1">
@@ -14998,6 +15230,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="2">
@@ -15159,6 +15392,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-5" y="3" />
@@ -15322,6 +15556,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-5" y="4" />
@@ -15491,6 +15726,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-5" y="5" />
@@ -15651,6 +15887,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="6">
@@ -15807,6 +16044,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="7">
@@ -15870,6 +16108,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>179</ground>
@@ -15880,6 +16119,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>179</ground>
@@ -15890,6 +16130,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>179</ground>
@@ -16011,6 +16252,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="8">
@@ -16018,6 +16260,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="8">
@@ -16094,6 +16337,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="9">
@@ -16101,6 +16345,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="9">
@@ -16189,6 +16434,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="10">
@@ -16196,6 +16442,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="10">
@@ -16278,6 +16525,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="11">
@@ -16285,6 +16533,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="11">
@@ -16364,6 +16613,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16374,6 +16624,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="12">
@@ -16417,6 +16668,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16427,6 +16679,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16437,6 +16690,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16445,6 +16699,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="12">
@@ -16452,6 +16707,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16462,6 +16718,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16472,6 +16729,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16482,6 +16740,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -16492,11 +16751,13 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="13">
@@ -16512,6 +16773,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-14" y="13">
@@ -16519,6 +16781,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="13">
@@ -16526,6 +16789,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-12" y="13">
@@ -16533,6 +16797,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-11" y="13">
@@ -16540,6 +16805,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-10" y="13">
@@ -16547,6 +16813,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-9" y="13">
@@ -16554,6 +16821,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-8" y="13">
@@ -16561,6 +16829,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-7" y="13">
@@ -16568,6 +16837,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-6" y="13">
@@ -16575,6 +16845,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-5" y="13">
@@ -16582,6 +16853,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="13">
@@ -16589,6 +16861,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="13">
@@ -16596,6 +16869,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-2" y="13">
@@ -16603,6 +16877,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-1" y="13">
@@ -16610,6 +16885,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="13">
@@ -16617,6 +16893,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="13">
@@ -16624,6 +16901,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="13">
@@ -16631,6 +16909,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="13">
@@ -16638,6 +16917,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="13">
@@ -16645,6 +16925,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="13">
@@ -16652,11 +16933,13 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="13">
@@ -16689,6 +16972,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="13" />
@@ -16698,6 +16982,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="14">
@@ -16830,6 +17115,9 @@
           <destroyed>343</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>1003</ground>
+        </component>
       </tile>
       <tile x="9" y="14">
         <component type="FloorComponent">
@@ -16841,6 +17129,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="15">
@@ -16848,6 +17137,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="15">
@@ -16980,6 +17270,10 @@
           <destroyed>343</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>375</ground>
+          <movementCost>1003</movementCost>
+        </component>
       </tile>
       <tile x="9" y="15">
         <component type="FloorComponent">
@@ -16991,6 +17285,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="16">
@@ -16998,6 +17293,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="16">
@@ -17008,6 +17304,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-14" y="16">
@@ -17018,6 +17315,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="16">
@@ -17028,6 +17326,10 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>1003</ground>
         </component>
       </tile>
       <tile x="-12" y="16">
@@ -17147,6 +17449,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17157,6 +17460,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17167,6 +17471,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17177,6 +17482,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17187,6 +17493,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17197,11 +17504,13 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="16">
@@ -17214,6 +17523,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="17">
@@ -17221,6 +17531,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="17">
@@ -17338,6 +17649,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="17">
@@ -17345,6 +17657,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="17">
@@ -17357,6 +17670,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="18">
@@ -17364,6 +17678,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="18">
@@ -17475,6 +17790,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="18">
@@ -17482,6 +17798,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="18">
@@ -17494,6 +17811,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="19">
@@ -17501,6 +17819,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="19">
@@ -17508,6 +17827,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17518,6 +17838,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17531,6 +17852,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -17624,6 +17946,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="19">
@@ -17631,6 +17954,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="19">
@@ -17643,6 +17967,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="20">
@@ -17650,6 +17975,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="20">
@@ -17767,6 +18093,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="20">
@@ -17774,6 +18101,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="20">
@@ -17781,6 +18109,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="20">
@@ -17788,11 +18117,13 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="21">
@@ -17800,6 +18131,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="21">
@@ -17911,6 +18243,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="22">
@@ -17918,6 +18251,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="22">
@@ -17928,6 +18262,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-14" y="22">
@@ -17938,6 +18273,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="22">
@@ -17948,6 +18284,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18075,6 +18412,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="23">
@@ -18082,6 +18420,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="23">
@@ -18196,6 +18535,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18206,6 +18546,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="24">
@@ -18317,6 +18658,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18327,6 +18669,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="25">
@@ -18337,6 +18680,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-14" y="25">
@@ -18347,6 +18691,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="25">
@@ -18357,6 +18702,10 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>375</ground>
         </component>
       </tile>
       <tile x="-12" y="25">
@@ -18450,6 +18799,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18460,6 +18810,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="26">
@@ -18577,6 +18928,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18587,6 +18939,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="27">
@@ -18692,6 +19045,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18702,6 +19056,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="28">
@@ -18712,6 +19067,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-14" y="28">
@@ -18722,6 +19078,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="28">
@@ -18735,6 +19092,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-12" y="28">
@@ -18829,6 +19187,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18839,6 +19198,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="29">
@@ -18956,6 +19316,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -18966,6 +19327,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="30">
@@ -19083,6 +19445,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19093,6 +19456,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="31">
@@ -19210,6 +19574,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19220,6 +19585,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="32">
@@ -19325,6 +19691,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19335,6 +19702,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="33">
@@ -19342,6 +19710,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19352,6 +19721,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19362,6 +19732,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19380,6 +19751,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19390,6 +19762,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-10" y="33">
@@ -19397,6 +19770,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-9" y="33">
@@ -19404,6 +19778,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-8" y="33">
@@ -19411,6 +19786,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-7" y="33">
@@ -19418,6 +19794,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-6" y="33">
@@ -19425,6 +19802,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-5" y="33">
@@ -19432,6 +19810,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="33">
@@ -19439,6 +19818,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="33">
@@ -19446,11 +19826,13 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-2" y="33">
@@ -19458,6 +19840,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-1" y="33">
@@ -19465,6 +19848,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19475,6 +19859,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19485,6 +19870,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19495,6 +19881,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -19505,11 +19892,13 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>1003</ground>
@@ -24529,6 +24918,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-1">
@@ -24546,6 +24936,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="0">
@@ -24553,6 +24944,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="0">
@@ -24570,6 +24962,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="1">
@@ -24585,6 +24978,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="1">
@@ -24592,6 +24986,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="1">
@@ -24599,6 +24994,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="1">
@@ -24606,11 +25002,13 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="1">
@@ -24641,6 +25039,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="1">
@@ -24648,6 +25047,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="1">
@@ -24655,6 +25055,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="1">
@@ -24662,6 +25063,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-23" y="2">
@@ -24717,6 +25119,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-16" y="2">
@@ -24724,6 +25127,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-15" y="2">
@@ -24731,6 +25135,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-14" y="2">
@@ -24738,6 +25143,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="2">
@@ -24745,6 +25151,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-12" y="2">
@@ -24752,6 +25159,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-11" y="2">
@@ -24759,6 +25167,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-10" y="2">
@@ -24766,6 +25175,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-9" y="2">
@@ -24773,6 +25183,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-8" y="2">
@@ -24780,6 +25191,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>211</static>
@@ -24790,6 +25202,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>211</static>
@@ -24800,6 +25213,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>211</static>
@@ -24810,6 +25224,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>211</static>
@@ -24820,6 +25235,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>211</static>
@@ -24830,6 +25246,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>211</static>
@@ -24840,6 +25257,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="2" />
@@ -24848,6 +25266,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="2">
@@ -25159,6 +25578,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="3">
@@ -25166,11 +25586,13 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="3">
@@ -25532,6 +25954,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="4">
@@ -25666,6 +26089,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="4">
@@ -25893,6 +26317,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="5">
@@ -26020,6 +26445,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="5">
@@ -26284,6 +26710,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="6">
@@ -26406,6 +26833,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="6">
@@ -26658,6 +27086,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="StaticComponent">
           <static>220</static>
@@ -26668,6 +27097,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="7">
@@ -26794,6 +27224,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="7">
@@ -26801,6 +27232,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="7">
@@ -26808,6 +27240,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="7">
@@ -26815,11 +27248,13 @@
           <wall>139</wall>
           <destroyed>141</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="7">
@@ -27109,6 +27544,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="8">
@@ -27116,11 +27552,13 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="8">
@@ -27128,6 +27566,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -27138,11 +27577,13 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="8">
@@ -27966,6 +28407,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="10">
@@ -27973,6 +28415,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -27986,6 +28429,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -27999,6 +28443,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="RuinsComponent">
           <ruins>170</ruins>
@@ -28140,6 +28585,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>5</ground>
@@ -28150,6 +28596,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>5</ground>
@@ -28160,6 +28607,7 @@
           <wall>29</wall>
           <destroyed>42</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>5</ground>
@@ -28170,6 +28618,7 @@
           <wall>139</wall>
           <destroyed>141</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>5</ground>
@@ -28454,6 +28903,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="11">
@@ -28589,6 +29039,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="11">
@@ -28841,6 +29292,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="12">
@@ -28974,6 +29426,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="12">
@@ -29257,6 +29710,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="13">
@@ -29386,6 +29840,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="13">
@@ -29615,6 +30070,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="14">
@@ -29731,6 +30187,7 @@
           <wall>30</wall>
           <destroyed>43</destroyed>
           <ruins>46</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="14">
@@ -30014,6 +30471,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="15">
@@ -30176,6 +30634,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30186,6 +30645,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30196,6 +30656,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30206,6 +30667,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-13" y="16">
@@ -30213,6 +30675,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30223,6 +30686,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30233,6 +30697,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30243,6 +30708,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>183</ground>
@@ -30253,6 +30719,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -30269,6 +30736,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-7" y="16">
@@ -30276,6 +30744,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-6" y="16">
@@ -30283,6 +30752,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-5" y="16">
@@ -30290,11 +30760,13 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-4" y="16">
@@ -30302,6 +30774,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-3" y="16">
@@ -30309,6 +30782,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-2" y="16">
@@ -30325,6 +30799,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="16">
@@ -30332,6 +30807,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="16">
@@ -30491,6 +30967,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="17">
@@ -30498,6 +30975,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="17">
@@ -30505,6 +30983,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="17">
@@ -30515,6 +30994,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="17">
@@ -30525,6 +31005,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="17">
@@ -30535,6 +31016,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="17">
@@ -30545,6 +31027,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="17">
@@ -30555,6 +31038,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="17">
@@ -30565,6 +31049,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="17">
@@ -30575,6 +31060,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="17">
@@ -30585,6 +31071,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="17">
@@ -30595,6 +31082,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="17">
@@ -30605,11 +31093,13 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="17">
@@ -30617,6 +31107,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="17">
@@ -30637,6 +31128,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="18" />
@@ -30647,6 +31139,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="18">
@@ -30679,6 +31172,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="19">
@@ -30686,6 +31180,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="19">
@@ -30696,6 +31191,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="19">
@@ -30706,6 +31202,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="19">
@@ -30716,11 +31213,13 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
     </region>
@@ -30742,6 +31241,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="2">
@@ -30749,6 +31249,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="2">
@@ -30756,6 +31257,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="2">
@@ -30763,6 +31265,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="2">
@@ -30770,6 +31273,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="2">
@@ -30777,6 +31281,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="2">
@@ -30784,6 +31289,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="RopeComponent">
           <destinationX>24</destinationX>
@@ -30797,6 +31303,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="2">
@@ -30804,6 +31311,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="2">
@@ -30811,6 +31319,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="2" />
@@ -30826,6 +31335,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="3">
@@ -30882,6 +31392,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -30975,6 +31486,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="4">
@@ -31037,6 +31549,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31097,6 +31610,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="5">
@@ -31153,6 +31667,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31222,6 +31737,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="6">
@@ -31287,6 +31803,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31347,6 +31864,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="7">
@@ -31406,6 +31924,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31466,6 +31985,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="8">
@@ -31525,6 +32045,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31595,6 +32116,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="9">
@@ -31651,6 +32173,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31711,6 +32234,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="10">
@@ -31767,6 +32291,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31869,6 +32394,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="11">
@@ -31937,6 +32463,11 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WaterComponent">
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -31955,6 +32486,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="12">
@@ -32011,6 +32543,11 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WaterComponent">
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="21" y="12" />
@@ -32025,6 +32562,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="13">
@@ -32084,6 +32622,11 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WaterComponent">
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="21" y="13" />
@@ -32098,6 +32641,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="14">
@@ -32158,6 +32702,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WaterComponent">
           <ground>180</ground>
@@ -32176,6 +32721,7 @@
           <wall>382</wall>
           <destroyed>395</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="15">
@@ -32183,6 +32729,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="15">
@@ -32190,6 +32737,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="15">
@@ -32197,6 +32745,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="15">
@@ -32204,6 +32753,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="15">
@@ -32211,6 +32761,7 @@
           <wall>381</wall>
           <destroyed>394</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="15">
@@ -32222,6 +32773,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="15">
@@ -32233,6 +32785,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="RopeComponent">
           <destinationX>10</destinationX>
@@ -32250,6 +32803,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="15">
@@ -32261,6 +32815,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="15">
@@ -32272,11 +32827,13 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
     </region>
@@ -32536,6 +33093,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="4" y="7">
         <component type="FloorComponent">
@@ -32627,6 +33187,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="4" y="8">
@@ -32720,6 +33283,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="4" y="9">
         <component type="FloorComponent">
@@ -32811,6 +33377,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="4" y="10">
@@ -33758,12 +34327,18 @@
           <destroyed>0</destroyed>
           <ruins>0</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="16" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="17" y="16">
@@ -33772,12 +34347,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="18" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="19" y="16">
@@ -33786,12 +34367,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="20" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="21" y="16">
@@ -33800,12 +34387,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="22" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="23" y="16">
@@ -33814,12 +34407,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="24" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="25" y="16">
@@ -33828,12 +34427,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="26" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="27" y="16">
@@ -33842,6 +34447,9 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="28" y="16">
         <component type="WallComponent">
@@ -33849,12 +34457,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="29" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="30" y="16">
@@ -33995,6 +34609,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="16" y="17">
         <component type="FloorComponent">
@@ -34092,6 +34709,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="30" y="17">
@@ -34221,6 +34841,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="16" y="18">
@@ -34372,6 +34995,9 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="30" y="18">
         <component type="WallComponent">
@@ -34401,7 +35027,7 @@
       </tile>
       <tile x="5" y="19">
         <component type="FloorComponent">
-          <ground>5196</ground>
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="6" y="19">
@@ -34498,6 +35124,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="16" y="19">
         <component type="FloorComponent">
@@ -34569,6 +35198,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="30" y="19">
@@ -34736,7 +35368,7 @@
       </tile>
       <tile x="10" y="20">
         <component type="FloorComponent">
-          <ground>10206</ground>
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="11" y="20">
@@ -34778,6 +35410,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="16" y="20">
@@ -34851,6 +35486,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="30" y="20">
         <component type="WallComponent">
@@ -34874,12 +35512,18 @@
           <destroyed>0</destroyed>
           <ruins>0</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="35" y="20">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="36" y="20">
@@ -34888,12 +35532,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="37" y="20">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="38" y="20">
@@ -34902,12 +35552,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="39" y="20">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="40" y="20">
@@ -34916,6 +35572,9 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="41" y="20">
         <component type="WallComponent">
@@ -34923,12 +35582,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="42" y="20">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="20">
@@ -35056,6 +35721,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="16" y="21">
         <component type="FloorComponent">
@@ -35168,6 +35836,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="30" y="21">
         <component type="WallComponent">
@@ -35190,6 +35861,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="35" y="21">
@@ -35250,6 +35924,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="21">
@@ -35369,6 +36046,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="16" y="22">
         <component type="FloorComponent">
@@ -35483,6 +36163,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="30" y="22">
         <component type="WallComponent">
@@ -35524,6 +36207,9 @@
         </component>
         <component type="StaticComponent">
           <static>221</static>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="35" y="22">
@@ -35573,6 +36259,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="43" y="22">
         <component type="WallComponent">
@@ -35611,6 +36300,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="7" y="23">
@@ -35677,6 +36369,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="16" y="23">
@@ -35832,12 +36527,18 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="30" y="23">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="31" y="23">
@@ -35846,6 +36547,9 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="32" y="23">
         <component type="WallComponent">
@@ -35853,12 +36557,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="33" y="23">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="34" y="23">
@@ -35874,6 +36584,9 @@
         </component>
         <component type="StaticComponent">
           <static>221</static>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="35" y="23">
@@ -35917,6 +36630,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="43" y="23">
         <component type="WallComponent">
@@ -35939,6 +36655,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="7" y="24">
@@ -36136,6 +36855,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="43" y="24">
         <component type="WallComponent">
@@ -36158,6 +36880,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="7" y="25">
@@ -36359,6 +37084,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="43" y="25">
         <component type="WallComponent">
@@ -36381,6 +37109,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="7" y="26">
@@ -36576,6 +37307,9 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="43" y="26">
         <component type="WallComponent">
@@ -36598,6 +37332,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="7" y="27">
@@ -36846,12 +37583,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="32" y="27">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="33" y="27">
@@ -36885,12 +37628,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="36" y="27">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="37" y="27">
@@ -36899,12 +37648,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="38" y="27">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="39" y="27">
@@ -36913,6 +37668,9 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="40" y="27">
         <component type="WallComponent">
@@ -36920,12 +37678,18 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
       </tile>
       <tile x="41" y="27">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="42" y="27">
@@ -36938,6 +37702,9 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="27">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -19486,6 +19486,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-4">
@@ -19493,6 +19494,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-4">
@@ -19500,6 +19502,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-4">
@@ -19507,6 +19510,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-4">
@@ -19514,6 +19518,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-4">
@@ -19521,6 +19526,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-4">
@@ -19528,6 +19534,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-3">
@@ -19535,6 +19542,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-3">
@@ -19572,6 +19580,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-2" />
@@ -19582,6 +19591,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-2">
@@ -19623,6 +19633,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-2">
@@ -19635,6 +19646,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-1">
@@ -19642,6 +19654,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-1">
@@ -19659,6 +19672,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-1">
@@ -19674,6 +19688,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="-1">
@@ -19686,6 +19701,7 @@
           <wall>334</wall>
           <destroyed>343</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="0">
@@ -19693,7 +19709,6 @@
           <wall>417</wall>
           <destroyed>418</destroyed>
           <ruins>0</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="0">
@@ -19701,6 +19716,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="0">
@@ -19708,6 +19724,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="0">
@@ -19715,6 +19732,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="0">
@@ -19722,11 +19740,13 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="0">
@@ -19737,6 +19757,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="0">
@@ -19756,11 +19777,13 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="0">
@@ -19768,6 +19791,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="0">
@@ -19775,11 +19799,13 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="0">
@@ -19799,11 +19825,13 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="0">
@@ -19811,6 +19839,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="0">
@@ -19818,6 +19847,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="1">
@@ -19825,6 +19855,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="1">
@@ -19876,6 +19907,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="1">
@@ -19912,6 +19944,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="2">
@@ -19919,6 +19952,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="2">
@@ -20000,6 +20034,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="3">
@@ -20045,6 +20080,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="3">
@@ -20081,6 +20117,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="3" />
@@ -20418,6 +20455,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="4" />
@@ -20692,6 +20730,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="6">
@@ -20948,6 +20987,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="7">
@@ -21238,6 +21278,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="8">
@@ -21498,6 +21539,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="9">
@@ -21750,6 +21792,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="10">
@@ -22033,6 +22076,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="11">
@@ -22320,6 +22364,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="12">
@@ -22565,6 +22610,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="13">
@@ -22804,6 +22850,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-24" y="14">
@@ -23218,6 +23265,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-12" y="15" />
@@ -23229,6 +23277,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="15">
@@ -23320,6 +23369,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="16">
@@ -23327,6 +23377,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="16">
@@ -23403,6 +23454,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="17">
@@ -23410,6 +23462,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="17">
@@ -23461,6 +23514,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="17">
@@ -23471,6 +23525,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="17">
@@ -23481,6 +23536,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="17">
@@ -23501,6 +23557,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="18">
@@ -23508,6 +23565,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="18">
@@ -23569,6 +23627,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="18">
@@ -23589,6 +23648,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="19">
@@ -23596,6 +23656,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="19">
@@ -23657,6 +23718,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="19">
@@ -23677,6 +23739,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="20">
@@ -23684,6 +23747,7 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="20">
@@ -23694,6 +23758,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="20">
@@ -23704,6 +23769,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="20">
@@ -23714,6 +23780,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="20">
@@ -23724,6 +23791,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="20">
@@ -23734,6 +23802,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="20">
@@ -23744,6 +23813,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="20">
@@ -23754,6 +23824,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="20">
@@ -23764,6 +23835,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="20">
@@ -23774,6 +23846,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="20">
@@ -23784,11 +23857,13 @@
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="20">
@@ -23799,6 +23874,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="20">
@@ -23809,6 +23885,7 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="20">
@@ -23819,11 +23896,13 @@
           <wall>413</wall>
           <destroyed>415</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>414</wall>
           <destroyed>416</destroyed>
           <ruins>398</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
     </region>


### PR DESCRIPTION
1st in a series of changes I plan on making based on some play throughs I've finished on my Non-twink knight. There's way too much gold for the difficulty, and there are some choke points with too many mobs. So I mean to address those issues in the next few changes. 

There are no new items, the most likely change to cause problems is the art I added. However, it should have already been compiled in. 

Made the following changes to Blackburrow:

- Lined up the stairs "vertically" so all the stairs and their location make logical sense with respect to the entire map
- Slowed the respawn rate by 5 minutes on all normal mobs
- Cut Gem drop rate in half on regular mobs
- Lowered drop chance of PP on lockjaw, removed Strong Shield bracer from miniboss loot table
- Added Dexterity ring to Dragon loot table
- Reduced crit density on the easier levels (Will make them harder in the next iteration of changes, after I walk through BB again on my baby Knight)
- Added new art courtesy of Tenser