### PR TITLE
Worldforge Save Error Fix

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Presenters/ApplicationPresenter.cs
@@ -25,6 +25,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using RoslynPad.Roslyn;
 using ZipFile = Ionic.Zip.ZipFile;
+using Microsoft.CodeAnalysis;
 
 namespace Kesmai.WorldForge.Editor;
 
@@ -682,8 +683,10 @@ public class ApplicationPresenter : ObservableRecipient
 
 	private bool CheckScriptSyntax() //Enumerate all script segments and verify that they pass syntax checks
 	{
-		//Segment code:
-		var syntaxErrors = CSharpSyntaxTree.ParseText(Segment.Internal.Blocks[1]).GetDiagnostics();
+        //Segment code:
+        var customParseOptions = CSharpParseOptions.Default;
+        customParseOptions = customParseOptions.WithKind(SourceCodeKind.Script);
+        var syntaxErrors = CSharpSyntaxTree.ParseText(Segment.Internal.Blocks[1],customParseOptions).GetDiagnostics();
 		if (syntaxErrors.Count()>0)
 		{
 			var errorList = String.Join('\n', syntaxErrors.Take(3).Select(err => (err.Location.GetLineSpan().StartLinePosition.Line+2) + ":" + err.GetMessage()));


### PR DESCRIPTION
The parser was treating our segment file like a normal c# document and looking for using/namespace/etc that wasn't going to be there. 

I tweaked the parse options to treat the files like a script and it seems to have resolved the issue I was having with extra errors that didn't apply. 

<img width="364" alt="Screenshot 2024-04-11 at 12 00 32 PM" src="https://github.com/jkachhad/Stormhalter/assets/98596410/65695e14-ca61-40b7-83bd-c405feb12fc1">
