### PR TITLE
Thief Lair update tiny kesmai -5 change

### DIFF
--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -95277,6 +95277,11 @@
           <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
       </tile>
       <tile x="39" y="1">
         <component type="WallComponent">
@@ -95359,6 +95364,12 @@
         </component>
       </tile>
       <tile x="35" y="3">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
         <component type="WallComponent">
           <wall>355</wall>
           <destroyed>356</destroyed>
@@ -95539,6 +95550,12 @@
       </tile>
       <tile x="29" y="4" />
       <tile x="34" y="4">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
         <component type="WallComponent">
           <wall>355</wall>
           <destroyed>356</destroyed>
@@ -95814,6 +95831,11 @@
           <destroyed>356</destroyed>
           <ruins>669</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
         </component>
       </tile>
       <tile x="34" y="5">
@@ -96177,6 +96199,11 @@
           <destroyed>356</destroyed>
           <ruins>669</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
         </component>
       </tile>
       <tile x="33" y="6">
@@ -96574,6 +96601,12 @@
       <tile x="49" y="7">
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>355</wall>
@@ -97566,6 +97599,13 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="50" y="11">
@@ -98889,6 +98929,19 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="50" y="15">
@@ -100792,6 +100845,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="51" y="19">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -99489,6 +99489,7 @@
           <wall>333</wall>
           <destroyed>342</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="51" y="16">
@@ -101732,6 +101733,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="50" y="21">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -103488,6 +103488,9 @@
           <indestructible>true</indestructible>
         </component>
         <component type="RopeComponent">
+          <destinationX>53</destinationX>
+          <destinationY>20</destinationY>
+          <destinationRegion>6</destinationRegion>
           <teleporterId>255</teleporterId>
         </component>
       </tile>
@@ -103872,13 +103875,13 @@
         </component>
       </tile>
       <tile x="6" y="27">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>25</wall>
+          <destroyed>38</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="7" y="27">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -95270,7 +95270,448 @@
       <id>6</id>
       <name>Thief Lair</name>
       <height>0</height>
+      <tile x="38" y="1">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="1">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="40" y="1">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="1">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="42" y="1">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="1">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="38" y="2">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="2">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="40" y="2">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="41" y="2">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="42" y="2">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="43" y="2">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="35" y="3">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="36" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="38" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="3">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="40" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="95" g="93" b="97" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="42" y="3">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="43" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="46" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="47" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="48" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="54" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="3">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="29" y="4" />
+      <tile x="34" y="4">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="35" y="4">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="36" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="37" y="4">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="38" y="4">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="39" y="4">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="40" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="41" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="42" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="43" y="4">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="44" y="4">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="45" y="4">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="46" y="4">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="47" y="4">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="48" y="4">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="50" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="51" y="4">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="52" y="4">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="4">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="54" y="4">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="4">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="2" y="5">
         <component type="WallComponent">
           <wall>31</wall>
@@ -95364,6 +95805,228 @@
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="33" y="5">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="34" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="35" y="5">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="36" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="37" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="38" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="40" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="42" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="129" g="123" b="122" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="44" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="45" y="5">
+        <component type="FloorComponent">
+          <color r="99" g="103" b="95" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="46" y="5">
+        <component type="FloorComponent">
+          <color r="123" g="120" b="121" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="47" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="48" y="5">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="49" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="51" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="5">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="114" g="112" b="112" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="54" y="5">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="55" y="5">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
@@ -95508,6 +96171,187 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="32" y="6">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="33" y="6">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="34" y="6">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="35" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="36" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="37" y="6">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="6">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="45" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="46" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="47" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="48" y="6">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="49" y="6">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="50" y="6">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="51" y="6">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="6">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="6">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="54" y="6">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="6">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="2" y="7">
         <component type="WallComponent">
           <wall>31</wall>
@@ -95527,27 +96371,34 @@
         </component>
       </tile>
       <tile x="4" y="7">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="5" y="7">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="SkyComponent">
+          <teleporterId>9</teleporterId>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="6" y="7">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="Fire">
-          <allowDispel>true</allowDispel>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="7" y="7">
@@ -95556,24 +96407,34 @@
         </component>
       </tile>
       <tile x="8" y="7">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="9" y="7">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="SkyComponent">
+          <teleporterId>9</teleporterId>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="10" y="7">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="11" y="7">
@@ -95603,6 +96464,174 @@
         </component>
       </tile>
       <tile x="14" y="7" />
+      <tile x="32" y="7">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="33" y="7">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="34" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="35" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="36" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="7">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="44" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="46" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="47" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="48" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="7">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="7">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="7">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="52" y="7">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="7">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="54" y="7">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="7">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="2" y="8">
         <component type="WallComponent">
           <wall>31</wall>
@@ -95622,45 +96651,57 @@
         </component>
       </tile>
       <tile x="4" y="8">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="5" y="8">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="6" y="8">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="Fire">
-          <allowDispel>true</allowDispel>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="7" y="8">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="FloorComponent">
+          <ground>1028</ground>
+        </component>
       </tile>
       <tile x="8" y="8">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="9" y="8">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="10" y="8">
@@ -95698,6 +96739,106 @@
         </component>
       </tile>
       <tile x="14" y="8" />
+      <tile x="32" y="8">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="33" y="8">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="34" y="8">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="35" y="8">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="8">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="8">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="8">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="8">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="8">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="54" y="8">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="8">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="2" y="9">
         <component type="WallComponent">
           <wall>31</wall>
@@ -95717,27 +96858,28 @@
         </component>
       </tile>
       <tile x="4" y="9">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="5" y="9">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="6" y="9">
         <component type="FloorComponent">
           <ground>6</ground>
-        </component>
-        <component type="Fire">
-          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="7" y="9">
@@ -95751,19 +96893,23 @@
         </component>
       </tile>
       <tile x="9" y="9">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="10" y="9">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="11" y="9">
@@ -95793,7 +96939,120 @@
         </component>
       </tile>
       <tile x="14" y="9" />
-      <tile x="2" y="10">
+      <tile x="32" y="9">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="33" y="9">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="118" g="108" b="105" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="34" y="9">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="35" y="9">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="36" y="9">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="50" y="9">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="9">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="9">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="53" y="9">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="54" y="9">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="9">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="9">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="1" y="10">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -95801,7 +97060,7 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="3" y="10">
+      <tile x="2" y="10">
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
@@ -95811,7 +97070,7 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="4" y="10">
+      <tile x="3" y="10">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
@@ -95819,6 +97078,22 @@
           <wall>32</wall>
           <destroyed>0</destroyed>
           <ruins>0</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>25</wall>
+          <destroyed>38</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="4" y="10">
+        <component type="WallComponent">
+          <wall>32</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
@@ -95828,26 +97103,18 @@
       </tile>
       <tile x="5" y="10">
         <component type="WallComponent">
-          <wall>32</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
+          <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
       </tile>
       <tile x="6" y="10">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -95873,19 +97140,23 @@
         <component type="Darkness">
           <allowDispel>true</allowDispel>
         </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="10" y="10">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
         <component type="Fire">
           <allowDispel>true</allowDispel>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="11" y="10">
@@ -95914,7 +97185,156 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="20" y="10">
+        <component type="HiddenTeleporterComponent">
+          <destinationX>37</destinationX>
+          <destinationY>-21</destinationY>
+          <destinationRegion>1</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
+        <component type="FloorComponent">
+          <ground>2</ground>
+        </component>
+      </tile>
+      <tile x="33" y="10">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="34" y="10">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="118" g="108" b="105" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="35" y="10">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="36" y="10">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="10">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="50" y="10">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="10">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="10">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="10">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="101" g="95" b="93" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="54" y="10">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="55" y="10">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="56" y="10">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="1" y="11">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="2" y="11">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -95923,6 +97343,14 @@
         </component>
       </tile>
       <tile x="3" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
+        </component>
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -95930,39 +97358,17 @@
           <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>26</wall>
+          <destroyed>39</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="11">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
       </tile>
       <tile x="5" y="11">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="6" y="11">
         <component type="ObstructionComponent">
           <obstruction>166</obstruction>
         </component>
@@ -95970,12 +97376,20 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="11">
+      <tile x="6" y="11">
         <component type="Darkness">
           <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="7" y="11">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="11">
@@ -96040,12 +97454,224 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="3" y="12">
+      <tile x="34" y="11">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="35" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="118" g="108" b="105" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="36" y="11">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="37" y="11">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="38" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="40" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="42" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="46" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="11">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="50" y="11">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="11">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="11">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="53" y="11">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="54" y="11">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="11">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="11">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="12">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="3" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="4" y="12">
@@ -96053,33 +97679,12 @@
           <ground>6</ground>
         </component>
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
       <tile x="5" y="12">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="6" y="12">
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
@@ -96089,17 +97694,25 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="6" y="12">
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="7" y="12">
-        <component type="Darkness">
-          <allowDispel>true</allowDispel>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="12">
@@ -96150,41 +97763,221 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="3" y="13">
+      <tile x="21" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="35" y="12">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="36" y="12">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="118" g="108" b="105" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="37" y="12">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="38" y="12">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="39" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="40" y="12">
+        <component type="FloorComponent">
+          <color r="118" g="118" b="114" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>77</openId>
+          <closedId>65</closedId>
+          <secretId>28</secretId>
+          <destroyedId>83</destroyedId>
+        </component>
+      </tile>
+      <tile x="41" y="12">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="42" y="12">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="43" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="44" y="12">
+        <component type="FloorComponent">
+          <color r="114" g="112" b="110" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>77</openId>
+          <closedId>65</closedId>
+          <secretId>28</secretId>
+          <destroyedId>83</destroyedId>
+        </component>
+      </tile>
+      <tile x="45" y="12">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+      </tile>
+      <tile x="46" y="12">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="12">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="12">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="12">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="52" y="12">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="12">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="54" y="12">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="12">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="12" />
+      <tile x="2" y="13">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="3" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="4" y="13">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
       </tile>
       <tile x="5" y="13">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="6" y="13">
         <component type="ObstructionComponent">
           <obstruction>166</obstruction>
         </component>
@@ -96192,12 +97985,20 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="13">
+      <tile x="6" y="13">
         <component type="Darkness">
           <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="7" y="13">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="13">
@@ -96268,12 +98069,197 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="3" y="14">
+      <tile x="36" y="13">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="13">
+        <component type="FloorComponent">
+          <color r="97" g="103" b="99" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>27</secretId>
+          <destroyedId>82</destroyedId>
+        </component>
+      </tile>
+      <tile x="38" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="13">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="40" y="13">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="13">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="42" y="13">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="43" y="13">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="44" y="13">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="13">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="13">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="13">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="13">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="13">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="13">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="54" y="13">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="13">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="14">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="3" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="4" y="14">
@@ -96281,33 +98267,12 @@
           <ground>6</ground>
         </component>
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
       <tile x="5" y="14">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="6" y="14">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
@@ -96317,6 +98282,14 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="6" y="14">
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -96385,41 +98358,215 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="3" y="15">
+      <tile x="36" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="38" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="39" y="14">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="40" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="41" y="14">
+        <component type="FloorComponent">
+          <color r="112" g="108" b="110" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>27</secretId>
+          <destroyedId>82</destroyedId>
+        </component>
+      </tile>
+      <tile x="42" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="14">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="44" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="45" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>27</secretId>
+          <destroyedId>82</destroyedId>
+        </component>
+      </tile>
+      <tile x="46" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="14">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="14">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="14">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="101" g="95" b="93" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="54" y="14">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="55" y="14">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="15">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="3" y="15">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="4" y="15">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
       </tile>
       <tile x="5" y="15">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="6" y="15">
         <component type="ObstructionComponent">
           <obstruction>166</obstruction>
         </component>
@@ -96427,12 +98574,20 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="15">
+      <tile x="6" y="15">
         <component type="Darkness">
           <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="7" y="15">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="15">
@@ -96635,6 +98790,182 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="36" y="15">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="15">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="38" y="15">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="91" g="97" b="95" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="39" y="15">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="40" y="15">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="41" y="15">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="42" y="15">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="95" g="95" b="90" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="43" y="15">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="44" y="15">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="15">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="15">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="15">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="50" y="15">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="15">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="15">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="53" y="15">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="54" y="15">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="15">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="1" y="16">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
       <tile x="2" y="16">
         <component type="WallComponent">
           <wall>31</wall>
@@ -96644,11 +98975,13 @@
         </component>
       </tile>
       <tile x="3" y="16">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>26</wall>
+          <destroyed>39</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="16">
@@ -96656,22 +98989,12 @@
           <ground>6</ground>
         </component>
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
       <tile x="5" y="16">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="6" y="16">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
@@ -96686,20 +99009,28 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="16">
-        <component type="Darkness">
-          <allowDispel>true</allowDispel>
+      <tile x="6" y="16">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+      </tile>
+      <tile x="7" y="16">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="16">
-        <component type="Darkness">
-          <allowDispel>true</allowDispel>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="9" y="16">
@@ -96761,13 +99092,13 @@
         </component>
       </tile>
       <tile x="16" y="16">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="17" y="16">
@@ -96779,6 +99110,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="18" y="16">
         <component type="WallComponent">
@@ -96788,6 +99124,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="19" y="16">
@@ -96799,6 +99140,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="20" y="16">
         <component type="WallComponent">
@@ -96808,6 +99154,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="21" y="16">
@@ -96819,6 +99170,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="22" y="16">
         <component type="WallComponent">
@@ -96828,6 +99184,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="23" y="16">
@@ -96839,6 +99200,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="24" y="16">
         <component type="WallComponent">
@@ -96848,6 +99214,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="25" y="16">
@@ -96859,6 +99230,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="26" y="16">
         <component type="WallComponent">
@@ -96868,6 +99244,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="27" y="16">
@@ -96879,6 +99260,16 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="28" y="16">
         <component type="WallComponent">
@@ -96888,6 +99279,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="29" y="16">
@@ -96899,8 +99295,181 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="30" y="16">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="36" y="16">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="16">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="38" y="16">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="39" y="16">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="40" y="16">
+        <component type="FloorComponent">
+          <color r="150" g="138" b="127" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>77</openId>
+          <closedId>65</closedId>
+          <secretId>28</secretId>
+          <destroyedId>83</destroyedId>
+        </component>
+      </tile>
+      <tile x="41" y="16">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="42" y="16">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="43" y="16">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="44" y="16">
+        <component type="FloorComponent">
+          <color r="125" g="125" b="125" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>77</openId>
+          <closedId>65</closedId>
+          <secretId>28</secretId>
+          <destroyedId>83</destroyedId>
+        </component>
+      </tile>
+      <tile x="45" y="16">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="16">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="16">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="16">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="51" y="16">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="52" y="16">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="16">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="54" y="16">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="16">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="1" y="17">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -96917,14 +99486,6 @@
         </component>
       </tile>
       <tile x="3" y="17">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="4" y="17">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
@@ -96934,14 +99495,22 @@
           <ruins>44</ruins>
         </component>
       </tile>
+      <tile x="4" y="17">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
       <tile x="5" y="17">
+        <component type="ObstructionComponent">
+          <obstruction>166</obstruction>
+        </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="6" y="17">
-        <component type="ObstructionComponent">
-          <obstruction>166</obstruction>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -97041,6 +99610,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="16" y="17">
         <component type="FloorComponent">
@@ -97062,6 +99636,11 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="18" y="17">
         <component type="FloorComponent">
@@ -97075,6 +99654,16 @@
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
@@ -97102,6 +99691,11 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="24" y="17">
         <component type="FloorComponent">
@@ -97127,6 +99721,11 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="28" y="17">
         <component type="FloorComponent">
@@ -97142,8 +99741,188 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="30" y="17">
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="36" y="17">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="17">
+        <component type="FloorComponent">
+          <color r="127" g="120" b="121" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>27</secretId>
+          <destroyedId>82</destroyedId>
+        </component>
+      </tile>
+      <tile x="38" y="17">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="39" y="17">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="40" y="17">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="41" y="17">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="42" y="17">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="43" y="17">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="17">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="17">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="17">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="17">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="17">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="52" y="17">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="53" y="17">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="54" y="17">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="99" g="93" b="93" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="17">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="1" y="18">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -97160,11 +99939,13 @@
         </component>
       </tile>
       <tile x="3" y="18">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>26</wall>
+          <destroyed>39</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="18">
@@ -97172,22 +99953,12 @@
           <ground>6</ground>
         </component>
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
       <tile x="5" y="18">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="6" y="18">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
@@ -97202,12 +99973,20 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="18">
-        <component type="Darkness">
-          <allowDispel>true</allowDispel>
+      <tile x="6" y="18">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+      </tile>
+      <tile x="7" y="18">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="18">
@@ -97274,6 +100053,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="16" y="18">
         <component type="FloorComponent">
@@ -97282,6 +100066,11 @@
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
@@ -97297,6 +100086,16 @@
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
@@ -97320,6 +100119,11 @@
         <component type="ObstructionComponent">
           <obstruction>165</obstruction>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="20" y="18">
         <component type="FloorComponent">
@@ -97328,6 +100132,11 @@
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
@@ -97361,6 +100170,16 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="24" y="18">
         <component type="FloorComponent">
@@ -97369,6 +100188,11 @@
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
@@ -97402,6 +100226,16 @@
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="28" y="18">
         <component type="FloorComponent">
@@ -97410,6 +100244,11 @@
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
@@ -97427,6 +100266,16 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="30" y="18">
         <component type="WallComponent">
@@ -97436,7 +100285,181 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="3" y="19">
+      <tile x="36" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="37" y="18">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="38" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="39" y="18">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="40" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="41" y="18">
+        <component type="FloorComponent">
+          <color r="123" g="118" b="114" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>27</secretId>
+          <destroyedId>82</destroyedId>
+        </component>
+      </tile>
+      <tile x="42" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="18">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
+      <tile x="44" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="18">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+        <component type="DoorComponent">
+          <openId>76</openId>
+          <closedId>64</closedId>
+          <secretId>27</secretId>
+          <destroyedId>82</destroyedId>
+        </component>
+      </tile>
+      <tile x="46" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="18">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="18">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="FloorComponent">
+          <color r="121" g="118" b="120" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="18">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="54" y="18">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="55" y="18">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="19">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -97444,7 +100467,7 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="4" y="19">
+      <tile x="3" y="19">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
@@ -97454,14 +100477,22 @@
           <ruins>44</ruins>
         </component>
       </tile>
+      <tile x="4" y="19">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
       <tile x="5" y="19">
+        <component type="ObstructionComponent">
+          <obstruction>166</obstruction>
+        </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="6" y="19">
-        <component type="ObstructionComponent">
-          <obstruction>166</obstruction>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -97548,23 +100579,34 @@
         </component>
       </tile>
       <tile x="15" y="19">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="16" y="19">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <teleporterId>9</teleporterId>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="17" y="19">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <teleporterId>9</teleporterId>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="18" y="19">
@@ -97578,8 +100620,11 @@
         </component>
       </tile>
       <tile x="20" y="19">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="21" y="19">
@@ -97593,13 +100638,19 @@
         </component>
       </tile>
       <tile x="23" y="19">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="24" y="19">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="25" y="19">
@@ -97618,8 +100669,11 @@
         </component>
       </tile>
       <tile x="28" y="19">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="29" y="19">
@@ -97631,6 +100685,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="30" y="19">
         <component type="WallComponent">
@@ -97640,87 +100699,185 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="33" y="19">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="34" y="19">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="35" y="19">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
+      <tile x="33" y="19" />
+      <tile x="34" y="19" />
+      <tile x="35" y="19" />
       <tile x="36" y="19">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="19">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="38" y="19">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="106" g="105" b="106" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="39" y="19">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="19">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="41" y="19">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="42" y="19">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="97" g="99" b="101" a="255" />
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="19">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="19">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="19">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="19">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="19">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="51" y="19">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="19">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="19">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="54" y="19">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="55" y="19">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <color r="93" g="95" b="95" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="56" y="19">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="57" y="19">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="20">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -97729,11 +100886,13 @@
         </component>
       </tile>
       <tile x="3" y="20">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>26</wall>
+          <destroyed>39</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="20">
@@ -97741,22 +100900,12 @@
           <ground>6</ground>
         </component>
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
       <tile x="5" y="20">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="6" y="20">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
@@ -97771,12 +100920,20 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="20">
-        <component type="Darkness">
-          <allowDispel>true</allowDispel>
+      <tile x="6" y="20">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+      </tile>
+      <tile x="7" y="20">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="20">
@@ -97835,18 +100992,23 @@
         </component>
       </tile>
       <tile x="15" y="20">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="16" y="20">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <teleporterId>9</teleporterId>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="17" y="20">
@@ -97865,8 +101027,11 @@
         </component>
       </tile>
       <tile x="20" y="20">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="21" y="20">
@@ -97882,6 +101047,9 @@
       <tile x="23" y="20">
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="24" y="20">
@@ -97900,8 +101068,11 @@
         </component>
       </tile>
       <tile x="27" y="20">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="28" y="20">
@@ -97918,6 +101089,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="30" y="20">
         <component type="WallComponent">
@@ -97927,105 +101103,171 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="33" y="20">
+      <tile x="33" y="20" />
+      <tile x="34" y="20" />
+      <tile x="35" y="20" />
+      <tile x="36" y="20">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="34" y="20">
-        <component type="WallComponent">
-          <wall>32</wall>
-          <destroyed>0</destroyed>
-          <ruins>0</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="35" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="36" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
       <tile x="37" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="38" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="39" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="40" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="116" g="116" b="112" a="255" />
           <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>77</openId>
+          <closedId>65</closedId>
+          <secretId>28</secretId>
+          <destroyedId>83</destroyedId>
         </component>
       </tile>
       <tile x="41" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="42" y="20">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="20">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="44" y="20">
+        <component type="FloorComponent">
+          <color r="118" g="110" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>77</openId>
+          <closedId>65</closedId>
+          <secretId>28</secretId>
+          <destroyedId>83</destroyedId>
+        </component>
+      </tile>
+      <tile x="45" y="20">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="20">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="50" y="20">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="20">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>53</destinationX>
+          <destinationY>25</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+      </tile>
+      <tile x="52" y="20">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="53" y="20">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="54" y="20">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="55" y="20">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="56" y="20">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>53</destinationX>
+          <destinationY>25</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+      </tile>
+      <tile x="57" y="20">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="21">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -98034,14 +101276,6 @@
         </component>
       </tile>
       <tile x="3" y="21">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="4" y="21">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
@@ -98051,12 +101285,12 @@
           <ruins>44</ruins>
         </component>
       </tile>
-      <tile x="5" y="21">
+      <tile x="4" y="21">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="6" y="21">
+      <tile x="5" y="21">
         <component type="ObstructionComponent">
           <obstruction>166</obstruction>
         </component>
@@ -98064,7 +101298,7 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="21">
+      <tile x="6" y="21">
         <component type="Darkness">
           <allowDispel>true</allowDispel>
         </component>
@@ -98072,12 +101306,20 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="8" y="21">
-        <component type="Darkness">
-          <allowDispel>true</allowDispel>
+      <tile x="7" y="21">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+      </tile>
+      <tile x="8" y="21">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="9" y="21">
@@ -98145,13 +101387,13 @@
         </component>
       </tile>
       <tile x="15" y="21">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="16" y="21">
@@ -98245,13 +101487,19 @@
         </component>
       </tile>
       <tile x="26" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="27" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="28" y="21">
@@ -98268,6 +101516,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="30" y="21">
         <component type="WallComponent">
@@ -98277,88 +101530,290 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="33" y="21">
+      <tile x="33" y="21" />
+      <tile x="34" y="21" />
+      <tile x="35" y="21" />
+      <tile x="36" y="21">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="34" y="21">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="35" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>173</static>
-        </component>
-      </tile>
-      <tile x="36" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>173</static>
-        </component>
-      </tile>
       <tile x="37" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>437</static>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="21">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="41" y="21">
-        <component type="HiddenTeleporterComponent">
-          <destinationX>37</destinationX>
-          <destinationY>-21</destinationY>
-          <destinationRegion>1</destinationRegion>
-          <lightphases select="all" />
-          <moonphases select="all" />
-          <professions select="all" />
-          <alignments select="all" />
-        </component>
-        <component type="FloorComponent">
-          <ground>2</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="42" y="21">
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="43" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
       </tile>
-      <tile x="43" y="21">
+      <tile x="45" y="21">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="21">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="21">
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="50" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="51" y="21">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="52" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>980</static>
+        </component>
+      </tile>
+      <tile x="53" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="54" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="55" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>980</static>
+        </component>
+      </tile>
+      <tile x="56" y="21">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="57" y="21">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="58" y="21">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>933</static>
+        </component>
+      </tile>
+      <tile x="2" y="22">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -98367,11 +101822,13 @@
         </component>
       </tile>
       <tile x="3" y="22">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>26</wall>
+          <destroyed>39</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="22">
@@ -98379,22 +101836,12 @@
           <ground>6</ground>
         </component>
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
+          <wall>25</wall>
+          <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
       </tile>
       <tile x="5" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-      </tile>
-      <tile x="6" y="22">
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
@@ -98404,6 +101851,14 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="6" y="22">
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -98470,18 +101925,20 @@
         </component>
       </tile>
       <tile x="15" y="22">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="16" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
         </component>
       </tile>
       <tile x="17" y="22">
@@ -98569,11 +102026,15 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="27" y="22">
@@ -98585,6 +102046,9 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="29" y="22">
         <component type="WallComponent">
@@ -98594,6 +102058,11 @@
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="30" y="22">
@@ -98614,85 +102083,170 @@
       </tile>
       <tile x="32" y="22">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="33" y="22">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="34" y="22">
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="StaticComponent">
-          <static>221</static>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="35" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>167</static>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>173</static>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="39" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="40" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="41" y="22">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
-      <tile x="42" y="22">
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
+      </tile>
+      <tile x="39" y="22" />
+      <tile x="40" y="22" />
+      <tile x="41" y="22" />
+      <tile x="42" y="22" />
+      <tile x="43" y="22" />
+      <tile x="44" y="22">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="22">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
-      <tile x="43" y="22">
+      <tile x="46" y="22">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="22">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>934</static>
+        </component>
+      </tile>
+      <tile x="50" y="22">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="51" y="22">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="52" y="22">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="53" y="22">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="54" y="22">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="55" y="22">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="56" y="22">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="57" y="22">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="58" y="22">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="2" y="23">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -98718,14 +102272,6 @@
       </tile>
       <tile x="5" y="23">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="6" y="23">
-        <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
@@ -98734,9 +102280,20 @@
           <ground>6</ground>
         </component>
       </tile>
+      <tile x="6" y="23">
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
+        </component>
+      </tile>
       <tile x="7" y="23">
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="8" y="23">
@@ -98745,13 +102302,19 @@
         </component>
       </tile>
       <tile x="9" y="23">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="10" y="23">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="11" y="23">
@@ -98789,18 +102352,18 @@
         </component>
       </tile>
       <tile x="15" y="23">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="16" y="23">
@@ -98928,6 +102491,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="23">
@@ -98939,6 +102503,9 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="28" y="23">
         <component type="FloorComponent">
@@ -98946,18 +102513,13 @@
         </component>
       </tile>
       <tile x="29" y="23">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="30" y="23">
@@ -98969,6 +102531,11 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="31" y="23">
         <component type="WallComponent">
@@ -98979,53 +102546,42 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-      </tile>
-      <tile x="32" y="23">
         <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
+          <wall>145</wall>
+          <destroyed>147</destroyed>
           <ruins>44</ruins>
         </component>
+      </tile>
+      <tile x="32" y="23">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="33" y="23">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="34" y="23">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="StaticComponent">
-          <static>221</static>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="35" y="23">
         <component type="FloorComponent">
           <ground>6</ground>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="36" y="23">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="37" y="23">
@@ -99034,36 +102590,160 @@
         </component>
       </tile>
       <tile x="38" y="23">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
         <component type="FloorComponent">
+          <color r="106" g="105" b="106" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="39" y="23">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="40" y="23">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="41" y="23">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="42" y="23">
         <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="43" y="23">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="44" y="23">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="23">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="23">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="23">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>934</static>
+        </component>
+      </tile>
+      <tile x="50" y="23">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="51" y="23">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="52" y="23">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="53" y="23">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="54" y="23">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="55" y="23">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="56" y="23">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="57" y="23">
+        <component type="FloorComponent">
+          <ground>6</ground>
+          <movementCost>2</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="58" y="23">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="4" y="24">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -99073,18 +102753,15 @@
       </tile>
       <tile x="5" y="24">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="6" y="24">
-        <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="6" y="24">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
@@ -99100,8 +102777,11 @@
         </component>
       </tile>
       <tile x="9" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="10" y="24">
@@ -99125,13 +102805,19 @@
         </component>
       </tile>
       <tile x="14" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="15" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="16" y="24">
@@ -99143,6 +102829,9 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="18" y="24">
         <component type="FloorComponent">
@@ -99150,8 +102839,11 @@
         </component>
       </tile>
       <tile x="19" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="20" y="24">
@@ -99160,8 +102852,11 @@
         </component>
       </tile>
       <tile x="21" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
         </component>
       </tile>
       <tile x="22" y="24">
@@ -99181,8 +102876,11 @@
         </component>
       </tile>
       <tile x="24" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
         </component>
       </tile>
       <tile x="25" y="24">
@@ -99193,6 +102891,9 @@
       <tile x="26" y="24">
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="27" y="24">
@@ -99206,8 +102907,11 @@
         </component>
       </tile>
       <tile x="29" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="30" y="24">
@@ -99226,36 +102930,40 @@
         </component>
       </tile>
       <tile x="33" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="34" y="24">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="StaticComponent">
-          <static>244</static>
-        </component>
       </tile>
       <tile x="35" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="36" y="24">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="37" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="38" y="24">
@@ -99264,31 +102972,150 @@
         </component>
       </tile>
       <tile x="39" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
         </component>
       </tile>
       <tile x="40" y="24">
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="41" y="24">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="42" y="24">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="24">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+      </tile>
+      <tile x="44" y="24">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="24">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="46" y="24">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="24">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>981</static>
+        </component>
+      </tile>
+      <tile x="50" y="24">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="51" y="24">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="52" y="24">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="53" y="24">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="Darkness" />
+      </tile>
+      <tile x="54" y="24">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="55" y="24">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="56" y="24">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="57" y="24">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="58" y="24">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="4" y="25">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -99298,14 +103125,6 @@
       </tile>
       <tile x="5" y="25">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="6" y="25">
-        <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
@@ -99314,14 +103133,25 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="25">
+      <tile x="6" y="25">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
+      <tile x="7" y="25">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
       <tile x="8" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="9" y="25">
@@ -99333,6 +103163,9 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="11" y="25">
         <component type="FloorComponent">
@@ -99340,8 +103173,11 @@
         </component>
       </tile>
       <tile x="12" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="13" y="25">
@@ -99355,8 +103191,11 @@
         </component>
       </tile>
       <tile x="15" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="16" y="25">
@@ -99370,8 +103209,11 @@
         </component>
       </tile>
       <tile x="18" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="19" y="25">
@@ -99420,6 +103262,9 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="26" y="25">
         <component type="FloorComponent">
@@ -99432,13 +103277,21 @@
         </component>
       </tile>
       <tile x="28" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="29" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
         </component>
       </tile>
       <tile x="30" y="25">
@@ -99452,72 +103305,208 @@
         </component>
       </tile>
       <tile x="32" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="33" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="34" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="DoorComponent">
-          <openId>75</openId>
-          <closedId>63</closedId>
-          <secretId>26</secretId>
-          <destroyedId>81</destroyedId>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="35" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="25">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
       </tile>
       <tile x="40" y="25">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="41" y="25">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="42" y="25">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="43" y="25">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
+        </component>
+      </tile>
+      <tile x="44" y="25">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="45" y="25">
+        <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
+          <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="46" y="25">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="25">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>981</static>
+        </component>
+      </tile>
+      <tile x="50" y="25">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="51" y="25">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="52" y="25">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness" />
+      </tile>
+      <tile x="53" y="25">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="54" y="25">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness" />
+      </tile>
+      <tile x="55" y="25">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="56" y="25">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="57" y="25">
+        <component type="PoisonedWaterComponent">
+          <color r="112" g="118" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>54</destinationX>
+          <destinationY>20</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
+      </tile>
+      <tile x="58" y="25">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="59" y="25" />
+      <tile x="4" y="26">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -99527,14 +103516,6 @@
       </tile>
       <tile x="5" y="26">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
-        </component>
-      </tile>
-      <tile x="6" y="26">
-        <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
@@ -99543,9 +103524,17 @@
           <ground>6</ground>
         </component>
       </tile>
-      <tile x="7" y="26">
+      <tile x="6" y="26">
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+      </tile>
+      <tile x="7" y="26">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="8" y="26">
@@ -99564,13 +103553,19 @@
         </component>
       </tile>
       <tile x="11" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="12" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="13" y="26">
@@ -99594,8 +103589,11 @@
         </component>
       </tile>
       <tile x="17" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="18" y="26">
@@ -99614,8 +103612,11 @@
         </component>
       </tile>
       <tile x="21" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
         </component>
       </tile>
       <tile x="22" y="26">
@@ -99635,8 +103636,11 @@
         </component>
       </tile>
       <tile x="24" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
         </component>
       </tile>
       <tile x="25" y="26">
@@ -99650,13 +103654,19 @@
         </component>
       </tile>
       <tile x="27" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="28" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="29" y="26">
@@ -99685,24 +103695,27 @@
         </component>
       </tile>
       <tile x="34" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-        <component type="DoorComponent">
-          <openId>75</openId>
-          <closedId>63</closedId>
-          <secretId>26</secretId>
-          <destroyedId>81</destroyedId>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="35" y="26">
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
       </tile>
       <tile x="36" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="37" y="26">
@@ -99716,31 +103729,148 @@
         </component>
       </tile>
       <tile x="39" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="SkyComponent">
+          <destinationX>7</destinationX>
+          <destinationY>7</destinationY>
+          <destinationRegion>6</destinationRegion>
+          <teleporterId>9</teleporterId>
         </component>
       </tile>
       <tile x="40" y="26">
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="41" y="26">
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="42" y="26">
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
+          <color r="103" g="103" b="103" a="255" />
           <ground>6</ground>
         </component>
       </tile>
       <tile x="43" y="26">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
+        </component>
+      </tile>
+      <tile x="44" y="26">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="45" y="26">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="46" y="26">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="26">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>934</static>
+        </component>
+      </tile>
+      <tile x="50" y="26">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="51" y="26">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="52" y="26">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="53" y="26">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness" />
+      </tile>
+      <tile x="54" y="26">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="55" y="26">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="56" y="26">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="57" y="26">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="58" y="26">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="RopeComponent">
+          <teleporterId>255</teleporterId>
+        </component>
+      </tile>
+      <tile x="4" y="27">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -99750,10 +103880,12 @@
       </tile>
       <tile x="5" y="27">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>26</wall>
+          <destroyed>39</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>6</ground>
         </component>
       </tile>
       <tile x="6" y="27">
@@ -99960,20 +104092,10 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
       </tile>
       <tile x="27" y="27">
         <component type="FloorComponent">
           <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="28" y="27">
@@ -100017,126 +104139,174 @@
         </component>
       </tile>
       <tile x="32" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="33" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="34" y="27">
         <component type="FloorComponent">
           <ground>6</ground>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
+          <movementCost>2</movementCost>
         </component>
       </tile>
       <tile x="35" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="36" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="37" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="255" b="0" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>8</potency>
         </component>
       </tile>
       <tile x="38" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
       </tile>
       <tile x="39" y="27">
-        <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
         <component type="FloorComponent">
           <ground>6</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>355</wall>
+          <destroyed>356</destroyed>
+          <ruins>669</ruins>
         </component>
       </tile>
       <tile x="40" y="27">
         <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="41" y="27">
         <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="42" y="27">
         <component type="WallComponent">
-          <wall>25</wall>
-          <destroyed>38</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="WallComponent">
-          <wall>26</wall>
-          <destroyed>39</destroyed>
-          <ruins>44</ruins>
-        </component>
-        <component type="FloorComponent">
-          <ground>6</ground>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="43" y="27">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="49" y="27">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>934</static>
+        </component>
+      </tile>
+      <tile x="50" y="27">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="51" y="27">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="52" y="27">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="53" y="27">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="54" y="27">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="55" y="27">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="56" y="27">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="57" y="27">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="58" y="27">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="4" y="28">
         <component type="WallComponent">
           <wall>31</wall>
           <destroyed>0</destroyed>
@@ -100311,21 +104481,42 @@
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="WallComponent">
+          <wall>336</wall>
+          <destroyed>345</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="26" y="28">
-        <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        <component type="DoorComponent">
+          <openId>74</openId>
+          <closedId>62</closedId>
+          <secretId>25</secretId>
+          <destroyedId>80</destroyedId>
+        </component>
+        <component type="FloorComponent">
+          <ground>12</ground>
         </component>
       </tile>
       <tile x="27" y="28">
+        <component type="FloorComponent">
+          <ground>1</ground>
+        </component>
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>335</wall>
+          <destroyed>344</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>336</wall>
+          <destroyed>345</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="28" y="28">
@@ -100335,6 +104526,17 @@
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="29" y="28">
         <component type="WallComponent">
@@ -100342,6 +104544,17 @@
           <destroyed>0</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
+        </component>
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
         </component>
       </tile>
       <tile x="30" y="28">
@@ -100351,6 +104564,11 @@
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="31" y="28">
         <component type="WallComponent">
@@ -100359,119 +104577,450 @@
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
       </tile>
       <tile x="32" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="33" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="34" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="35" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
-      </tile>
-      <tile x="40" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="41" y="28">
+      <tile x="40" y="28" />
+      <tile x="41" y="28" />
+      <tile x="42" y="28" />
+      <tile x="43" y="28" />
+      <tile x="49" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="StaticComponent">
+          <static>934</static>
+        </component>
       </tile>
-      <tile x="42" y="28">
+      <tile x="50" y="28">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="51" y="28">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="52" y="28">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="53" y="28">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="54" y="28">
+        <component type="PoisonedWaterComponent">
+          <color r="0" g="0" b="255" a="255" />
+          <ground>180</ground>
+          <movementCost>3</movementCost>
+          <potency>7</potency>
+        </component>
+      </tile>
+      <tile x="55" y="28">
+        <component type="FloorComponent">
+          <color r="108" g="103" b="106" a="255" />
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="56" y="28">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="57" y="28">
+        <component type="FloorComponent">
+          <ground>6</ground>
+        </component>
+        <component type="Darkness">
+          <allowDispel>true</allowDispel>
+        </component>
+      </tile>
+      <tile x="58" y="28">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
-          <ruins>44</ruins>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="43" y="28">
+      <tile x="24" y="29" />
+      <tile x="25" y="29">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>336</wall>
+          <destroyed>345</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="34" y="29">
+      <tile x="26" y="29">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="27" y="29">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="28" y="29">
+        <component type="Fire" />
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="29" y="29">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>336</wall>
+          <destroyed>345</destroyed>
           <ruins>44</ruins>
-          <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="35" y="29">
+      <tile x="34" y="29" />
+      <tile x="35" y="29" />
+      <tile x="49" y="29">
         <component type="WallComponent">
-          <wall>31</wall>
-          <destroyed>0</destroyed>
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="StaticComponent">
+          <static>934</static>
+        </component>
+      </tile>
+      <tile x="50" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="51" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="52" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="53" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="54" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="55" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="56" y="29">
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="57" y="29">
+        <component type="DoorComponent">
+          <color r="71" g="71" b="71" a="255" />
+          <openId>1047</openId>
+          <closedId>1046</closedId>
+          <secretId>152</secretId>
+          <destroyedId>1047</destroyedId>
+          <isSecret>true</isSecret>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="FloorComponent">
+          <ground>184</ground>
+        </component>
+      </tile>
+      <tile x="58" y="29">
+        <component type="WallComponent">
+          <wall>334</wall>
+          <destroyed>343</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>333</wall>
+          <destroyed>342</destroyed>
+          <ruins>669</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="24" y="30" />
+      <tile x="25" y="30">
+        <component type="WallComponent">
+          <wall>336</wall>
+          <destroyed>345</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="26" y="30">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="27" y="30">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="28" y="30">
+        <component type="FloorComponent">
+          <ground>12</ground>
+        </component>
+      </tile>
+      <tile x="29" y="30">
+        <component type="WallComponent">
+          <wall>336</wall>
+          <destroyed>345</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="56" y="30">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
           <ruins>44</ruins>
           <indestructible>true</indestructible>
         </component>
       </tile>
+      <tile x="57" y="30">
+        <component type="HiddenTeleporterComponent">
+          <destinationX>37</destinationX>
+          <destinationY>-21</destinationY>
+          <destinationRegion>1</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
+        <component type="FloorComponent">
+          <ground>2</ground>
+        </component>
+      </tile>
+      <tile x="58" y="30">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="24" y="31" />
+      <tile x="25" y="31">
+        <component type="WallComponent">
+          <wall>336</wall>
+          <destroyed>345</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="26" y="31">
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="27" y="31">
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="28" y="31">
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="29" y="31">
+        <component type="DoorComponent">
+          <openId>47</openId>
+          <closedId>35</closedId>
+          <secretId>139</secretId>
+          <destroyedId>37</destroyedId>
+        </component>
+        <component type="WallComponent">
+          <wall>336</wall>
+          <destroyed>345</destroyed>
+          <ruins>44</ruins>
+        </component>
+        <component type="WallComponent">
+          <wall>335</wall>
+          <destroyed>344</destroyed>
+          <ruins>44</ruins>
+        </component>
+      </tile>
+      <tile x="56" y="31">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="57" y="31">
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="58" y="31">
+        <component type="WallComponent">
+          <wall>146</wall>
+          <destroyed>148</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+        <component type="WallComponent">
+          <wall>145</wall>
+          <destroyed>147</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
+      </tile>
+      <tile x="29" y="32" />
     </region>
     <region>
       <id>7</id>
@@ -112495,6 +117044,11 @@
         <rectangle left="-49" top="34" right="25" bottom="59" />
       </rectangles>
     </subregion>
+    <subregion name="Thief Lair" type="Lair" region="6">
+      <rectangles>
+        <rectangle left="0" top="2" right="57" bottom="31" />
+      </rectangles>
+    </subregion>
   </subregions>
   <entities>
     <entity name="Level12NormEntranceGnollGuard">
@@ -115003,7 +119557,7 @@ if (spokeRecently(source))
 	   MaxHealth = 180, Health = 180,
 	   BaseDodge = 25,
 	   BasePenetration = ShieldPenetration.Light,
-	   HideDetection = 50,
+	   HideDetection = 32,
 	   Experience = 10000,
 	   CanSwim = false,
 	   Immunity = CreatureImmunity.Poison,
@@ -115052,7 +119606,7 @@ return skeleton;
         Name = "Skeleton Assassin",
         MaxHealth = 234, Health = 234,
         BaseDodge = 27,
-        HideDetection = 50,
+        HideDetection = 32,
         Experience = 13000,  
         CanJumpkick = true,
         CanSwim = true,
@@ -115066,22 +119620,22 @@ return skeleton;
     skelninja.AddStatus(new NightVisionStatus(skelninja));
     skelninja.AddStatus(new BreatheWaterStatus(skelninja));
     
-    skelninja.CombatantChangeInterval = TimeSpan.FromSeconds(4.0);
+    skelninja.CombatantChangeInterval = TimeSpan.FromSeconds(5.0);
     
     skelninja.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(18,      10, 30,      "Skeleton Assassin hits you with a flurry of fists.",
+            new CreatureAttack(18,      5, 15,      "Skeleton Assassin hits you with a flurry of fists.",
                                                         new AttackProneComponent(5), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(18,      25, 35,     "Skeleton Assassin slams his bony fist into your chest.",
+            new CreatureAttack(18,      15, 25,     "Skeleton Assassin slams his bony fist into your chest.",
                                                         new AttackProneComponent(10), 
                                                         new AttackStunComponent(5)),               40
         },
         {
-            new CreatureAttack(19,      30, 45,     "Skeleton Assassin knocks you back with a forceful kick.",
+            new CreatureAttack(19,      15, 30,     "Skeleton Assassin knocks you back with a forceful kick.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),               20
         },
@@ -115125,10 +119679,10 @@ return skeleton;
     var swordmaster = new Skeleton()
     {
         Name = "Dartanian",
-        Body = 163,
+        Body = 460,
         MaxHealth = 2700, Health = 2700,
         BaseDodge = 21,
-        HideDetection = 50,
+        HideDetection = 34,
         Experience = 123000,
        
         CanCharge = true,
@@ -115144,7 +119698,7 @@ return skeleton;
     
     swordmaster.Attacks = new CreatureAttackCollection()
     {
-        new CreatureAttack(19,    55, 77,     "The swordmaster pierces you with his rapier.",
+        new CreatureAttack(19,    55, 77,     "Dartanian PIERCES you with his rapier.",
                                                     new AttackAgeComponent(250, 50))
     };
     
@@ -118112,7 +122666,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="Level16NormThiefBane" size="1" minimum="1" maximum="1" />
-      <location x="5" y="11" region="6" />
+      <location x="4" y="11" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Thief Bane 2">
       <minimumDelay>-180</minimumDelay>
@@ -118154,7 +122708,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="Level16NormThiefBane" size="1" minimum="1" maximum="1" />
-      <location x="5" y="13" region="6" />
+      <location x="4" y="13" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Thief Bane 4">
       <minimumDelay>180</minimumDelay>
@@ -118196,7 +122750,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="Level16NormThiefBane" size="1" minimum="1" maximum="1" />
-      <location x="5" y="15" region="6" />
+      <location x="4" y="15" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Thief Bane 6">
       <minimumDelay>180</minimumDelay>
@@ -118238,7 +122792,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="Level16NormThiefBane" size="1" minimum="1" maximum="1" />
-      <location x="5" y="17" region="6" />
+      <location x="4" y="17" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Thief Bane 8">
       <minimumDelay>180</minimumDelay>
@@ -118280,7 +122834,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="Level16NormThiefBane" size="1" minimum="1" maximum="1" />
-      <location x="5" y="19" region="6" />
+      <location x="4" y="19" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Thief Bane 10">
       <minimumDelay>180</minimumDelay>
@@ -118322,7 +122876,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="Level16NormThiefBane" size="1" minimum="1" maximum="1" />
-      <location x="5" y="21" region="6" />
+      <location x="4" y="21" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Thief Lair">
       <minimumDelay>4500</minimumDelay>
@@ -118343,7 +122897,7 @@ if (spokeRecently(source))
         <block><![CDATA[]]></block>
       </script>
       <entry entity="BossMinorLevel16Dartanian" size="1" minimum="1" maximum="1" />
-      <location x="38" y="24" region="6" />
+      <location x="50" y="24" region="6" />
     </spawn>
     <spawn type="LocationSpawner" name="Gem Dark Hall Trap 1">
       <minimumDelay>900</minimumDelay>
@@ -119135,6 +123689,65 @@ if (spokeRecently(source))
       </script>
       <entry entity="Level17PlayfulKitten" size="1" minimum="1" maximum="1" />
       <location x="13" y="43" region="4" />
+    </spawn>
+    <spawn type="LocationSpawner" name="ThiefLairConcTrap1">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="HallTrapsConc" size="1" minimum="1" maximum="1" />
+      <location x="45" y="13" region="6" />
+    </spawn>
+    <spawn type="LocationSpawner" name="ThiefLairFirestormTrap">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <location x="41" y="16" region="6" />
+    </spawn>
+    <spawn type="LocationSpawner" name="ThiefLairConcTrap2">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="HallTrapsConc" size="1" minimum="1" maximum="1" />
+      <location x="37" y="15" region="6" />
     </spawn>
     <spawn type="RegionSpawner" name="EntranceBlacksmith">
       <minimumDelay>900</minimumDelay>
@@ -120809,6 +125422,54 @@ if (spokeRecently(source))
       <bounds region="7">
         <inclusion left="49" top="21" right="56" bottom="25" />
         <inclusion left="55" top="12" right="55" bottom="25" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="Thief Lair Door Traps">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="Level16HighThiefNinja" size="1" minimum="4" maximum="4" />
+      <entry entity="Level16NormThiefBane" size="1" minimum="4" maximum="4" />
+      <bounds region="6">
+        <inclusion left="37" top="12" right="45" bottom="20" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="New Thief Lair Spawner">
+      <minimumDelay>900</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="Level16NormThiefBane" size="1" minimum="4" maximum="4" />
+      <entry entity="Level16HighThiefNinja" size="1" minimum="4" maximum="4" />
+      <bounds region="6">
+        <inclusion left="51" top="7" right="54" bottom="16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -97185,20 +97185,7 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="20" y="10">
-        <component type="HiddenTeleporterComponent">
-          <destinationX>37</destinationX>
-          <destinationY>-21</destinationY>
-          <destinationRegion>1</destinationRegion>
-          <lightphases select="all" />
-          <moonphases select="all" />
-          <professions select="all" />
-          <alignments select="all" />
-        </component>
-        <component type="FloorComponent">
-          <ground>2</ground>
-        </component>
-      </tile>
+      <tile x="20" y="10" />
       <tile x="33" y="10">
         <component type="WallComponent">
           <wall>334</wall>
@@ -97763,11 +97750,7 @@
           <indestructible>true</indestructible>
         </component>
       </tile>
-      <tile x="21" y="12">
-        <component type="FloorComponent">
-          <ground>6</ground>
-        </component>
-      </tile>
+      <tile x="21" y="12" />
       <tile x="35" y="12">
         <component type="WallComponent">
           <wall>334</wall>
@@ -103504,6 +103487,9 @@
           <ruins>669</ruins>
           <indestructible>true</indestructible>
         </component>
+        <component type="RopeComponent">
+          <teleporterId>255</teleporterId>
+        </component>
       </tile>
       <tile x="59" y="25" />
       <tile x="4" y="26">
@@ -103865,9 +103851,6 @@
           <destroyed>343</destroyed>
           <ruins>669</ruins>
           <indestructible>true</indestructible>
-        </component>
-        <component type="RopeComponent">
-          <teleporterId>255</teleporterId>
         </component>
       </tile>
       <tile x="4" y="27">

--- a/Segments/Blackburrow.mapproj
+++ b/Segments/Blackburrow.mapproj
@@ -95281,6 +95281,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="1">
@@ -95374,6 +95375,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="3">
@@ -95560,6 +95562,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="35" y="4">
@@ -95836,6 +95839,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="34" y="5">
@@ -95876,6 +95880,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="5">
@@ -96204,6 +96209,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="33" y="6">
@@ -96244,6 +96250,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="6">
@@ -96392,6 +96399,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -96472,6 +96480,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="7">
@@ -96523,6 +96532,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="36" y="7">
@@ -96550,6 +96560,7 @@
           <wall>355</wall>
           <destroyed>356</destroyed>
           <ruins>669</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="44" y="7">
@@ -96678,6 +96689,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -96753,6 +96765,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="8">
@@ -96885,6 +96898,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -96953,6 +96967,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="9">
@@ -97117,6 +97132,12 @@
           <destroyed>38</destroyed>
           <ruins>44</ruins>
         </component>
+        <component type="WallComponent">
+          <wall>26</wall>
+          <destroyed>39</destroyed>
+          <ruins>44</ruins>
+          <indestructible>true</indestructible>
+        </component>
       </tile>
       <tile x="4" y="10">
         <component type="WallComponent">
@@ -97132,6 +97153,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="10">
@@ -97200,6 +97222,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="10">
@@ -97456,6 +97479,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="11">
@@ -97716,11 +97740,13 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -98300,11 +98326,13 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -98634,6 +98662,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="15">
@@ -98641,6 +98670,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -99035,11 +99065,13 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -99581,6 +99613,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="17">
@@ -99588,6 +99621,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -99999,11 +100033,13 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -100108,6 +100144,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="18">
@@ -100128,11 +100165,13 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="18">
@@ -100159,6 +100198,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="18">
@@ -100174,6 +100214,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="18">
@@ -100210,6 +100251,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>146</wall>
@@ -100230,6 +100272,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="25" y="18">
@@ -100266,11 +100309,13 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="28" y="18">
@@ -100286,6 +100331,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="29" y="18">
@@ -100563,6 +100609,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="19">
@@ -100570,6 +100617,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -100622,6 +100670,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="19">
@@ -100947,11 +100996,13 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -101036,6 +101087,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="20">
@@ -101367,6 +101419,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="21">
@@ -101374,6 +101427,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -101389,6 +101443,7 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
@@ -101431,6 +101486,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="21">
@@ -101883,11 +101939,13 @@
           <wall>25</wall>
           <destroyed>38</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -101932,6 +101990,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -101969,6 +102028,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="22">
@@ -102312,6 +102372,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -102359,6 +102420,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -102396,11 +102458,13 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="23">
@@ -102557,6 +102621,7 @@
           <wall>146</wall>
           <destroyed>148</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="30" y="23">
@@ -102572,6 +102637,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="31" y="23">
@@ -102587,6 +102653,7 @@
           <wall>145</wall>
           <destroyed>147</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="32" y="23">
@@ -102793,6 +102860,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -103165,6 +103233,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -103562,6 +103631,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -103923,6 +103993,7 @@
           <wall>26</wall>
           <destroyed>39</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="FloorComponent">
           <ground>6</ground>
@@ -104525,6 +104596,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="28">
@@ -104552,11 +104624,13 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="28" y="28">
@@ -104576,6 +104650,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="29" y="28">
@@ -104595,6 +104670,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="30" y="28">
@@ -104608,6 +104684,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="31" y="28">
@@ -104621,6 +104698,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="32" y="28">
@@ -104780,6 +104858,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="29">
@@ -104803,6 +104882,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="34" y="29" />
@@ -104911,6 +104991,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="30">
@@ -104933,6 +105014,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="56" y="30">
@@ -104971,6 +105053,7 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="26" y="31">
@@ -104984,6 +105067,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="27" y="31">
@@ -104997,6 +105081,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="28" y="31">
@@ -105010,6 +105095,7 @@
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="29" y="31">
@@ -105023,11 +105109,13 @@
           <wall>336</wall>
           <destroyed>345</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>335</wall>
           <destroyed>344</destroyed>
           <ruins>44</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="56" y="31">


### PR DESCRIPTION
Updated the Thief Lair of Blackburrow.
Changed damage values for lair minions.
Extended Thief lair with traps and shadowstepping encouragement.

Fixed 1 hex in Kesmai -5. Rubble is visible now.