### PR TITLE
Remove Dagger until we can figure out how to keep defenses the same on Carfel

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100076,8 +100076,7 @@
         new LootPackEntry(true, UnderkingdomGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, (from, container) => new BearSkull(),        100),
         new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
-        new LootPackEntry(true, (from, container) => new StrongStrengthRing(),        100),
-        new LootPackEntry(true, (from, container) => new MainGauche(),        100)
+        new LootPackEntry(true, (from, container) => new StrongStrengthRing(),        100)
     ));
     
     return carfel;


### PR DESCRIPTION
- Currently boss is comparable to Leng Kosh if dagger is left wielded, but potentially easier due to no fire.
- Carfel hits for less, can crit but for 50-60. 
- Carfel does hit more often due to 18 weapon skill. 

- If previous code is left in, potential item exploit will occur. Portals allow corpses to be transported out. (As good as a fan)