### PR TITLE
Overlord Loot table Reversion

### DIFF
--- a/Segments/Underkingdom.mapproj
+++ b/Segments/Underkingdom.mapproj
@@ -100380,7 +100380,6 @@
         new LootPackEntry(true, (from, container) => new ClearBalm(),           50),
         new LootPackEntry(true, (from, container) => new PurpleSilkRobe(),           100),
         new LootPackEntry(true, (from, container) => new EbonyStaff(),           100),
-        new LootPackEntry(true, (from, container) => new StrongShieldRing(), 5),
         new LootPackEntry(true, overlordTreasure, 100)
     ));
     
@@ -106419,7 +106418,7 @@ var gargoyle = new Gargoyle()
       </entry>
     </treasure>
     <treasure name="overlordTreasure">
-      <entry weight="60">
+      <entry weight="50">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
@@ -106428,11 +106427,20 @@ var gargoyle = new Gargoyle()
           <block><![CDATA[]]></block>
         </script>
       </entry>
-      <entry weight="40">
+      <entry weight="46">
         <script name="OnCreate" enabled="true">
           <block><![CDATA[]]></block>
           <block><![CDATA[
 	return new StunDeathProtectionBracelet();
+]]></block>
+          <block><![CDATA[]]></block>
+        </script>
+      </entry>
+      <entry weight="4">
+        <script name="OnCreate" enabled="true">
+          <block><![CDATA[]]></block>
+          <block><![CDATA[
+	return new StrongShieldRing();
 ]]></block>
           <block><![CDATA[]]></block>
         </script>


### PR DESCRIPTION
Keep SShielder rarer. Vlad already has a flat 6% drop. PP amulet has like 4 more percent higher than S/D.

OG Loot tables:

OL Staff 100%
PP Amulet 100%
S/D Amulet (not sure)
SShielder didn't exist

Lands Loot Table
OL Staff 100%
PP Amulet 100%
S/D Amulet was only in AG
SShielder didn't exist