### PR TITLE
Oak UD - Tone back down the new scorps and Up mana on liches for 3 casts

### DIFF
--- a/Segments/Oakvael.mapproj
+++ b/Segments/Oakvael.mapproj
@@ -113649,7 +113649,7 @@
 	var lich = new Lich()
     {
         MaxHealth = 99, Health = 99,
-        MaxMana = 14, Mana = 14,
+        MaxMana = 21, Mana = 21,
         BaseDodge = 22,
         HideDetection = 26,
         Experience = 9094,
@@ -115695,11 +115695,12 @@
         <block><![CDATA[
 	var scorpion = new Scorpion()
     {
-        MaxHealth = 250, Health = 250,
+        MaxHealth = 100, Health = 100,
 
-        Experience = 7000,
+        Experience = 4500,
         BaseDodge = 26,
         HideDetection = 25,  
+        VisibilityDistance = 1,
 
         Movement = 2,
         


### PR DESCRIPTION
https://discord.com/channels/577503035526348810/587249411772645406/1104158833846255628

* Noticed the crits only took two-three halberd swings. Adjusting the HP now.
* Re-adjusting the Mana back to 21 for the liches. 

(Both tested on other Emulator)