### PR TITLE
Add Roslyn script workspace and example entity scripts

### DIFF
--- a/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
@@ -1,15 +1,33 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace Kesmai.WorldForge.Roslyn;
 
-public abstract class EntityScript
+public abstract class EntityScript : ObservableObject
 {
-    protected EntityScript(string body)
+    private string _body;
+    private bool _isEnabled = true;
+
+    protected EntityScript(string name, string body)
     {
-        Body = body;
+        Name = name;
+        _body = body;
     }
 
     protected abstract string MethodSignature { get; }
 
-    public string Body { get; set; }
+    public string Name { get; }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set => SetProperty(ref _isEnabled, value);
+    }
+
+    public string Body
+    {
+        get => _body;
+        set => SetProperty(ref _body, value);
+    }
 
     public string ToDocumentText()
     {
@@ -20,7 +38,7 @@ public abstract class EntityScript
 public class OnDeathScript : EntityScript
 {
     public OnDeathScript()
-        : base("killer.SendMessage(\"You have killed {0}.\", this.Name);")
+        : base("OnDeath", "killer.SendMessage(\"You have killed {0}.\", this.Name);")
     {
     }
 
@@ -31,7 +49,7 @@ public class OnDeathScript : EntityScript
 public class OnIncomingPlayerScript : EntityScript
 {
     public OnIncomingPlayerScript()
-        : base("player.SendMessage(\"Welcome to the game, {0}!\", player.Name);")
+        : base("OnIncomingPlayer", "player.SendMessage(\"Welcome to the game, {0}!\", player.Name);")
     {
     }
 

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
@@ -20,7 +20,7 @@ public abstract class EntityScript
 public class OnDeathScript : EntityScript
 {
     public OnDeathScript()
-        : base(@"killer.SendMessage(""You have killed {0}.", this.Name);")
+        : base("killer.SendMessage(\"You have killed {0}.\", this.Name);")
     {
     }
 
@@ -31,7 +31,7 @@ public class OnDeathScript : EntityScript
 public class OnIncomingPlayerScript : EntityScript
 {
     public OnIncomingPlayerScript()
-        : base(@"player.SendMessage(""Welcome to the game, {0}!"", player.Name);")
+        : base("player.SendMessage(\"Welcome to the game, {0}!\", player.Name);")
     {
     }
 

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
@@ -1,0 +1,41 @@
+namespace Kesmai.WorldForge.Roslyn;
+
+public abstract class EntityScript
+{
+    protected EntityScript(string body)
+    {
+        Body = body;
+    }
+
+    protected abstract string MethodSignature { get; }
+
+    public string Body { get; set; }
+
+    public string ToDocumentText()
+    {
+        return $"{MethodSignature}\n{{\n\t{Body}\n}}";
+    }
+}
+
+public class OnDeathScript : EntityScript
+{
+    public OnDeathScript()
+        : base(@"killer.SendMessage(""You have killed {0}.", this.Name);")
+    {
+    }
+
+    protected override string MethodSignature =>
+        "public void OnDeath(MobileEntity source, MobileEntity killer)";
+}
+
+public class OnIncomingPlayerScript : EntityScript
+{
+    public OnIncomingPlayerScript()
+        : base(@"player.SendMessage(""Welcome to the game, {0}!"", player.Name);")
+    {
+    }
+
+    protected override string MethodSignature =>
+        "public void OnIncomingPlayer(MobileEntity source, MobileEntity player)";
+}
+

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
@@ -31,7 +31,7 @@ public abstract class EntityScript : ObservableObject
 
     public string ToDocumentText()
     {
-        return $"{MethodSignature}\n{{\n\t{Body}\n}}";
+        return $"{MethodSignature}\n{{\n{Body}\n}}";
     }
 }
 

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/EntityScript.cs
@@ -13,7 +13,7 @@ public abstract class EntityScript : ObservableObject
         _body = body;
     }
 
-    protected abstract string MethodSignature { get; }
+    public abstract string MethodSignature { get; }
 
     public string Name { get; }
 
@@ -42,7 +42,7 @@ public class OnDeathScript : EntityScript
     {
     }
 
-    protected override string MethodSignature =>
+    public override string MethodSignature =>
         "public void OnDeath(MobileEntity source, MobileEntity killer)";
 }
 
@@ -53,7 +53,7 @@ public class OnIncomingPlayerScript : EntityScript
     {
     }
 
-    protected override string MethodSignature =>
+    public override string MethodSignature =>
         "public void OnIncomingPlayer(MobileEntity source, MobileEntity player)";
 }
 

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/ScriptWorkspace.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/ScriptWorkspace.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Kesmai.WorldForge.Roslyn;
+
+public class ScriptWorkspace
+{
+    private readonly AdhocWorkspace _workspace;
+    private readonly Project _project;
+
+    public ScriptWorkspace()
+    {
+        _workspace = new AdhocWorkspace();
+
+        var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(), "ScriptProject", "ScriptProject", LanguageNames.CSharp)
+            .WithMetadataReferences(new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location)
+            });
+
+        _project = _workspace.AddProject(projectInfo);
+    }
+
+    public Document CreateDocument(string name, EntityScript script)
+    {
+        var text = SourceText.From(script.ToDocumentText());
+        return _workspace.AddDocument(_project.Id, name, text);
+    }
+
+    public Document UpdateDocument(Document document, EntityScript script)
+    {
+        var text = SourceText.From(script.ToDocumentText());
+        _workspace.TryApplyChanges(document.WithText(text).Project.Solution);
+        return _workspace.CurrentSolution.GetDocument(document.Id)!;
+    }
+
+    public async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Document document)
+    {
+        var model = await document.GetSemanticModelAsync().ConfigureAwait(false);
+        return model.GetDiagnostics();
+    }
+}
+

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/ScriptWorkspace.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/ScriptWorkspace.cs
@@ -25,6 +25,13 @@ public class ScriptWorkspace
             });
 
         _project = _workspace.AddProject(projectInfo);
+
+        const string hostCode = @"public static class ScriptHost
+{
+    public static void Greet(string name) { }
+}";
+
+        _workspace.AddDocument(_project.Id, "ScriptHost.cs", SourceText.From(hostCode));
     }
 
     public Document CreateDocument(string name, EntityScript script)

--- a/Source/Kesmai.WorldForge/Editor/Roslyn/ScriptWorkspace.cs
+++ b/Source/Kesmai.WorldForge/Editor/Roslyn/ScriptWorkspace.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Kesmai.WorldForge.Roslyn;
@@ -13,7 +14,8 @@ public class ScriptWorkspace
 
     public ScriptWorkspace()
     {
-        _workspace = new AdhocWorkspace();
+        var host = MefHostServices.Create(MefHostServices.DefaultAssemblies);
+        _workspace = new AdhocWorkspace(host);
 
         var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(), "ScriptProject", "ScriptProject", LanguageNames.CSharp)
             .WithMetadataReferences(new[]

--- a/Source/Kesmai.WorldForge/Kesmai.WorldForge.csproj
+++ b/Source/Kesmai.WorldForge/Kesmai.WorldForge.csproj
@@ -50,6 +50,8 @@
       </PackageReference>
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.8.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
       <PackageReference Include="Syncfusion.PropertyGrid.WPF" Version="18.4.0.44" />
       <PackageReference Include="System.Linq" Version="4.3.0" />
       <PackageReference Include="WriteableBitmapEx" Version="1.6.7" />

--- a/Source/Kesmai.WorldForge/Kesmai.WorldForge.csproj
+++ b/Source/Kesmai.WorldForge/Kesmai.WorldForge.csproj
@@ -48,6 +48,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
       <PackageReference Include="Syncfusion.PropertyGrid.WPF" Version="18.4.0.44" />
       <PackageReference Include="System.Linq" Version="4.3.0" />
       <PackageReference Include="WriteableBitmapEx" Version="1.6.7" />

--- a/Source/Kesmai.WorldForge/UI/Controls/BindableTextEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/BindableTextEditor.cs
@@ -1,0 +1,68 @@
+using System.Windows;
+using ICSharpCode.AvalonEdit;
+
+namespace Kesmai.WorldForge.UI.Controls;
+
+/// <summary>
+/// A <see cref="TextEditor"/> that exposes the <see cref="Text"/> property as a
+/// dependency property so it can participate in WPF bindings.
+/// </summary>
+public class BindableTextEditor : TextEditor
+{
+    private bool _isUpdating;
+
+    /// <summary>
+    /// Identifies the <see cref="Text"/> dependency property.
+    /// </summary>
+    public new static readonly DependencyProperty TextProperty =
+        DependencyProperty.Register(
+            nameof(Text),
+            typeof(string),
+            typeof(BindableTextEditor),
+            new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnTextPropertyChanged));
+
+    /// <summary>
+    /// Gets or sets the editor's text content.
+    /// </summary>
+    public new string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public BindableTextEditor()
+    {
+        TextChanged += (_, __) =>
+        {
+            if (_isUpdating)
+                return;
+
+            try
+            {
+                _isUpdating = true;
+                SetCurrentValue(TextProperty, base.Text);
+            }
+            finally
+            {
+                _isUpdating = false;
+            }
+        };
+    }
+
+    private static void OnTextPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var editor = (BindableTextEditor)d;
+        if (editor._isUpdating)
+            return;
+
+        try
+        {
+            editor._isUpdating = true;
+            ((TextEditor)editor).Text = e.NewValue as string ?? string.Empty;
+        }
+        finally
+        {
+            editor._isUpdating = false;
+        }
+    }
+}

--- a/Source/Kesmai.WorldForge/UI/Controls/RoslynCompletionData.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/RoslynCompletionData.cs
@@ -1,0 +1,36 @@
+using System;
+using ICSharpCode.AvalonEdit.CodeCompletion;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Editing;
+using Microsoft.CodeAnalysis.Completion;
+
+namespace Kesmai.WorldForge.UI.Controls;
+
+internal class RoslynCompletionData : ICompletionData
+{
+    private readonly CompletionItem _item;
+    private readonly string _description;
+
+    public RoslynCompletionData(CompletionItem item, string description)
+    {
+        _item = item;
+        _description = description;
+        Text = item.DisplayText;
+    }
+
+    public System.Windows.Media.ImageSource Image => null;
+
+    public string Text { get; }
+
+    public object Content => Text;
+
+    public object Description => _description;
+
+    public double Priority => 0;
+
+    public void Complete(TextArea textArea, ISegment completionSegment, EventArgs insertionRequestEventArgs)
+    {
+        textArea.Document.Replace(completionSegment, Text);
+    }
+}
+

--- a/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Text;
+using RoslynDocument = Microsoft.CodeAnalysis.Document;
+
+namespace Kesmai.WorldForge.UI.Controls;
+
+/// <summary>
+/// Applies syntax highlighting based on Roslyn classification results.
+/// </summary>
+public class RoslynHighlightingColorizer : DocumentColorizingTransformer
+{
+    private IList<ClassifiedSpan> _classifications = new List<ClassifiedSpan>();
+
+    private static readonly Dictionary<string, Brush> _brushes = new()
+    {
+        { ClassificationTypeNames.Keyword, CreateBrush(0x56, 0x9C, 0xD6) },
+        { ClassificationTypeNames.StringLiteral, CreateBrush(0xD6, 0x9D, 0x85) },
+        { ClassificationTypeNames.Comment, CreateBrush(0x00, 0x80, 0x00) },
+        { ClassificationTypeNames.ClassName, CreateBrush(0x2B, 0x91, 0xAF) },
+        { ClassificationTypeNames.NumericLiteral, CreateBrush(0xB5, 0xCE, 0xA8) },
+    };
+
+    private static Brush CreateBrush(byte r, byte g, byte b)
+    {
+        var brush = new SolidColorBrush(Color.FromRgb(r, g, b));
+        brush.Freeze();
+        return brush;
+    }
+
+    /// <summary>
+    /// Updates the classification spans for the specified document.
+    /// </summary>
+    public async Task UpdateAsync(RoslynDocument document)
+    {
+        var text = await document.GetTextAsync().ConfigureAwait(true);
+        _classifications = await Classifier.GetClassifiedSpansAsync(document, new TextSpan(0, text.Length)).ConfigureAwait(true);
+    }
+
+    protected override void ColorizeLine(DocumentLine line)
+    {
+        int lineStart = line.Offset;
+        int lineEnd = line.EndOffset;
+
+        foreach (var span in _classifications)
+        {
+            if (span.TextSpan.End <= lineStart)
+                continue;
+            if (span.TextSpan.Start >= lineEnd)
+                break;
+
+            if (_brushes.TryGetValue(span.ClassificationType, out var brush))
+            {
+                int start = System.Math.Max(span.TextSpan.Start, lineStart);
+                int end = System.Math.Min(span.TextSpan.End, lineEnd);
+
+                ChangeLinePart(start, end, element =>
+                {
+                    element.TextRunProperties.SetForegroundBrush(brush);
+                });
+            }
+        }
+    }
+}

--- a/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using ICSharpCode.AvalonEdit.Document;
@@ -38,7 +39,7 @@ public class RoslynHighlightingColorizer : DocumentColorizingTransformer
     public async Task UpdateAsync(RoslynDocument document)
     {
         var text = await document.GetTextAsync().ConfigureAwait(true);
-        _classifications = await Classifier.GetClassifiedSpansAsync(document, new TextSpan(0, text.Length)).ConfigureAwait(true);
+        _classifications = (await Classifier.GetClassifiedSpansAsync(document, new TextSpan(0, text.Length)).ConfigureAwait(true)).ToList();
     }
 
     protected override void ColorizeLine(DocumentLine line)

--- a/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Media;
 using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.AvalonEdit.Rendering;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Text;
@@ -15,23 +19,8 @@ namespace Kesmai.WorldForge.UI.Controls;
 /// </summary>
 public class RoslynHighlightingColorizer : DocumentColorizingTransformer
 {
+    private readonly ClassificationHighlightColors _colors = new();
     private IList<ClassifiedSpan> _classifications = new List<ClassifiedSpan>();
-
-    private static readonly Dictionary<string, Brush> _brushes = new()
-    {
-        { ClassificationTypeNames.Keyword, CreateBrush(0x56, 0x9C, 0xD6) },
-        { ClassificationTypeNames.StringLiteral, CreateBrush(0xD6, 0x9D, 0x85) },
-        { ClassificationTypeNames.Comment, CreateBrush(0x00, 0x80, 0x00) },
-        { ClassificationTypeNames.ClassName, CreateBrush(0x2B, 0x91, 0xAF) },
-        { ClassificationTypeNames.NumericLiteral, CreateBrush(0xB5, 0xCE, 0xA8) },
-    };
-
-    private static Brush CreateBrush(byte r, byte g, byte b)
-    {
-        var brush = new SolidColorBrush(Color.FromRgb(r, g, b));
-        brush.Freeze();
-        return brush;
-    }
 
     /// <summary>
     /// Updates the classification spans for the specified document.
@@ -54,16 +43,106 @@ public class RoslynHighlightingColorizer : DocumentColorizingTransformer
             if (span.TextSpan.Start >= lineEnd)
                 break;
 
-            if (_brushes.TryGetValue(span.ClassificationType, out var brush))
+            var color = _colors.GetColor(span.ClassificationType);
+            if (color != null)
             {
-                int start = System.Math.Max(span.TextSpan.Start, lineStart);
-                int end = System.Math.Min(span.TextSpan.End, lineEnd);
+                int start = Math.Max(span.TextSpan.Start, lineStart);
+                int end = Math.Min(span.TextSpan.End, lineEnd);
 
                 ChangeLinePart(start, end, element =>
                 {
-                    element.TextRunProperties.SetForegroundBrush(brush);
+                    var foreground = color.Foreground?.GetBrush(CurrentContext);
+                    if (foreground != null)
+                        element.TextRunProperties.SetForegroundBrush(foreground);
+
+                    var background = color.Background?.GetBrush(CurrentContext);
+                    if (background != null)
+                        element.TextRunProperties.SetBackgroundBrush(background);
+
+                    if (color.FontWeight != null)
+                        element.TextRunProperties.SetFontWeight(color.FontWeight.Value);
                 });
             }
         }
     }
+}
+
+internal sealed class ClassificationHighlightColors
+{
+    public HighlightingColor DefaultBrush { get; } = CreateColor(Colors.Black);
+
+    public HighlightingColor TypeBrush { get; } = CreateColor(Colors.Teal);
+    public HighlightingColor MethodBrush { get; } = CreateColor(Colors.Olive);
+    public HighlightingColor ParameterBrush { get; } = CreateColor(Colors.DarkBlue);
+    public HighlightingColor CommentBrush { get; } = CreateColor(Colors.Green);
+    public HighlightingColor XmlCommentBrush { get; } = CreateColor(Colors.Gray);
+    public HighlightingColor KeywordBrush { get; } = CreateColor(Colors.Blue);
+    public HighlightingColor PreprocessorKeywordBrush { get; } = CreateColor(Colors.Gray);
+    public HighlightingColor StringBrush { get; } = CreateColor(Colors.Maroon);
+    public HighlightingColor BraceMatchingBrush { get; } = CreateColor(Colors.Black, Color.FromArgb(150, 219, 224, 204));
+    public HighlightingColor StaticSymbolBrush { get; } = CreateColor(null, null, FontWeights.Bold);
+
+    private readonly Lazy<ImmutableDictionary<string, HighlightingColor>> _map;
+
+    public ClassificationHighlightColors()
+    {
+        _map = new Lazy<ImmutableDictionary<string, HighlightingColor>>(() => new Dictionary<string, HighlightingColor>
+        {
+            [ClassificationTypeNames.ClassName] = TypeBrush,
+            [ClassificationTypeNames.RecordClassName] = TypeBrush,
+            [ClassificationTypeNames.RecordStructName] = TypeBrush,
+            [ClassificationTypeNames.StructName] = TypeBrush,
+            [ClassificationTypeNames.InterfaceName] = TypeBrush,
+            [ClassificationTypeNames.DelegateName] = TypeBrush,
+            [ClassificationTypeNames.EnumName] = TypeBrush,
+            [ClassificationTypeNames.ModuleName] = TypeBrush,
+            [ClassificationTypeNames.TypeParameterName] = TypeBrush,
+            [ClassificationTypeNames.MethodName] = MethodBrush,
+            [ClassificationTypeNames.ExtensionMethodName] = MethodBrush,
+            [ClassificationTypeNames.ParameterName] = ParameterBrush,
+            [ClassificationTypeNames.Comment] = CommentBrush,
+            [ClassificationTypeNames.StaticSymbol] = StaticSymbolBrush,
+            [ClassificationTypeNames.XmlDocCommentAttributeName] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentAttributeQuotes] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentAttributeValue] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentCDataSection] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentComment] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentDelimiter] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentEntityReference] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentName] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentProcessingInstruction] = XmlCommentBrush,
+            [ClassificationTypeNames.XmlDocCommentText] = CommentBrush,
+            [ClassificationTypeNames.Keyword] = KeywordBrush,
+            [ClassificationTypeNames.ControlKeyword] = KeywordBrush,
+            [ClassificationTypeNames.PreprocessorKeyword] = PreprocessorKeywordBrush,
+            [ClassificationTypeNames.StringLiteral] = StringBrush,
+            [ClassificationTypeNames.VerbatimStringLiteral] = StringBrush,
+            [AdditionalClassificationTypeNames.BraceMatching] = BraceMatchingBrush,
+        }.ToImmutableDictionary());
+    }
+
+    public HighlightingColor GetColor(string classificationType)
+    {
+        return _map.Value.TryGetValue(classificationType, out var color) ? color : DefaultBrush;
+    }
+
+    private static HighlightingColor CreateColor(Color? foreground, Color? background = null, FontWeight? fontWeight = null)
+    {
+        var color = new HighlightingColor();
+
+        if (foreground.HasValue)
+            color.Foreground = new SimpleHighlightingBrush(foreground.Value);
+        if (background.HasValue)
+            color.Background = new SimpleHighlightingBrush(background.Value);
+        if (fontWeight.HasValue)
+            color.FontWeight = fontWeight.Value;
+
+        color.Freeze();
+        return color;
+    }
+}
+
+internal static class AdditionalClassificationTypeNames
+{
+    public const string BraceMatching = nameof(BraceMatching);
 }

--- a/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/RoslynHighlightingColorizer.cs
@@ -60,7 +60,11 @@ public class RoslynHighlightingColorizer : DocumentColorizingTransformer
                         element.TextRunProperties.SetBackgroundBrush(background);
 
                     if (color.FontWeight != null)
-                        element.TextRunProperties.SetFontWeight(color.FontWeight.Value);
+                    {
+                        var typeface = element.TextRunProperties.Typeface;
+                        var bold = new Typeface(typeface.FontFamily, typeface.Style, color.FontWeight.Value, typeface.Stretch);
+                        element.TextRunProperties.SetTypeface(bold);
+                    }
                 });
             }
         }

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Document;
+
+namespace Kesmai.WorldForge.UI.Controls;
+
+/// <summary>
+/// Text editor that displays a read-only method signature and braces while allowing
+/// the user to edit only the script body.
+/// </summary>
+public class ScriptEditor : TextEditor
+{
+    private bool _isUpdating;
+    private int _prefixLength;
+    private int _suffixLength;
+
+    /// <summary>
+    /// Identifies the <see cref="Body"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty BodyProperty =
+        DependencyProperty.Register(
+            nameof(Body),
+            typeof(string),
+            typeof(ScriptEditor),
+            new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnBodyChanged));
+
+    /// <summary>
+    /// Identifies the <see cref="Header"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty HeaderProperty =
+        DependencyProperty.Register(
+            nameof(Header),
+            typeof(string),
+            typeof(ScriptEditor),
+            new FrameworkPropertyMetadata(string.Empty, OnHeaderChanged));
+
+    /// <summary>
+    /// Gets or sets the editable body of the script.
+    /// </summary>
+    public string Body
+    {
+        get => (string)GetValue(BodyProperty);
+        set => SetValue(BodyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the read-only method signature displayed above the body.
+    /// </summary>
+    public string Header
+    {
+        get => (string)GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    public ScriptEditor()
+    {
+        TextChanged += (_, __) =>
+        {
+            if (_isUpdating)
+                return;
+
+            try
+            {
+                _isUpdating = true;
+                var text = base.Text ?? string.Empty;
+                if (text.Length >= _prefixLength + _suffixLength)
+                {
+                    var body = text.Substring(_prefixLength, text.Length - _prefixLength - _suffixLength);
+                    SetCurrentValue(BodyProperty, body);
+                }
+            }
+            finally
+            {
+                _isUpdating = false;
+            }
+        };
+    }
+
+    private static void OnBodyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var editor = (ScriptEditor)d;
+        editor.UpdateDocument();
+    }
+
+    private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var editor = (ScriptEditor)d;
+        editor.UpdateDocument();
+    }
+
+    private void UpdateDocument()
+    {
+        if (_isUpdating)
+            return;
+
+        try
+        {
+            _isUpdating = true;
+
+            var nl = Environment.NewLine;
+            var header = Header ?? string.Empty;
+            var body = Body ?? string.Empty;
+            var prefix = header + nl + "{" + nl;
+            var suffix = nl + "}";
+
+            _prefixLength = prefix.Length;
+            _suffixLength = suffix.Length;
+
+            base.Text = prefix + body + suffix;
+            TextArea.CaretOffset = _prefixLength;
+            TextArea.ReadOnlySectionProvider = new HeaderFooterReadOnlySectionProvider(this);
+        }
+        finally
+        {
+            _isUpdating = false;
+        }
+    }
+
+    private class HeaderFooterReadOnlySectionProvider : IReadOnlySectionProvider
+    {
+        private readonly ScriptEditor _editor;
+
+        public HeaderFooterReadOnlySectionProvider(ScriptEditor editor)
+        {
+            _editor = editor;
+        }
+
+        public bool CanInsert(int offset)
+        {
+            return offset >= _editor._prefixLength &&
+                   offset <= _editor.Document.TextLength - _editor._suffixLength;
+        }
+
+        public IEnumerable<ISegment> GetDeletableSegments(ISegment segment)
+        {
+            int start = Math.Max(segment.Offset, _editor._prefixLength);
+            int end = Math.Min(segment.EndOffset, _editor.Document.TextLength - _editor._suffixLength);
+            if (start < end)
+                yield return new SimpleSegment(start, end - start);
+        }
+    }
+}

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
@@ -134,7 +134,7 @@ public class ScriptEditor : TextEditor
         public ReadOnlyBackgroundRenderer(ScriptEditor editor)
         {
             _editor = editor;
-            _backgroundBrush = new SolidColorBrush(Color.FromRgb(0x22, 0x22, 0x22));
+            _backgroundBrush = new SolidColorBrush(Color.FromRgb(0xEE, 0xEE, 0xEE));
             _backgroundBrush.Freeze();
         }
 

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
@@ -159,8 +159,7 @@ public class ScriptEditor : TextEditor
             var segment = new TextSegment { StartOffset = start, Length = length };
             foreach (var rect in BackgroundGeometryBuilder.GetRectsForSegment(textView, segment))
             {
-                var full = new Rect(rect.Location, new Size(textView.ActualWidth, rect.Height));
-                drawingContext.DrawRectangle(_backgroundBrush, null, full);
+                drawingContext.DrawRectangle(_backgroundBrush, null, rect);
             }
         }
     }

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows;
 using ICSharpCode.AvalonEdit;
 using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Editing;
 
 namespace Kesmai.WorldForge.UI.Controls;
 

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
@@ -110,7 +110,7 @@ public class ScriptEditor : TextEditor
             _suffixLength = suffix.Length;
 
             base.Text = prefix + body + suffix;
-            TextArea.CaretOffset = _prefixLength;
+            TextArea.Caret.Offset = _prefixLength;
             TextArea.ReadOnlySectionProvider = new HeaderFooterReadOnlySectionProvider(this);
         }
         finally
@@ -139,7 +139,7 @@ public class ScriptEditor : TextEditor
             int start = Math.Max(segment.Offset, _editor._prefixLength);
             int end = Math.Min(segment.EndOffset, _editor.Document.TextLength - _editor._suffixLength);
             if (start < end)
-                yield return new SimpleSegment(start, end - start);
+                yield return new TextSegment { StartOffset = start, Length = end - start };
         }
     }
 }

--- a/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/ScriptEditor.cs
@@ -159,7 +159,7 @@ public class ScriptEditor : TextEditor
             var segment = new TextSegment { StartOffset = start, Length = length };
             foreach (var rect in BackgroundGeometryBuilder.GetRectsForSegment(textView, segment))
             {
-                var full = new Rect(rect.Location, new Size(textView.Bounds.Width, rect.Height));
+                var full = new Rect(rect.Location, new Size(textView.ActualWidth, rect.Height));
                 drawingContext.DrawRectangle(_backgroundBrush, null, full);
             }
         }

--- a/Source/Kesmai.WorldForge/UI/Controls/TextMarkerService.cs
+++ b/Source/Kesmai.WorldForge/UI/Controls/TextMarkerService.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+
+namespace Kesmai.WorldForge.UI.Controls;
+
+internal sealed class TextMarkerService : IBackgroundRenderer
+{
+    private readonly List<TextMarker> _markers = new();
+
+    public TextMarkerService(TextDocument document)
+    {
+        // document parameter reserved for future use
+    }
+
+    public KnownLayer Layer => KnownLayer.Selection;
+
+    public void Draw(TextView textView, DrawingContext drawingContext)
+    {
+        if (_markers.Count == 0 || !textView.VisualLinesValid)
+            return;
+
+        foreach (var marker in _markers)
+        {
+            foreach (var rect in BackgroundGeometryBuilder.GetRectsForSegment(textView, marker))
+            {
+                var geometry = CreateSquiggle(rect.BottomLeft, rect.BottomRight);
+                drawingContext.DrawGeometry(null, new Pen(Brushes.Red, 1), geometry);
+            }
+        }
+    }
+
+    private static StreamGeometry CreateSquiggle(Point start, Point end)
+    {
+        const double step = 2;
+        var geometry = new StreamGeometry();
+        using var ctx = geometry.Open();
+        var x = start.X;
+        var y = start.Y;
+        var up = true;
+        ctx.BeginFigure(new Point(x, y), false, false);
+        while (x < end.X)
+        {
+            x += step;
+            y += up ? -step : step;
+            ctx.LineTo(new Point(x, y), true, false);
+            up = !up;
+        }
+        geometry.Freeze();
+        return geometry;
+    }
+
+    public void Mark(int startOffset, int length)
+    {
+        _markers.Add(new TextMarker(startOffset, length));
+    }
+
+    public void Clear()
+    {
+        _markers.Clear();
+    }
+
+    public TextMarker? GetMarkerAt(int offset)
+    {
+        return _markers.FirstOrDefault(m => offset >= m.StartOffset && offset <= m.EndOffset);
+    }
+
+    internal sealed class TextMarker : TextSegment
+    {
+        public TextMarker(int start, int length)
+        {
+            StartOffset = start;
+            Length = length;
+        }
+    }
+}
+

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
              xmlns:componentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-             xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
+             xmlns:controls="clr-namespace:Kesmai.WorldForge.UI.Controls"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300"
              
@@ -162,7 +162,7 @@
                 </TabControl.ItemTemplate>
                 <TabControl.ContentTemplate>
                     <DataTemplate>
-                        <avalonedit:TextEditor
+                        <controls:BindableTextEditor
                             SyntaxHighlighting="C#"
                             ShowLineNumbers="True"
                             Text="{Binding Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
              xmlns:componentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+             xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300"
              
@@ -161,7 +162,10 @@
                 </TabControl.ItemTemplate>
                 <TabControl.ContentTemplate>
                     <DataTemplate>
-                       
+                        <avalonedit:TextEditor
+                            SyntaxHighlighting="C#"
+                            ShowLineNumbers="True"
+                            Text="{Binding Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </DataTemplate>
                 </TabControl.ContentTemplate>
             </TabControl>

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -163,7 +163,6 @@
                 <TabControl.ContentTemplate>
                     <DataTemplate>
                         <controls:ScriptEditor
-                            SyntaxHighlighting="C#"
                             ShowLineNumbers="True"
                             Header="{Binding MethodSignature}"
                             Body="{Binding Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml
@@ -162,10 +162,11 @@
                 </TabControl.ItemTemplate>
                 <TabControl.ContentTemplate>
                     <DataTemplate>
-                        <controls:BindableTextEditor
+                        <controls:ScriptEditor
                             SyntaxHighlighting="C#"
                             ShowLineNumbers="True"
-                            Text="{Binding Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            Header="{Binding MethodSignature}"
+                            Body="{Binding Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </DataTemplate>
                 </TabControl.ContentTemplate>
             </TabControl>

--- a/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
+++ b/Source/Kesmai.WorldForge/UI/Documents/EntitiesDocument.xaml.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using Kesmai.WorldForge.Roslyn;
 
 namespace Kesmai.WorldForge.UI.Documents;
 
@@ -128,12 +129,19 @@ public partial class EntitiesDocument : UserControl
 			.Register<EntitiesDocument, Entity>(
 				this, (r, m) => { ChangeEntity(m); });
 
-		WeakReferenceMessenger.Default.Register<EntitiesDocument, GetSelectedSpawner>(this,
-			(r, m) => m.Reply(_spawnersList.SelectedItem as Spawner));
+                WeakReferenceMessenger.Default.Register<EntitiesDocument, GetSelectedSpawner>(this,
+                        (r, m) => m.Reply(_spawnersList.SelectedItem as Spawner));
 
-		WeakReferenceMessenger.Default.Register<EntitiesDocument, UnregisterEvents>(this,
-			(r, m) => { WeakReferenceMessenger.Default.UnregisterAll(this); });
-	}
+                WeakReferenceMessenger.Default.Register<EntitiesDocument, GetCurrentScriptSelection>(this,
+                        (r, m) =>
+                        {
+                                if (_scriptsTabControl.SelectedItem is EntityScript script)
+                                        m.Reply(script.Name);
+                        });
+
+                WeakReferenceMessenger.Default.Register<EntitiesDocument, UnregisterEvents>(this,
+                        (r, m) => { WeakReferenceMessenger.Default.UnregisterAll(this); });
+        }
 
 	private void ChangeEntity(Entity entity)
 	{


### PR DESCRIPTION
## Summary
- add Roslyn-based workspace for in-memory script editing and diagnostics
- demonstrate entity script fragments with OnDeath and OnIncomingPlayer examples
- include Roslyn package references for workspace support

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af69912f588321be371c45bf8767c5