### PR TITLE
Add poison multiplier to base dagger

### DIFF
--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/Dagger.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Daggers/Dagger.cs
@@ -28,6 +28,8 @@ public abstract partial class Dagger : MeleeWeapon
 	/// <inheritdoc />
 	public override Skill Skill => Skill.Dagger;
 
+	public double PoisonMultiplier { get; set; } = 1.0;
+
 	/// <inheritdoc />
 	public override WeaponFlags Flags => WeaponFlags.Piercing | WeaponFlags.Throwable | WeaponFlags.QuickThrow;
 		
@@ -44,6 +46,15 @@ public abstract partial class Dagger : MeleeWeapon
 	public override TimeSpan GetSwingDelay(MobileEntity entity)
 	{
 		return entity.GetRoundDelay(0.75);
+	}
+	
+	public override void OnHit(MobileEntity attacker, MobileEntity defender)
+	{
+		if (IsPoisoned && PoisonMultiplier > 1)
+		{
+			var newPotency = Poison.Potency * PoisonMultiplier;
+			Poison.Potency = (int)newPotency;
+		}
 	}
 		
 	public override double GetSkillMultiplier()


### PR DESCRIPTION
Added a property to dagger base class that allows venom to be scaled across all daggers. Also implemented the multiplier by overriding the base OnHit method to check for poison on the dagger and modifier the potency with the multiplier if it's greater than 1. 

I put a setter on the property so we could make other wearable items that could have multipliers that further adjust the potency. 