### PR TITLE
Move Ram Staff and Unholy Scepter to Wield

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -79115,6 +79115,8 @@
     
     critter.CombatantChangeInterval = TimeSpan.FromSeconds(10.0);
     
+    critter.Wield(new RamStaff());
+    
     critter.Attacks = new CreatureAttackCollection()
     {
         {
@@ -79142,8 +79144,7 @@
     critter.AddGold(10000);
      critter.AddGold(1000);
       critter.AddLoot(new LootPack(
-        new LootPackEntry(true, LengGems,       100,     gemsPriceMutatorVeryHigh),
-        new LootPackEntry(true, (from, container) => new RamStaff(),        100)
+        new LootPackEntry(true, LengGems,       100,     gemsPriceMutatorVeryHigh)
     ));
     
     return critter;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/UnholyScepter.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/UnholyScepter.cs
@@ -51,6 +51,10 @@ namespace Kesmai.Server.Items
         {
         }
 
+        public UnholyScepter(Serial serial) : base(serial)
+        {
+        }
+
         /// <inheritdoc />
 		public override bool CanEquip(MobileEntity entity)
         {


### PR DESCRIPTION
Currently this is the only way we have found out to make sure people don't carry a corpse with the item on it. This ensures the player has to attempt or at least traverse to the region to get the item. (similar to OL staff)

Leng: Killer Rabbit 
Bloodlands: The Queen