### PR TITLE
Evil / Chaotic can not wield lawful weapons

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -79115,8 +79115,6 @@
     
     critter.CombatantChangeInterval = TimeSpan.FromSeconds(10.0);
     
-    critter.Wield(new RamStaff());
-    
     critter.Attacks = new CreatureAttackCollection()
     {
         {
@@ -79144,7 +79142,8 @@
     critter.AddGold(10000);
      critter.AddGold(1000);
       critter.AddLoot(new LootPack(
-        new LootPackEntry(true, LengGems,       100,     gemsPriceMutatorVeryHigh)
+        new LootPackEntry(true, LengGems,       100,     gemsPriceMutatorVeryHigh),
+        new LootPackEntry(true, (from, container) => new RamStaff(),        100)
     ));
     
     return critter;


### PR DESCRIPTION
Revert Change due to Lawful weapons don't work on Chaotic / Evil creatures. Correction 1 swing, looks like the jump kick did not trigger it. 