### PR TITLE
Add Roslyn-based scripting support with editor integration

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Entity.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Entity.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.ComponentModel;
 using Kesmai.WorldForge.Editor;
+using Kesmai.WorldForge.Editor.Scripting;
 
 namespace Kesmai.WorldForge;
 
@@ -10,7 +11,8 @@ public class Entity : ObservableObject, ICloneable, ISegmentObject
 {
 	private string _name;
 	private string _notes;
-	private string _group;
+        private string _group;
+        public ScriptHost Scripts { get; } = new ScriptHost();
 	
 	public string Name
 	{
@@ -48,9 +50,12 @@ public class Entity : ObservableObject, ICloneable, ISegmentObject
 		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}	
 	
-	public Entity()
-	{
-	}
+        public Entity()
+        {
+            Scripts.SetScript("OnSpawn", string.Empty);
+            Scripts.SetScript("OnDeath", string.Empty);
+            Scripts.SetScript("OnCreate", string.Empty);
+        }
 		
 	public Entity(XElement element)
 	{

--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Spawner.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/Game/Spawner.cs
@@ -9,6 +9,7 @@ using Kesmai.WorldForge.Editor;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
+using Kesmai.WorldForge.Editor.Scripting;
 
 namespace Kesmai.WorldForge;
 
@@ -279,13 +280,14 @@ public class SpawnEntry : ObservableObject
 		
 	private int _size;
 	private int _minimum;
-	private int _maximum;
-		
-	public Entity Entity
-	{
-		get => _entity;
-		set => SetProperty(ref _entity, value);
-	}
+        private int _maximum;
+        public ScriptHost Scripts { get; } = new ScriptHost();
+
+        public Entity Entity
+        {
+                get => _entity;
+                set => SetProperty(ref _entity, value);
+        }
 		
 	public int Size
 	{
@@ -305,24 +307,27 @@ public class SpawnEntry : ObservableObject
 		set => SetProperty( ref _maximum, value);
 	}
 
-	public SpawnEntry()
-	{
-		Size = 1;
-	}
+        public SpawnEntry()
+        {
+                Size = 1;
+                Scripts.SetScript("OnSpawn", string.Empty);
+        }
 
-	public SpawnEntry(XElement element)
-	{
-		Size = (int)element.Attribute("size");
-			
-		var minimumAttribute = element.Attribute("minimum");
-		var maximumAttribute = element.Attribute("maximum");
+        public SpawnEntry(XElement element)
+        {
+                Size = (int)element.Attribute("size");
 
-		if (minimumAttribute != null)
-			Minimum = (int)minimumAttribute;
-			
-		if (maximumAttribute != null)
-			Maximum = (int)maximumAttribute;
-	}
+                var minimumAttribute = element.Attribute("minimum");
+                var maximumAttribute = element.Attribute("maximum");
+
+                if (minimumAttribute != null)
+                        Minimum = (int)minimumAttribute;
+
+                if (maximumAttribute != null)
+                        Maximum = (int)maximumAttribute;
+
+                Scripts.SetScript("OnSpawn", string.Empty);
+        }
 
 	public XElement GetXElement()
 	{

--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/World/Segment.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/World/Segment.cs
@@ -5,6 +5,7 @@ using System.Xml.Linq;
 using CommonServiceLocator;
 using DigitalRune.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Kesmai.WorldForge.Editor.Scripting;
 
 namespace Kesmai.WorldForge.Editor;
 
@@ -40,9 +41,11 @@ public class Segment : ObservableObject
 	public SegmentLocations Locations { get; set; } = new SegmentLocations();
 	public SegmentSubregions Subregions { get; set; } = new SegmentSubregions();
 	public SegmentEntities Entities { get; set; } = new SegmentEntities();
-	public SegmentSpawns Spawns { get; set; } = new SegmentSpawns();
-	public SegmentTreasures Treasures { get; set; } = new SegmentTreasures();
-	public NotifyingCollection<VirtualFile> VirtualFiles { get; } = new NotifyingCollection<VirtualFile>();
+        public SegmentSpawns Spawns { get; set; } = new SegmentSpawns();
+        public SegmentTreasures Treasures { get; set; } = new SegmentTreasures();
+        public NotifyingCollection<VirtualFile> VirtualFiles { get; } = new NotifyingCollection<VirtualFile>();
+        public ScriptHost Scripts { get; } = new ScriptHost();
+        public string? ScriptFile { get; set; }
 
         public Segment()
         {

--- a/Source/Kesmai.WorldForge/Editor/MVP/Models/World/SegmentTreasure.cs
+++ b/Source/Kesmai.WorldForge/Editor/MVP/Models/World/SegmentTreasure.cs
@@ -7,13 +7,15 @@ using DigitalRune.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using Kesmai.WorldForge.Editor.Scripting;
 
 namespace Kesmai.WorldForge.Editor;
 
 public class SegmentTreasure : ObservableObject, ISegmentObject
 {
 	private string _name;
-	private string _notes;
+        private string _notes;
+        public ScriptHost Scripts { get; } = new ScriptHost();
 		
 	private ObservableCollection<TreasureEntry> _entries = new ObservableCollection<TreasureEntry>();
 		
@@ -39,43 +41,46 @@ public class SegmentTreasure : ObservableObject, ISegmentObject
 
 	public virtual bool IsHoard => false;
 		
-	public SegmentTreasure()
-	{
-		_entries.Add(new TreasureEntry(this));
-		_entries.CollectionChanged += EntriesOnCollectionChanged;
+        public SegmentTreasure()
+        {
+                _entries.Add(new TreasureEntry(this));
+                _entries.CollectionChanged += EntriesOnCollectionChanged;
 
-		InvalidateChance();
-	}
+                Scripts.SetScript("GetChance", string.Empty);
+                InvalidateChance();
+        }
 	#nullable enable
     private void EntriesOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)
 	{
 		InvalidateChance();
 	}
 	#nullable disable
-    public SegmentTreasure(XElement element)
-	{
-		_name = (string)element.Attribute("name");
-			
-		if (element.TryGetElement("notes", out var notesElement))
-			_notes = (string)notesElement;
-			
-		foreach(var entryElement in element.Elements("entry"))
-			_entries.Add(new TreasureEntry(this, entryElement));
+        public SegmentTreasure(XElement element)
+        {
+                _name = (string)element.Attribute("name");
 
-		InvalidateChance();
-	}
+                if (element.TryGetElement("notes", out var notesElement))
+                        _notes = (string)notesElement;
 
-	public SegmentTreasure(SegmentTreasure treasure)
-	{
-		_name = treasure.Name;
-		_notes = treasure.Notes;
-		_entries.AddRange(treasure.Entries.Select(e => new TreasureEntry(e)
-		{
-			Treasure = treasure
-		}));
+                foreach(var entryElement in element.Elements("entry"))
+                        _entries.Add(new TreasureEntry(this, entryElement));
 
-		InvalidateChance();
-	}
+                Scripts.SetScript("GetChance", string.Empty);
+                InvalidateChance();
+        }
+
+        public SegmentTreasure(SegmentTreasure treasure)
+        {
+                _name = treasure.Name;
+                _notes = treasure.Notes;
+                _entries.AddRange(treasure.Entries.Select(e => new TreasureEntry(e)
+                {
+                        Treasure = treasure
+                }));
+
+                Scripts.SetScript("GetChance", string.Empty);
+                InvalidateChance();
+        }
 
 	public virtual XElement GetXElement()
 	{

--- a/Source/Kesmai.WorldForge/Editor/Scripting/ScriptDocument.cs
+++ b/Source/Kesmai.WorldForge/Editor/Scripting/ScriptDocument.cs
@@ -1,0 +1,24 @@
+using Microsoft.CodeAnalysis;
+
+namespace Kesmai.WorldForge.Editor.Scripting;
+
+public class ScriptDocument
+{
+    public string Name { get; }
+    public string? FilePath { get; }
+    public DocumentId DocumentId { get; }
+    public string Text { get; private set; }
+
+    internal ScriptDocument(DocumentId id, string name, string text, string? filePath)
+    {
+        DocumentId = id;
+        Name = name;
+        Text = text;
+        FilePath = filePath;
+    }
+
+    internal void UpdateText(string text)
+    {
+        Text = text;
+    }
+}

--- a/Source/Kesmai.WorldForge/Editor/Scripting/ScriptHost.cs
+++ b/Source/Kesmai.WorldForge/Editor/Scripting/ScriptHost.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Kesmai.WorldForge.Editor.Scripting;
+
+public class ScriptHost
+{
+    private readonly Dictionary<string, ScriptDocument> _scripts = new();
+
+    public ScriptDocument? this[string name] => _scripts.TryGetValue(name, out var doc) ? doc : null;
+
+    public ScriptDocument SetScript(string name, string text, string? filePath = null)
+    {
+        var doc = ScriptWorkspace.Instance.AddOrUpdate(name, text, filePath);
+        _scripts[name] = doc;
+        return doc;
+    }
+
+    public IEnumerable<KeyValuePair<string, ScriptDocument>> Scripts => _scripts;
+}

--- a/Source/Kesmai.WorldForge/Editor/Scripting/ScriptWorkspace.cs
+++ b/Source/Kesmai.WorldForge/Editor/Scripting/ScriptWorkspace.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Kesmai.WorldForge.Editor.Scripting;
+
+public class ScriptWorkspace
+{
+    private readonly AdhocWorkspace _workspace;
+    private readonly ProjectId _projectId;
+    private readonly Dictionary<string, ScriptDocument> _documents = new();
+
+    public static ScriptWorkspace Instance { get; } = new ScriptWorkspace();
+
+    private ScriptWorkspace()
+    {
+        _workspace = new AdhocWorkspace();
+        var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(),
+            "Scripts", "Scripts", LanguageNames.CSharp);
+        _workspace.AddProject(projectInfo);
+        _projectId = projectInfo.Id;
+    }
+
+    public ScriptDocument AddOrUpdate(string name, string text, string? filePath = null)
+    {
+        if (_documents.TryGetValue(name, out var existing))
+        {
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithDocumentText(existing.DocumentId, SourceText.From(text)));
+            existing.UpdateText(text);
+            return existing;
+        }
+
+        var documentId = DocumentId.CreateNewId(_projectId);
+        var loader = TextLoader.From(TextAndVersion.Create(SourceText.From(text), VersionStamp.Create(), filePath));
+        var documentInfo = DocumentInfo.Create(documentId, name, filePath: filePath, loader: loader);
+        _workspace.AddDocument(documentInfo);
+
+        var doc = new ScriptDocument(documentId, name, text, filePath);
+        _documents[name] = doc;
+        return doc;
+    }
+
+    public Document? GetDocument(string name)
+    {
+        return _documents.TryGetValue(name, out var doc) ? _workspace.CurrentSolution.GetDocument(doc.DocumentId) : null;
+    }
+}

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.xaml
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.xaml
@@ -1,0 +1,6 @@
+<UserControl x:Class="Kesmai.WorldForge.UI.Controls.ScriptEditor"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:avaloniaedit="clr-namespace:ICSharpCode.AvalonEdit;assembly=ICSharpCode.AvalonEdit">
+    <avaloniaedit:TextEditor Name="PART_Editor" ShowLineNumbers="True"/>
+</UserControl>

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows.Controls;
+using ICSharpCode.AvalonEdit;
+using Kesmai.WorldForge.Editor.Scripting;
+
+namespace Kesmai.WorldForge.UI.Controls;
+
+public partial class ScriptEditor : UserControl
+{
+    public ScriptEditor()
+    {
+        InitializeComponent();
+    }
+
+    public string Text
+    {
+        get => PART_Editor.Text;
+        set => PART_Editor.Text = value;
+    }
+
+    public void Bind(ScriptDocument document)
+    {
+        Text = document.Text;
+    }
+}


### PR DESCRIPTION
## Summary
- add ScriptWorkspace and script host utilities powered by Roslyn
- allow Segment, Entity, Treasure, and Spawn objects to store script documents
- introduce AvaloniaEdit-based ScriptEditor control

## Testing
- ❌ `dotnet build Source/Kesmai.WorldForge/Kesmai.WorldForge.csproj` *(missing: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68af64bb2ed483218a997fc8b7955d3e