### PR TITLE
Proposed phantasm changes

### DIFF
--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedDjinn.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedDjinn.cs
@@ -14,8 +14,8 @@ public partial class SummonedDjinn : Djinn
 	{
 		Summoned = true;
 			
-		Health = MaxHealth = 300;
-		BaseDodge = 25;
+		Health = MaxHealth = PowerCurve().health;
+		BaseDodge = PowerCurve().defense;
 		Mana = MaxMana = 24;
 
 		Movement = 3;
@@ -39,6 +39,17 @@ public partial class SummonedDjinn : Djinn
 
 		CanFly = true;
 	}
+	private (int health, int defense) PowerCurve()
+    {
+        var player = Director;
+        var level = player.Level;
+        var magicSkill = player.GetSkillLevel(Skill.Magic);
+
+        var health = (level + (int)magicSkill)*11;
+        var defense = (level + 9).Clamp(25,30);
+        
+        return (health,(int)defense);
+    }
 		
 	protected override void OnCreate()
 	{

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedEfreet.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedEfreet.cs
@@ -36,6 +36,7 @@ public partial class SummonedEfreet : Efreet
 		};
 			
 		AddStatus(new NightVisionStatus(this));
+		AddStatus(new PoisonProtectionStatus(this));
 			
 		CanFly = true;
 	}
@@ -53,7 +54,7 @@ public partial class SummonedEfreet : Efreet
 	protected override void OnCreate()
 	{
 		base.OnCreate();
-			
+		
 		_stats[EntityStat.FireProtection].Base = 100;
 		_stats[EntityStat.MagicDamageTakenReduction].Base = 30;
 	}

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedEfreet.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedEfreet.cs
@@ -15,8 +15,8 @@ public partial class SummonedEfreet : Efreet
 	{
 		Summoned = true;
 			
-		Health = MaxHealth = 400;
-		BaseDodge = 30;
+		Health = MaxHealth = PowerCurve().health;
+		BaseDodge = PowerCurve().defense;
 		Mana = MaxMana = 40;
 		Movement = 3;
 
@@ -39,7 +39,17 @@ public partial class SummonedEfreet : Efreet
 			
 		CanFly = true;
 	}
-		
+	private (int health, int defense) PowerCurve()
+    {
+        var player = Director;
+        var level = player.Level;
+        var magicSkill = player.GetSkillLevel(Skill.Magic);
+
+        var health = (level + (int)magicSkill)*11;
+        var defense = (30 + ((level - 21)* 0.5));
+        
+        return (health,(int)defense);
+    }		
 	protected override void OnCreate()
 	{
 		base.OnCreate();
@@ -62,7 +72,6 @@ public partial class SummonedEfreet : Efreet
 
 		return true;
 	}
-
 	public override void OnSpellTarget(Target target, MobileEntity combatant)
 	{
 		if (Spell is DragonBreathSpell dragonBreath)

--- a/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedPhantom.cs
+++ b/Source/Kesmai.Server/Game/Entities/Mobiles/Creatures/Phantasm/SummonedPhantom.cs
@@ -10,27 +10,39 @@ public partial class SummonedPhantom : Phantom
 	public override bool CanOrderCarry => true;
 
 	public SummonedPhantom()
-	{
-		Summoned = true;
-			
-		Health = MaxHealth = 250;
-		BaseDodge = 24;
-		Movement = 3;
+    {
+        Summoned = true;
+            
+        Health = MaxHealth = PowerCurve().health;
+        BaseDodge = PowerCurve().defense;
+        Movement = 3;
 
-		Attacks = new CreatureAttackCollection
-		{
-			{ new CreatureBasicAttack(14) },
-		};
+        Attacks = new CreatureAttackCollection
+        {
+            { new CreatureBasicAttack(14) },
+        };
 
-		Blocks = new CreatureBlockCollection
-		{
-			new CreatureBlock(12, "a hand"),
-		};
-			
-		AddStatus(new NightVisionStatus(this));
-			
-		CanFly = true;
-	}
+        Blocks = new CreatureBlockCollection
+        {
+            new CreatureBlock(12, "a hand"),
+        };
+            
+        AddStatus(new NightVisionStatus(this));
+            
+        CanFly = true;
+    }
+
+    private (int health, int defense) PowerCurve()
+    {
+        var player = Director;
+        var level = player.Level;
+        var magicSkill = player.GetSkillLevel(Skill.Magic);
+
+        var health = (level + (int)magicSkill)*11;
+        var defense = (level + 10).Clamp(0,25);
+        
+        return (health,defense);
+    }	
 		
 	protected override void OnCreate()
 	{


### PR DESCRIPTION
In order to allow Efreet power to scale up with higher level characters I developed curves for the various summon types that allow them to rise in power proportional to both experience level and magic level. For the lower level summons I put minimum/maximum values... but I was on the fence on that... it might make sense to have them all scale the same?

See code for details. I did copy the classes into a segment on worldforge and made sure they compiled properly. 