### PR TITLE
Enable static Internal helpers in scripts

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/Roslyn/SegmentRoslynHost.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/SegmentRoslynHost.cs
@@ -23,12 +23,25 @@ public class SegmentRoslynHost : RoslynHost, IDisposable
             Assembly.Load("RoslynPad.Roslyn.Windows"),
             Assembly.Load("RoslynPad.Editor.Windows"),
         },
-        RoslynHostReferences.NamespaceDefault.With(imports: new[]
-        {
-            "WorldForge",
-        }))
+        RoslynHostReferences.NamespaceDefault.With(imports: CreateImports(segment)))
     {
         _segment = segment;
+    }
+
+    private static string[] CreateImports(Segment segment)
+    {
+        var imports = new List<string>
+        {
+            "WorldForge"
+        };
+
+        if (!string.IsNullOrEmpty(segment?.Name))
+        {
+            imports.Add($"Kesmai.Server.Segment.{segment.Name}");
+            imports.Add($"static Kesmai.Server.Segment.{segment.Name}.Internal");
+        }
+
+        return imports.ToArray();
     }
 
     protected override Project CreateProject(Solution solution, DocumentCreationArgs args, CompilationOptions compilationOptions, Project? previousProject = null)

--- a/Source/Kesmai.WorldForge/Editor/Scripting/Script.cs
+++ b/Source/Kesmai.WorldForge/Editor/Scripting/Script.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommonServiceLocator;
+using Kesmai.WorldForge.Editor;
 
 namespace Kesmai.WorldForge.Scripting;
 
@@ -77,27 +79,44 @@ public class Script : ObservableObject
 		};
 	}
 
-	public override string ToString()
-	{
-		var segments = Template.GetSegments().ToList();
-		var blocks = Blocks;
+        public override string ToString()
+        {
+                var segments = Template.GetSegments().ToList();
+                var blocks = Blocks;
 
-		var builder = new StringBuilder();
-			
-		if (blocks.Any() && blocks.Count >= (segments.Count + 1))
-		{
-			for (var i = 0; i < segments.Count; i++)
-			{
-				builder.Append(blocks[i]);
-				builder.Append(segments[i]);
-					
-				if (i < (segments.Count - 1))
-					continue;
+                var builder = new StringBuilder();
 
-				builder.Append(blocks[i + 1]);
-			}
-		}
+                if (!String.Equals(Name, "Internal", StringComparison.OrdinalIgnoreCase))
+                {
+                        try
+                        {
+                                var presenter = ServiceLocator.Current.GetInstance<ApplicationPresenter>();
+                                var segmentName = presenter.Segment?.Name;
 
-		return builder.ToString();
-	}
+                                if (!String.IsNullOrEmpty(segmentName))
+                                {
+                                        builder.Append($"using static Kesmai.Server.Segment.{segmentName}.Internal;\n");
+                                }
+                        }
+                        catch
+                        {
+                        }
+                }
+
+                if (blocks.Any() && blocks.Count >= (segments.Count + 1))
+                {
+                        for (var i = 0; i < segments.Count; i++)
+                        {
+                                builder.Append(blocks[i]);
+                                builder.Append(segments[i]);
+
+                                if (i < (segments.Count - 1))
+                                        continue;
+
+                                builder.Append(blocks[i + 1]);
+                        }
+                }
+
+                return builder.ToString();
+        }
 }


### PR DESCRIPTION
## Summary
- statically import segment-specific Internal class in Roslyn host
- auto-prepend using static Internal to generated scripts

## Testing
- `dotnet build Kesmai.WorldForge.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aea7b149e0832190ed9aed2995dce9