### PR TITLE
Bloodlands can use and fumble calc to two weapons

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/UnholyScepter.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/UnholyScepter.cs
@@ -56,12 +56,27 @@ namespace Kesmai.Server.Items
         }
 
         /// <inheritdoc />
-		public override bool CanEquip(MobileEntity entity)
+        public override bool CanUse(MobileEntity entity)
         {
+            var isUsable = true;
+            
             if (entity is PlayerEntity player)
-                return player.Profession == Profession.Thaumaturge || player.Profession == Profession.Wizard;
-
-            return false;
+            {
+                if (player.Profession == Profession.Wizard || player.Profession == Profession.Thaumaturge)
+                {
+                    isUsable = true;
+                }
+                else
+                {
+                    isUsable = false;
+                }
+            }
+            else
+            {
+                isUsable = false;   
+            }
+            
+            return isUsable;        
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Bloodsword:
* Moved Item to twins down in the Forest
* Add 2 H to sword and also make it fumble if something is in left hand

Unholy Scepter
* Add CanUse to Scepter since it worked for Scythe. (Only Wizards / Thaums)