### PR TITLE
Fixes for Bloodlands and Baggable Bright Feather

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Miscellaneous/BrightFeather.cs
+++ b/Source/Kesmai.Server/Game/Items/Miscellaneous/BrightFeather.cs
@@ -14,6 +14,9 @@ namespace Kesmai.Server.Items
 		public override uint BasePrice => 300;
 
 		/// <inheritdoc />
+		public override int Category => 3;
+
+		/// <inheritdoc />
 		public override bool CanBind => true;
 
 		public BrightFeather() : base(397)


### PR DESCRIPTION
* Bright Feather Category for Baggable
* Adjust Drop Ratio Higher on Bright Feathers for Lower Bosses in Bloodlands so everything is not so dependent on DXing people up to Sky temple
* Fix Anubis by adding Poison Immunity as well as PC immunity
* Add actual Hide Detection for level 14-17 crits

* Feedback from Ekky - Scythe does not need speed adjustment. Removing. 