### PR TITLE
Kosh casting rate change

### DIFF
--- a/Segments/Leng.mapproj
+++ b/Segments/Leng.mapproj
@@ -75891,7 +75891,7 @@
         new CreatureBlock(3, "a wing"),
     };
         
-    dragon.Spells = new CreatureSpellCollection(40.0)
+    dragon.Spells = new CreatureSpellCollection(20.0)
     {
         new CreatureSpell<DragonBreathFireSpell>(
             skillLevel: 14)


### PR DESCRIPTION
Since Lux fixed the instant casting fizzles on mobs the cast rate on certain bosses feels a little high. 

Tweaking Kosh's DB fire from 4 out of 10 attacks down to 2. We can test it again and tweak back up if necessary. 