### PR TITLE
Grove Snakes only spawn in Grove

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -1347,6 +1347,11 @@
                 {
                     if (!combatant.IsAlive)
                         return;
+                        
+                    if(combatant.Location.Region != 236)
+                    {
+                        return;
+                    }
     
                     combatant.EmitSound(206, 3, 9);
     


### PR DESCRIPTION
Grove Snakes only spawn in Grove

Currently if user recalls into another region, they can accidently kill another player. The region needs to be evaluated before the entity is spawned.