### PR TITLE
Fix Carfel's block to not be bugged from MainGauche Alignment

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100067,9 +100067,7 @@
         new CreatureBasicAttack(18, 18, 30)
     };
     
-    carfel.Wield(new YasnakiDagger());
-    carfel.Wield(new MainGauche());
-    
+    carfel.Wield(new YasnakiDagger()); 
         
     carfel.AddGold(4800);
     carfel.AddLoot(new LootPack(
@@ -100078,7 +100076,8 @@
         new LootPackEntry(true, UnderkingdomGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, (from, container) => new BearSkull(),        100),
         new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
-        new LootPackEntry(true, (from, container) => new StrongStrengthRing(),        100)
+        new LootPackEntry(true, (from, container) => new StrongStrengthRing(),        100),
+        new LootPackEntry(true, (from, container) => new MainGauche(),        100)
     ));
     
     return carfel;


### PR DESCRIPTION
Carfel was accidently made easier due to MainGauche was added as part of his weapons. Carfel can no longer block properly due to it is a Neutral Dagger. Switching it to just drop the dagger versus use the dagger.