### PR TITLE
Yasnaki Wizards are casting 2 concs and then an icestorm when full mana 

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -101856,13 +101856,13 @@
     wizard.Spells = new CreatureSpellCollection()
     {
         { new CreatureSpell<ConcussionSpell>(
-            skillLevel: 13, cost: 6, 
+            skillLevel: 13, cost: 10, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   50 },
         { new CreatureSpell<MagicMissileSpell>(
-            skillLevel: 10, cost: 5, 
+            skillLevel: 10, cost: 3, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 },
         { new CreatureSpell<IceStormSpell>(
-            skillLevel: 15, cost: 5, 
+            skillLevel: 15, cost: 6, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false),   25 }
     };
     


### PR DESCRIPTION
The skill level is what matters here. The concs are basically killing off all crits and then some.  A user should be able to react. This should probably make them a wee harder from Magic Missile though, since conc is actually weaker.