### PR TITLE
Add Adhoc workspace for map projects

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/Roslyn/MapProjectWorkspace.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/MapProjectWorkspace.cs
@@ -1,0 +1,100 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Kesmai.WorldForge.Roslyn;
+
+public class MapProjectWorkspace : IDisposable
+{
+    public AdhocWorkspace Workspace { get; }
+    public Project Project { get; private set; }
+    public string FolderPath { get; }
+
+    public MapProjectWorkspace(string folderPath, string projectName)
+    {
+        FolderPath = folderPath;
+        Workspace = new AdhocWorkspace();
+
+        var projectInfo = ProjectInfo.Create(
+            ProjectId.CreateNewId(projectName),
+            VersionStamp.Create(),
+            projectName,
+            projectName,
+            LanguageNames.CSharp,
+            filePath: Path.Combine(folderPath, projectName + ".csproj"));
+
+        Workspace.AddProject(projectInfo);
+
+        var csFiles = Directory.EnumerateFiles(FolderPath, "*.cs", SearchOption.TopDirectoryOnly);
+        foreach (var file in csFiles)
+        {
+            var source = SourceText.From(File.ReadAllText(file));
+            var docInfo = DocumentInfo.Create(
+                DocumentId.CreateNewId(projectInfo.Id),
+                Path.GetFileName(file),
+                loader: TextLoader.From(TextAndVersion.Create(source, VersionStamp.Create())),
+                filePath: file);
+            Workspace.AddDocument(docInfo);
+        }
+
+        Project = Workspace.CurrentSolution.GetProject(projectInfo.Id);
+    }
+
+    public void AddFile(string fileName)
+    {
+        var filePath = Path.Combine(FolderPath, fileName);
+        if (!File.Exists(filePath))
+            File.WriteAllText(filePath, string.Empty);
+        var source = SourceText.From(File.ReadAllText(filePath));
+        var docInfo = DocumentInfo.Create(
+            DocumentId.CreateNewId(Project.Id),
+            fileName,
+            loader: TextLoader.From(TextAndVersion.Create(source, VersionStamp.Create())),
+            filePath: filePath);
+        Workspace.AddDocument(docInfo);
+        Project = Workspace.CurrentSolution.GetProject(Project.Id);
+    }
+
+    public void RemoveFile(string fileName)
+    {
+        var document = Project.Documents.FirstOrDefault(d => Path.GetFileName(d.FilePath) == fileName);
+        if (document != null)
+        {
+            Workspace.RemoveDocument(document.Id);
+            if (File.Exists(document.FilePath))
+                File.Delete(document.FilePath);
+            Project = Workspace.CurrentSolution.GetProject(Project.Id);
+        }
+    }
+
+    public void RenameFile(string oldName, string newName)
+    {
+        var document = Project.Documents.FirstOrDefault(d => Path.GetFileName(d.FilePath) == oldName);
+        if (document != null)
+        {
+            var folder = Path.GetDirectoryName(document.FilePath);
+            var newPath = Path.Combine(folder, newName);
+            if (File.Exists(newPath))
+                File.Delete(newPath);
+            File.Move(document.FilePath, newPath);
+
+            Workspace.RemoveDocument(document.Id);
+            var source = SourceText.From(File.ReadAllText(newPath));
+            var docInfo = DocumentInfo.Create(
+                DocumentId.CreateNewId(Project.Id),
+                newName,
+                loader: TextLoader.From(TextAndVersion.Create(source, VersionStamp.Create())),
+                filePath: newPath);
+            Workspace.AddDocument(docInfo);
+            Project = Workspace.CurrentSolution.GetProject(Project.Id);
+        }
+    }
+
+    public void Dispose()
+    {
+        Workspace.Dispose();
+    }
+}

--- a/Source/Kesmai.WorldForge/Editor/Scripting/CodeFileEditor.cs
+++ b/Source/Kesmai.WorldForge/Editor/Scripting/CodeFileEditor.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using CommonServiceLocator;
+using DigitalRune.ServiceLocation;
+using RoslynPad.Editor;
+
+namespace Kesmai.WorldForge.Scripting;
+
+public class CodeFileEditor : RoslynCodeEditor
+{
+    private bool _initialized;
+
+    public string FilePath { get; private set; }
+
+    public CodeFileEditor()
+    {
+        FontFamily = new FontFamily("Consolas");
+        HorizontalScrollBarVisibility = System.Windows.Controls.ScrollBarVisibility.Auto;
+        Loaded += OnLoaded;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("VSTHRD", "VSTHRD100:Avoid async void methods")]
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_initialized)
+            return;
+
+        var services = (ServiceContainer)ServiceLocator.Current;
+        var presenter = services.GetInstance<ApplicationPresenter>();
+
+        await InitializeAsync(presenter.RoslynHost, new ClassificationHighlightColors(),
+            Directory.GetCurrentDirectory(), string.Empty, Microsoft.CodeAnalysis.SourceCodeKind.Regular);
+
+        _initialized = true;
+    }
+
+    public void LoadFile(string path)
+    {
+        FilePath = path;
+        Text = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        Document.UndoStack.ClearAll();
+    }
+
+    public void SaveFile()
+    {
+        if (!string.IsNullOrEmpty(FilePath))
+        {
+            File.WriteAllText(FilePath, Text);
+        }
+    }
+}

--- a/Source/Kesmai.WorldForge/UI/ApplicationWindow.xaml
+++ b/Source/Kesmai.WorldForge/UI/ApplicationWindow.xaml
@@ -206,6 +206,9 @@
                 <DataTemplate DataType="{x:Type documents:TreasuresViewModel}">
                     <documents:TreasuresDocument />
                 </DataTemplate>
+                <DataTemplate DataType="{x:Type documents:SolutionViewModel}">
+                    <documents:SolutionDocument />
+                </DataTemplate>
             </DockingManager.Resources>
             
             

--- a/Source/Kesmai.WorldForge/UI/Documents/SolutionDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/SolutionDocument.xaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="Kesmai.WorldForge.UI.Documents.SolutionDocument"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:scripting="clr-namespace:Kesmai.WorldForge.Scripting"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <ListBox x:Name="_filesList"
+                 ItemsSource="{Binding Files}"
+                 SelectedItem="{Binding SelectedFile}">
+            <ListBox.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Add File" Command="{Binding AddFileCommand}" />
+                    <MenuItem Header="Remove File" Command="{Binding RemoveFileCommand}" CommandParameter="{Binding SelectedFile}" />
+                    <MenuItem Header="Rename File" Command="{Binding RenameFileCommand}" CommandParameter="{Binding SelectedFile}" />
+                </ContextMenu>
+            </ListBox.ContextMenu>
+        </ListBox>
+        <Border Grid.Column="1" BorderBrush="Black" BorderThickness="1" Margin="5,0,0,0">
+            <scripting:CodeFileEditor x:Name="_codeEditor" />
+        </Border>
+    </Grid>
+</UserControl>

--- a/Source/Kesmai.WorldForge/UI/Documents/SolutionDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/SolutionDocument.xaml.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Kesmai.WorldForge.Editor.Roslyn;
+using Kesmai.WorldForge.Scripting;
+
+namespace Kesmai.WorldForge.UI.Documents;
+
+public partial class SolutionDocument : UserControl
+{
+    public SolutionDocument()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private SolutionViewModel _viewModel;
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (_viewModel != null)
+        {
+            _viewModel.SelectedFileChanged -= OnSelectedFileChanged;
+        }
+
+        _viewModel = e.NewValue as SolutionViewModel;
+
+        if (_viewModel != null)
+        {
+            _viewModel.SelectedFileChanged += OnSelectedFileChanged;
+            LoadSelectedFile();
+        }
+    }
+
+
+    private void OnSelectedFileChanged(object sender, EventArgs e)
+    {
+        LoadSelectedFile();
+    }
+
+    private void LoadSelectedFile()
+    {
+        if (_viewModel?.CurrentFilePath != null)
+        {
+            _codeEditor.LoadFile(_viewModel.CurrentFilePath);
+        }
+    }
+}
+
+public class SolutionViewModel : ObservableObject
+{
+    private MapProjectWorkspace _workspace;
+    private string _selectedFile;
+
+    public string WorkspaceFolder => _workspace?.FolderPath;
+
+    public string CurrentFilePath =>
+        !string.IsNullOrEmpty(SelectedFile) && WorkspaceFolder != null
+            ? Path.Combine(WorkspaceFolder, SelectedFile)
+            : null;
+
+    public event EventHandler SelectedFileChanged;
+
+    public string Name => "(Solution)";
+
+    public ObservableCollection<string> Files { get; } = new();
+
+    public string SelectedFile
+    {
+        get => _selectedFile;
+        set
+        {
+            if (SetProperty(ref _selectedFile, value))
+            {
+                SelectedFileChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public RelayCommand AddFileCommand { get; }
+    public RelayCommand<string> RemoveFileCommand { get; }
+    public RelayCommand<string> RenameFileCommand { get; }
+
+    public SolutionViewModel(MapProjectWorkspace workspace)
+    {
+        _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+        RefreshFiles();
+
+        AddFileCommand = new RelayCommand(AddFile);
+        RemoveFileCommand = new RelayCommand<string>(RemoveFile, f => f != null);
+        RenameFileCommand = new RelayCommand<string>(RenameFile, f => f != null);
+    }
+
+    public void SetWorkspace(MapProjectWorkspace workspace)
+    {
+        _workspace = workspace;
+        RefreshFiles();
+    }
+
+    private void RefreshFiles()
+    {
+        Files.Clear();
+        if (_workspace?.Project != null)
+        {
+            foreach (var doc in _workspace.Project.Documents)
+                Files.Add(Path.GetFileName(doc.FilePath));
+        }
+    }
+
+    private void AddFile()
+    {
+        if (_workspace == null)
+            return;
+        var baseName = "NewFile";
+        var index = 1;
+        var name = $"{baseName}{index}.cs";
+        while (Files.Contains(name))
+            name = $"{baseName}{++index}.cs";
+        _workspace.AddFile(name);
+        RefreshFiles();
+        SelectedFile = name;
+    }
+
+    private void RemoveFile(string file)
+    {
+        _workspace?.RemoveFile(file);
+        RefreshFiles();
+    }
+
+    private void RenameFile(string file)
+    {
+        if (_workspace == null)
+            return;
+        var dialog = new Kesmai.WorldForge.UI.Documents.InputDialog("Rename file", file);
+        if (dialog.ShowDialog() == true)
+        {
+            var newName = dialog.Input;
+            if (!string.IsNullOrWhiteSpace(newName) && newName != file)
+            {
+                _workspace.RenameFile(file, newName);
+                RefreshFiles();
+                SelectedFile = newName;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `MapProjectWorkspace` using `AdhocWorkspace`
- manage a shared workspace in `ApplicationPresenter`
- load all *.cs files from a map project's folder
- dispose workspace when closing the segment
- create `(Solution)` tab for managing workspace files
- add RoslynPad-based code editor for solution files

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865b05f6b2c8321bdf3ced539d3d921