### PR TITLE
WorldForge - Add Validation on Save for Region and Location Spawns

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/World/SegmentEntities.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/World/SegmentEntities.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using System.Windows;
 using System.Xml.Linq;
 using Ionic.Zip;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
@@ -156,11 +157,29 @@ namespace Kesmai.WorldForge.Editor
 #else
 		public void Save(XElement element)
 		{
+			string messageForBlankEntities = $" has an entry that is blank. {Environment.NewLine} {Environment.NewLine}" +
+                $"Update prior to Checkin, otherwise compilation errors.";
+
 			foreach (var locationSpawner in Location)
+			{
+				if (locationSpawner.Entries.Count < 1)
+				{
+					MessageBox.Show($"Location Spawner: {locationSpawner.Name} {messageForBlankEntities}", 
+						"Location Spawner Save Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+				}
+
 				element.Add(locationSpawner.GetXElement());
-			
+			}
+
 			foreach (var regionSpawner in Region)
+			{
+				if (regionSpawner.Entries.Count < 1)
+				{
+					MessageBox.Show($"Region Spawner: {regionSpawner.Name} {messageForBlankEntities}",
+						"Region Spawner Save Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+				}
 				element.Add(regionSpawner.GetXElement());
+			}
 		}
 #endif
 	}

--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/World/SegmentEntities.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/World/SegmentEntities.cs
@@ -164,7 +164,7 @@ namespace Kesmai.WorldForge.Editor
 			{
 				if (locationSpawner.Entries.Count < 1)
 				{
-					MessageBox.Show($"Location Spawner: {locationSpawner.Name} {messageForBlankEntities}", 
+					MessageBox.Show($"Location Spawner:{locationSpawner.Name} {messageForBlankEntities}", 
 						"Location Spawner Save Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
 				}
 
@@ -175,7 +175,7 @@ namespace Kesmai.WorldForge.Editor
 			{
 				if (regionSpawner.Entries.Count < 1)
 				{
-					MessageBox.Show($"Region Spawner: {regionSpawner.Name} {messageForBlankEntities}",
+					MessageBox.Show($"Region Spawner:{regionSpawner.Name} {messageForBlankEntities}",
 						"Region Spawner Save Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
 				}
 				element.Add(regionSpawner.GetXElement());


### PR DESCRIPTION
* Ensure Entries are present prior to Save
* Only throw warning and do not bail out. This will ensure XML doesn't save in a bad state.

Added video in: 

https://discord.com/channels/577503035526348810/1085958474363580527/1089923618168918088