### PR TITLE
Add Key for nubs to skill with

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Miscellaneous/IronKey.cs
+++ b/Source/Kesmai.Server/Game/Items/Miscellaneous/IronKey.cs
@@ -6,7 +6,7 @@ using Kesmai.Server.Network;
 
 namespace Kesmai.Server.Items;
 
-public partial class IronKey : ItemEntity, ITreasure
+public partial class IronKey : MeleeWeapon, ITreasure
 {
 	/// <inheritdoc />
 	public override int LabelNumber => 6000055;
@@ -18,7 +18,17 @@ public partial class IronKey : ItemEntity, ITreasure
 	public override int Weight => 15;
 
 	/// <inheritdoc />
-	public override int Category => 3;
+	public override int Category => 14;
+	
+	public override int MinimumDamage => 1;
+	
+	public override int MaximumDamage => 1;
+	
+	public override ShieldPenetration Penetration => ShieldPenetration.Full;
+	
+	public override Skill Skill => Skill.Thieving;
+	
+	public override WeaponFlags Flags => WeaponFlags.Bashing | WeaponFlags.Neutral;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="IronKey"/> class.


### PR DESCRIPTION
This changes the iron key to make it a 'weapon' that beginners can skill their thieving with until they're big enough to get a real lock pick. 