### PR TITLE
Both Rhammers drop on ground (similar to -4 Kes Rhammer) - Adventurers need to Adventure

### DIFF
--- a/Segments/Axe Glacier.mapproj
+++ b/Segments/Axe Glacier.mapproj
@@ -105886,7 +105886,6 @@
     giant.AddLoot(new LootPack(
         new LootPackEntry(true, AxeGems,       100,     gemsPriceMutatorVeryHigh), 
         new LootPackEntry(true, AxeGems,       100,     gemsPriceMutatorVeryHigh), 
-        new LootPackEntry(true, (from, container) => new ReturningHammer(),        100),
         new LootPackEntry(true, (from, container) => new MoonstoneRing(),        100),
         new LootPackEntry(true, AxePotions,        50)
     ));
@@ -105895,9 +105894,14 @@
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <script name="OnDeath" enabled="false">
+      <script name="OnDeath" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
+    if (killer is PlayerEntity player)
+    {
+        var rhammer = new ReturningHammer();
+        rhammer.Move( player.Location, true, player.Segment );
+    }
 ]]></block>
         <block><![CDATA[]]></block>
       </script>


### PR DESCRIPTION
Giant
Since it is 100% - just drop at feet. No more corpse teleportation.

Ydnac
Add D3 roll for the removal of the group loot. (33.33%) Evaluate if lands on 3 and drop at feet, otherwise bail out. No more corpse teleportation.