### PR TITLE
Adjusting Mama to be able to fly/hit 3x away. DB Ice is super infrequent currently. 

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -107034,7 +107034,7 @@
         Experience = 213980,
         
         CanFly = true,
-        CanCharge = true,
+        CanJumpkick = true,
         CanStrikeCritically = false,
         BasePenetration = ShieldPenetration.VeryHeavy,
 
@@ -107091,7 +107091,7 @@
     dragon.Spells = new CreatureSpellCollection(35.0)
     {
        { new CreatureSpell<DragonBreathIceSpell>(
-            skillLevel: 21), 100, TimeSpan.FromSeconds(15.0) }
+            skillLevel: 21), 100, TimeSpan.FromSeconds(10.0) }
     };
     //todo: add griffin figurine, protection from cold amulet (replaces f/i ammy?)
     dragon.AddGold(18000);


### PR DESCRIPTION
1) Mama has always been able to attack 3 hexes away in other emulators. This is a fix since Charge only attacks 2x away. 

2) Due to CreatureSpellCollection(35.0) is at 35% spell to melee ratio and also a timespan is being applied for 15 seconds, the icestorm is far less frequent than any other version. Just to slightly affect db ice percentage bumping the rate up by 5 seconds. 