### PR TITLE
Rapier Fix

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/BlackSteelRapier.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/BlackSteelRapier.cs
@@ -8,11 +8,20 @@ namespace Kesmai.Server.Items
 	{
 		/// <inheritdoc />
 		public override uint BasePrice => 1;
+
+		/// <inheritdoc />
+		public override ShieldPenetration Penetration => ShieldPenetration.Medium;
+
+		/// <inheritdoc />
+		public override int MinimumDamage => 1;
+
+		/// <inheritdoc />
+		public override int MaximumDamage => 10;
 		
 		/// <inheritdoc />
 		public override int BaseAttackBonus => 4;
 
-		public override int BaseArmorBonus => 2;
+		public override int BaseArmorBonus => 3;
 
 		/// <inheritdoc />
 		public override WeaponFlags Flags => base.Flags | WeaponFlags.BlueGlowing;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/Rapier.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/Rapier.cs
@@ -14,7 +14,7 @@ namespace Kesmai.Server.Items
 		public override uint BasePrice => 20;
 
 		/// <inheritdoc />
-		public override int Weight => 1150;33
+		public override int Weight => 1150;
 
 		/// <inheritdoc />
 		public override int MinimumDamage => 1;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/Rapier.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Swords/Rapier.cs
@@ -14,16 +14,13 @@ namespace Kesmai.Server.Items
 		public override uint BasePrice => 20;
 
 		/// <inheritdoc />
-		public override int Weight => 1150;
-
-		/// <inheritdoc />
-		public override ShieldPenetration Penetration => ShieldPenetration.Medium;
+		public override int Weight => 1150;33
 
 		/// <inheritdoc />
 		public override int MinimumDamage => 1;
 
 		/// <inheritdoc />
-		public override int MaximumDamage => 10;
+		public override int MaximumDamage => 6;
 
 		/// <inheritdoc />
 		public override int BaseArmorBonus => 1;


### PR DESCRIPTION
Reset the Rapier base-class. (should probably avoid altering these.)

Moved nesc attributes to the Blackrapier, and boosted Brapiers defense to 3.