### PR TITLE
Various Bug Fixes for Fear/Stun/Blind and others

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -42918,7 +42918,7 @@
     <region>
       <id>10</id>
       <name>Dungeon of DOOM</name>
-      <height>100</height>
+      <height>90</height>
       <level>16</level>
       <tile x="5" y="2">
         <component type="StaticComponent">
@@ -108432,7 +108432,7 @@
         Health = 180,
         BaseDodge = 25,
         HideDetection = 31,
-        Mana = 15, MaxMana = 15,
+        MaxMana = 15, Mana = 15, 
         BasePenetration = ShieldPenetration.Light,
         Experience = 13095,
         Movement = 2,

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -89122,6 +89122,7 @@ return elemental;
 
 dragon.AddStatus(new NightVisionStatus(dragon));
 dragon.AddStatus(new BreatheWaterStatus(dragon));
+dragon.AddStatus(new BlindFearProtectionStatus(dragon));
 
 dragon.AddImmunity(typeof(BlindSpell));
 dragon.AddImmunity(typeof(FearSpell));

--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -80239,7 +80239,7 @@
     <region>
       <id>236</id>
       <name>Grove</name>
-      <height>-230</height>
+      <height>-210</height>
       <level>26</level>
       <tile x="42" y="-22">
         <component type="WallComponent">
@@ -113208,7 +113208,7 @@
         new CreatureBasicAttack(14)
     };
     
-    banshee.Spells = new CreatureSpellCollection()
+    banshee.Spells = new CreatureSpellCollection(90.0)
     {
         { new CreatureSpell<CurseSpell>(
             skillLevel: 2, cost: 3), 100, TimeSpan.FromSeconds(1.0) }
@@ -117268,7 +117268,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSpawner">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>41</maximum>
+      <maximum>31</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117577,7 +117577,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaNorthwest">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>25</maximum>
+      <maximum>15</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117609,7 +117609,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaNortheast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>25</maximum>
+      <maximum>15</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117642,7 +117642,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSouthwest">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>25</maximum>
+      <maximum>15</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -117674,7 +117674,7 @@
     <spawn type="RegionSpawner" name="serpentsSeaSoutheast">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1200</maximumDelay>
-      <maximum>25</maximum>
+      <maximum>15</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[


### PR DESCRIPTION
Axe - Spectre had Mana reversed in props, so the mana would always be 0. 

Bloodlands/Blackburrow - Fear/Blind status on Bosses instead of immunity type of spell.

Oakvael - Complaints that the zone was over populated. Thinned it by 10 a quadrant to see if that helps. (40 less and the -10 more on the Gap Coverage)