### PR TITLE
Traps need night vision due to OL Hall is permadark. Also cast 100% if their spell is not on cool down.

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -103215,7 +103215,9 @@ var gargoyle = new Gargoyle()
         CanLoot = false
     };
     
-    trap.Spells = new CreatureSpellCollection(50.0)
+    trap.AddStatus(new NightVisionStatus(trap));
+    
+    trap.Spells = new CreatureSpellCollection(100.0)
     {
         {
             new CreatureSpell<ConcussionSpell>(


### PR DESCRIPTION
- OL Traps need night vision to see players or any other non aligned. 
- OL Traps will now cast 100.0 if their spell rotation is within the 5 seconds. 