### PR TITLE
Carfel Difficulty - Change Back to Original State

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100039,7 +100039,7 @@
         Body = 206,
         
         MaxHealth = 1800, Health = 1800,
-        BaseDodge = 24,
+        BaseDodge = 26,
         HideDetection = 28,
         Alignment = Alignment.Evil,
         
@@ -100068,6 +100068,7 @@
     };
     
     carfel.Wield(new YasnakiDagger()); 
+    carfel.Wield(new YasnakiDagger()); 
         
     carfel.AddGold(4800);
     carfel.AddLoot(new LootPack(
@@ -100076,8 +100077,7 @@
         new LootPackEntry(true, UnderkingdomGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, (from, container) => new BearSkull(),        100),
         new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
-        new LootPackEntry(true, (from, container) => new StrongStrengthRing(),        100),
-        new LootPackEntry(true, (from, container) => new MainGauche(),        100)
+        new LootPackEntry(true, (from, container) => new StrongStrengthRing(),        100)
     ));
     
     return carfel;

--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100067,8 +100067,15 @@
         new CreatureBasicAttack(18, 18, 30)
     };
     
+    carfel.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(6, "a high block"),
+        new CreatureBlock(4, "an inside block"),
+        new CreatureBlock(3, "a low block"),
+    };
+    
     carfel.Wield(new YasnakiDagger()); 
-    carfel.Wield(new YasnakiDagger()); 
+    carfel.Wield(new MainGauche()); 
         
     carfel.AddGold(4800);
     carfel.AddLoot(new LootPack(


### PR DESCRIPTION
At this current time Carfel can not block a level 9 skill thief. Looking at the history, noticing that a change was made to dodge.

Reverting these changes in hopes to fix his block. Otherwise a level, 15/5th dan thief can kill him solo at this time with kosh gaunts. 

![image](https://user-images.githubusercontent.com/90510109/198015016-5d1f55ca-02cb-4580-b372-dd06a4ec3ddd.png)


