### PR TITLE
Refactor equipment stat modifiers

### DIFF
--- a/Documentation/Kesmai.Server/ItemUseValidation.md
+++ b/Documentation/Kesmai.Server/ItemUseValidation.md
@@ -16,7 +16,7 @@ Keeping those questions separate allows tooltips, equipment bonuses, AI, and oth
 | `entity.TryUse(item)` | Performing a non-combat attempt and displaying its denial reason. |
 | `entity.TryUseForCombat(item)` | Performing a combat attempt; denial displays its reason and fumbles the item. |
 
-Override `ValidateUse`. `CanUse` is a convenience wrapper and cannot be overridden.
+Derived items with additional use requirements should override `ValidateUse`. Call `CanUse` when only a side-effect-free boolean result is needed; it automatically invokes the item's most-derived `ValidateUse` implementation. Derived items without additional requirements do not need to override either method.
 
 ## Defining Item Requirements
 

--- a/Documentation/Kesmai.Server/ItemUseValidation.md
+++ b/Documentation/Kesmai.Server/ItemUseValidation.md
@@ -1,0 +1,139 @@
+# Item Use Validation
+
+Item-use validation answers two separate questions:
+
+1. May this entity use the item?
+2. What should happen when an actual attempt is denied?
+
+Keeping those questions separate allows tooltips, equipment bonuses, AI, and other background calculations to check an item without displaying messages or causing a fumble.
+
+## API Overview
+
+| API | Use it for |
+| --- | --- |
+| `ValidateUse(MobileEntity entity)` | Defining an item's requirements and optional denial reason. |
+| `CanUse(MobileEntity entity)` | Checking eligibility without feedback or other side effects. |
+| `entity.TryUse(item)` | Performing a non-combat attempt and displaying its denial reason. |
+| `entity.TryUseForCombat(item)` | Performing a combat attempt; denial displays its reason and fumbles the item. |
+
+Override `ValidateUse`. `CanUse` is a convenience wrapper and cannot be overridden.
+
+## Defining Item Requirements
+
+Always check the base result first. This preserves binding restrictions and requirements inherited from the item's base class.
+
+```csharp
+public override ItemUseResult ValidateUse(MobileEntity entity)
+{
+    var result = base.ValidateUse(entity);
+
+    if (!result.IsAllowed)
+        return result;
+
+    if (entity is not PlayerEntity player)
+        return ItemUseResult.Denied();
+
+    if (player.Profession != Profession.Wizard)
+        return ItemUseResult.Denied("Only wizards may use this staff.");
+
+    if (player.Level < 20)
+        return ItemUseResult.Denied(Color.Red, "You must be level 20 to use this staff.");
+
+    return ItemUseResult.Allowed;
+}
+```
+
+Localized reasons are also supported:
+
+```csharp
+return ItemUseResult.Denied(new LocalizationEntry(6300001));
+return ItemUseResult.Denied(Color.Red, new LocalizationEntry(6300001));
+```
+
+A reason is optional. Prefer a useful reason when a player can correct the problem, such as a missing level, profession, alignment, unlock, or ownership requirement.
+
+## Checking Without Feedback
+
+Use `CanUse` when merely asking whether an item is eligible:
+
+```csharp
+if (item.CanUse(player))
+    entries.Add(new LocalizationEntry("You can use this item."));
+```
+
+This is appropriate for tooltips, AI decisions, previews, stat modifier calculations, and other queries that may happen frequently.
+
+## Performing an Attempt
+
+For an actual non-combat interaction, use `TryUse`:
+
+```csharp
+if (!player.TryUse(item))
+    return false;
+
+ActivateItem(player, item);
+return true;
+```
+
+If validation fails, `TryUse` displays the reason returned by the item. It does not fumble or move the item.
+
+Combat code uses `TryUseForCombat`:
+
+```csharp
+if (!attacker.TryUseForCombat(weapon) || attacker.CheckFumble(weapon))
+    return true;
+```
+
+When use requirements fail, `TryUseForCombat` displays the reason and fumbles the item. `CheckFumble` still handles the separate chance that an otherwise usable weapon is randomly or mechanically fumbled.
+
+## Use Requirements and Stat Modifiers
+
+Equipment stat eligibility uses the same pure validation by default. Guard the modifier calculation with `CanApplyStatModifiers` so an item that cannot be used does not contribute its continuous modifiers:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    if (CanApplyStatModifiers(wearer))
+        modifiers.Add(EntityStat.MaxHealth, 10);
+
+    return modifiers;
+}
+```
+
+Override `CanApplyStatModifiers` only when an item may be used but its stat bonus has an additional, distinct condition. The method must remain free of messages and other side effects. See [Equipment Stat Modifiers](StatModifiers.md) for the complete snapshot API.
+
+## Pitfalls to Avoid
+
+### Sending messages from validation
+
+Do not call `SendMessage`, `SendCombatMessage`, or `SendLocalizedMessage` from `ValidateUse`. A harmless `CanUse` query could otherwise display messages repeatedly. Return the message in `ItemUseResult.Denied`.
+
+### Calling `base.CanUse` from an override
+
+Do not do this:
+
+```csharp
+public override ItemUseResult ValidateUse(MobileEntity entity)
+{
+    if (!base.CanUse(entity))
+        return ItemUseResult.Denied();
+
+    return ItemUseResult.Allowed;
+}
+```
+
+`CanUse` calls `ValidateUse`, so this recurses into the override. Call `base.ValidateUse` and preserve its result.
+
+### Using combat validation everywhere
+
+`TryUseForCombat` fumbles on denial. Do not use it for equipping, inspecting, activating, or calculating an item. Use `TryUse` for a real non-combat attempt and `CanUse` for a query.
+
+### Duplicating requirements
+
+Do not independently reimplement the same profession, level, ownership, or alignment rule in `CanApplyStatModifiers`. Put the shared rule in `ValidateUse`; the default modifier eligibility will reuse it.
+
+### Mutating state during validation
+
+Validation may run during equipment refreshes and other background operations. Do not bind or move items, update quests, consume resources, start cooldowns, roll randomness, or change stats from `ValidateUse`.

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -1,0 +1,359 @@
+# Bonus Refactor API: Equipment Stat Modifiers
+
+This guide explains how to give equipped and wielded items continuous stat bonuses using the source-aware stat modifier API.
+
+## Overview
+
+Each active item supplies a complete snapshot of its stat modifiers. The wearer stores that snapshot under the item that supplied it.
+
+When an item changes, the system:
+
+1. removes the exact snapshot previously registered by that item;
+2. calculates a new snapshot;
+3. applies the new values.
+
+When the item is removed, the stored snapshot is removed without recalculating it. This prevents stale bonuses and arithmetic drift when a bonus depends on quality, level, profession, skills, alignment, segment, or other equipment.
+
+## API at a Glance
+
+| API | Purpose |
+| --- | --- |
+| `GetStatModifiers(MobileEntity wearer)` | Returns the item's complete continuous stat snapshot. Override this when creating equipment bonuses. |
+| `StatModifierSet.Add(...)` | Adds an ordinary `EntityStat` modifier to the snapshot. |
+| `StatModifierSet.AddMaximumValue(...)` | Changes the maximum-value constraint of an `EntityStat`. |
+| `UpdateStatModifiers()` | Replaces this item's active snapshot after one of its dependencies changes. It does nothing while the item is inactive. |
+| `MobileEntity.UpdateStatModifiers()` | Refreshes every equipped and wielded item for the wearer. |
+| `CanApplyStatModifiers(MobileEntity wearer)` | Determines whether the item may currently provide its stat modifiers. Override it with a side-effect-free eligibility check when needed. |
+| `ActivateBonus(...)` / `InactivateBonus(...)` | Lifecycle operations used by equipment containers. Normal item code should not call these to refresh a bonus. |
+
+The system resolves the wearer from the item's `Parent`. Items do not need to store their own wearer reference.
+
+## Basic Example
+
+This ring always grants five Strength while equipped:
+
+```csharp
+public class ExampleStrengthRing : Ring
+{
+    public ExampleStrengthRing() : base(1)
+    {
+    }
+
+    public ExampleStrengthRing(Serial serial) : base(serial)
+    {
+    }
+
+    protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+    {
+        var modifiers = base.GetStatModifiers(wearer);
+        modifiers.Add(EntityStat.Strength, 5);
+        return modifiers;
+    }
+}
+```
+
+Always call `base.GetStatModifiers(wearer)`. Base equipment classes may already provide protection, regeneration, or other modifiers.
+
+## Multiple Modifiers and Modifier Types
+
+One snapshot can contain any number of entries:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    modifiers.Add(EntityStat.MaxHealth, 20);
+    modifiers.Add(EntityStat.FireProtection, 5);
+    modifiers.Add(EntityStat.MagicDamageDealtIncrease, 10, ModifierType.AdditivePercent);
+
+    return modifiers;
+}
+```
+
+The default modifier type is `ModifierType.Constant`. Specify another type only when the stat calculation requires percentage behavior.
+
+Repeated entries are preserved. This is important for multiplicative modifiers, where two entries may not be equivalent to one combined entry.
+
+## Changing a Stat's Maximum Value
+
+Use `AddMaximumValue` when the item changes an attribute's allowed maximum rather than its current calculated value:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    modifiers.Add(EntityStat.FireProtection, 10);
+    modifiers.AddMaximumValue(EntityStat.FireProtection, 10);
+
+    return modifiers;
+}
+```
+
+Do not implement maximum-value changes by modifying `MaximumValue` directly in activation hooks. The snapshot system must own both application and removal.
+
+## Quality-Dependent Bonus
+
+The built-in `Quality` setter automatically refreshes an active item's snapshot:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+    var bonus = Math.Max(0, Quality.Value - 1);
+
+    if (bonus > 0)
+        modifiers.Add(EntityStat.HealthRegenerationRate, bonus);
+
+    return modifiers;
+}
+```
+
+There is no need to call `InactivateBonus` and `ActivateBonus` around a quality change.
+
+## Refreshing a Custom Item Property
+
+If a custom property affects the snapshot, refresh the item in that property's setter:
+
+```csharp
+private int _power;
+
+[CommandProperty(AccessLevel.GameMaster)]
+public int Power
+{
+    get => _power;
+    set
+    {
+        if (_power == value)
+            return;
+
+        _power = value;
+        UpdateStatModifiers();
+        Delta(ItemDelta.Update);
+    }
+}
+
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+    modifiers.Add(EntityStat.MaxMana, Power);
+    return modifiers;
+}
+```
+
+`UpdateStatModifiers` safely does nothing if the item is not active.
+
+## Wearer-Dependent Bonus
+
+The wearer passed to `GetStatModifiers` may be used to calculate the snapshot:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    if (wearer is PlayerEntity player && player.Profession == Profession.Wizard)
+        modifiers.Add(EntityStat.MaxMana, player.Level * 2);
+
+    return modifiers;
+}
+```
+
+Core gameplay refreshes equipment after level, profession, alignment, relevant skill, segment, facet, and equipment changes. If new wearer state affects equipment, its change path must call `wearer.UpdateStatModifiers()`.
+
+Use an ordinary equality expression for professions. `Profession` is not a compile-time constant, so this property-pattern form does not compile:
+
+```csharp
+// Do not use this.
+if (wearer is PlayerEntity { Profession: Profession.Wizard })
+{
+}
+```
+
+## Segment-Dependent Bonus
+
+Items may inspect the segment occupied by the wearer:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    if (wearer.Segment != null && wearer.Segment.Index == 3)
+        modifiers.Add(EntityStat.MagicDamageDealtIncrease, 10);
+
+    return modifiers;
+}
+```
+
+Equipment is refreshed after segment and facet changes, so the old segment snapshot is removed and the new one is applied.
+
+## Bonus Depending on Other Equipment
+
+Calculate set bonuses from the wearer's current equipment:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    if (wearer is PlayerEntity player &&
+        player.Paperdoll.Helmet is ValorHelm &&
+        player.Paperdoll.Gauntlets is HonorGaunts)
+    {
+        modifiers.Add(EntityStat.MaxHealth, 25);
+    }
+
+    return modifiers;
+}
+```
+
+Paperdoll, ring, and hand transactions refresh equipped sources after the transaction. Do not activate, inactivate, or directly modify one item from another item.
+
+## Eligibility Checks
+
+Use `CanApplyStatModifiers` when an item should remain equipped but temporarily stop providing stats:
+
+```csharp
+protected override bool CanApplyStatModifiers(MobileEntity wearer)
+{
+    if (!MeetsBaseUseRequirements(wearer))
+        return false;
+
+    return wearer.Alignment == Alignment.Lawful;
+}
+
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+
+    if (CanApplyStatModifiers(wearer))
+        modifiers.Add(EntityStat.Strength, 3);
+
+    return modifiers;
+}
+```
+
+Keep this check free of messages, timers, random rolls, subscriptions, and other side effects because it may run often during refreshes.
+
+## Lifecycle Side Effects
+
+`OnActivateBonus` and `OnInactivateBonus` still have a purpose. Use them for behavior that happens once when the item becomes active or inactive, such as adding an item source to a status effect.
+
+Likewise, `OnWield` and `OnUnwield` remain appropriate for wield messages, cooldowns, event subscriptions, and other actual wield events.
+
+Do not also modify an `EntityStat` in those hooks if it is returned by `GetStatModifiers`.
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+    modifiers.Add(EntityStat.Strength, StrengthBonus);
+    return modifiers;
+}
+
+protected override void OnActivateBonus(MobileEntity entity)
+{
+    base.OnActivateBonus(entity);
+    AddStatusSource(entity);
+}
+
+protected override void OnInactivateBonus(MobileEntity entity)
+{
+    RemoveStatusSource(entity);
+    base.OnInactivateBonus(entity);
+}
+```
+
+## Dynamic Combat Properties
+
+Not every calculated equipment value belongs in a snapshot. Properties read only when combat occurs can remain ordinary calculated properties, for example:
+
+- minimum and maximum damage;
+- swing speed;
+- proc chance;
+- armor protection and blocking calculations;
+- tooltip-only values.
+
+Refresh a stat snapshot only when the item contributes to an `EntityStat` or an attribute maximum. Dynamic properties may still require an item delta so the tooltip is updated.
+
+## BaseDodge Compatibility
+
+`StatModifierSet.BaseDodge` is a temporary compatibility path because dodge is not yet represented by an `EntityStat`. Use it only for an equipped item's continuous dodge contribution:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+{
+    var modifiers = base.GetStatModifiers(wearer);
+    modifiers.BaseDodge += 1;
+    return modifiers;
+}
+```
+
+Do not add new direct `wearer.BaseDodge += value` and `-= value` pairs for equipment. When Dodge becomes an `EntityStat`, this special snapshot field will be replaced by a normal `Add` call.
+
+## Pitfalls to Avoid
+
+### Direct add/remove pairs
+
+Do not write equipment stats like this:
+
+```csharp
+protected override void OnActivateBonus(MobileEntity entity) =>
+    entity.Stats[EntityStat.MaxHealth].Add(Bonus, ModifierType.Constant);
+
+protected override void OnInactivateBonus(MobileEntity entity) =>
+    entity.Stats[EntityStat.MaxHealth].Remove(Bonus, ModifierType.Constant);
+```
+
+If `Bonus` changes between activation and inactivation, the wrong value is removed. Return it from `GetStatModifiers` instead.
+
+### Replaying activation to refresh stats
+
+Do not call `InactivateBonus` followed by `ActivateBonus` when a property changes. That replays unrelated lifecycle behavior. Call `UpdateStatModifiers()`.
+
+### Depending on activation-hook setup
+
+The initial snapshot is registered before `OnActivateBonus` runs, and it is removed before `OnInactivateBonus` runs. Do not make `GetStatModifiers` depend on state initialized or cleared by those hooks. Store required item state before equip or refresh it explicitly after that state changes.
+
+### Omitting the base snapshot
+
+Failing to call `base.GetStatModifiers(wearer)` silently drops modifiers declared by base equipment classes.
+
+### Side effects during calculation
+
+`GetStatModifiers` can run because of unrelated equipment or wearer changes. It must be deterministic and safe to call repeatedly. Do not send messages, roll randomness, create timers, subscribe to events, or mutate other items from it.
+
+### Returning only the value that changed
+
+Every call must return the item's complete snapshot. `Replace` removes the entire old snapshot before applying the new one.
+
+### Forgetting a refresh trigger
+
+The system cannot detect arbitrary custom dependencies. A custom item property must call `UpdateStatModifiers`; a new wearer dependency must call `MobileEntity.UpdateStatModifiers` from its change path.
+
+### Recalculating during removal
+
+Do not compute what should be subtracted during unequip. The collection already retains and removes the exact registered snapshot.
+
+## Testing Checklist
+
+For an item with stat modifiers, verify:
+
+- equipping or wielding applies the expected values once;
+- calling `UpdateStatModifiers` replaces rather than stacks the snapshot;
+- quality and custom property changes replace the active values;
+- relevant wearer changes refresh the values;
+- set bonuses update after both equipping and removing another piece;
+- unequipping or unwielding restores the original values;
+- lifecycle hooks are not replayed during a refresh;
+- ineligible wearers receive no modifiers.
+
+## Related Source
+
+- `Kesmai.Server.Game.StatModifier`
+- `Kesmai.Server.Game.StatModifierSet`
+- `Kesmai.Server.Game.StatModifierCollection`
+- `Kesmai.Server.Items.ItemEntity`
+- `Kesmai.Server.Game.MobileEntity`

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -31,6 +31,8 @@ The system resolves the wearer from the item's `Parent`. Items do not need to st
 
 Sources are compared by object identity. Always replace and remove a modifier snapshot with the same item or status instance that registered it.
 
+`EntityStat.None` does not identify a real stat and cannot be added to a snapshot. `Add` and `AddMaximumValue` throw `ArgumentOutOfRangeException` when it is supplied.
+
 ## Basic Example
 
 This ring always grants five Strength while equipped:
@@ -295,6 +297,10 @@ protected override StatModifierSet GetStatModifiers(MobileEntity target)
 
 Multiple casters do not automatically multiply the modifier. The status decides whether sources are fixed, additive, or strongest-wins when it builds the snapshot.
 
+`Spells` and `Items` are read-only, runtime-enforced views. Add and remove entries through `AddSource` and `RemoveSource`; direct dictionary mutation is not supported because it would bypass source ownership, expiration timers, lifecycle hooks, and modifier refreshes. Only `SpellSource` and `ItemSource` are accepted, their fixed mobile or item key cannot be null, and one source instance cannot belong to multiple statuses.
+
+Adding another source for the same caster or item is a refresh. The old source instance is detached and the new instance becomes the status-owned source.
+
 A debuff uses negative values:
 
 ```csharp
@@ -310,6 +316,8 @@ protected override StatModifierSet GetStatModifiers(MobileEntity target)
 When a source is added, refreshed, or removed, the status replaces its previous aggregate snapshot. When the status expires, the exact stored snapshot is removed. Do not recalculate an amount to subtract in `OnRemoved`.
 
 Keep messages, sounds, timers, and other lifecycle behavior in `OnAcquire`, `OnRemoved`, `OnSourceAdded`, and `OnSourceRemoved`. Those hooks must not directly mutate stats represented by the snapshot.
+
+The owning mobile controls status lifecycle through internal `NotifyAcquired` and `NotifyRemoved` dispatchers. Status implementations override the protected `OnAcquire` and `OnRemoved` hooks; they do not call or override the internal dispatchers.
 
 ## Dynamic Combat Properties
 
@@ -371,6 +379,14 @@ Failing to call `base.GetStatModifiers(wearer)` silently drops modifiers declare
 `GetStatModifiers` can run because of unrelated equipment or wearer changes. It must be deterministic and safe to call repeatedly. Do not send messages, roll randomness, create timers, subscribe to events, or mutate other items from it.
 
 The same rule applies to `SpellStatus.GetStatModifiers`. Read authoritative status sources and wearer state rather than another source's already-calculated stat value, which would make refresh results order dependent.
+
+### Throwing from calculations or lifecycle hooks
+
+Treat `GetStatModifiers`, `OnActivateBonus`, `OnInactivateBonus`, `OnAcquire`, and `OnRemoved` as no-throw operations. Item modifier calculation finishes before the item is marked active, but the framework cannot automatically reverse arbitrary messages, timers, subscriptions, or other side effects if a hook throws. Handle expected missing or inapplicable state by returning the appropriate snapshot and completing the hook normally.
+
+### Mutating status source dictionaries
+
+Do not cast or otherwise attempt to mutate the `Spells` or `Items` views. Use `AddSource` and `RemoveSource` so timers, ownership, hooks, and the aggregate modifier snapshot stay consistent.
 
 ### Returning only the value that changed
 

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -23,7 +23,7 @@ When the item is removed, the stored snapshot is removed without recalculating i
 | `StatModifierSet.AddMaximumValue(...)` | Changes the maximum-value constraint of an `EntityStat`. |
 | `UpdateStatModifiers()` | Replaces this item's active snapshot after one of its dependencies changes. It does nothing while the item is inactive. |
 | `MobileEntity.UpdateStatModifiers()` | Refreshes every equipped and wielded item for the wearer. |
-| `CanApplyStatModifiers(MobileEntity wearer)` | Determines whether the item may currently provide its stat modifiers. Override it with a side-effect-free eligibility check when needed. |
+| `CanApplyStatModifiers(MobileEntity wearer)` | Determines whether the item may currently provide its stat modifiers. It uses side-effect-free item validation by default. Override it only when modifier eligibility differs from use eligibility. |
 | `ActivateBonus(...)` / `InactivateBonus(...)` | Lifecycle operations used by equipment containers. Normal item code should not call these to refresh a bonus. |
 
 The system resolves the wearer from the item's `Parent`. Items do not need to store their own wearer reference.
@@ -213,15 +213,19 @@ Paperdoll, ring, and hand transactions refresh equipped sources after the transa
 
 ## Eligibility Checks
 
-Use `CanApplyStatModifiers` when an item should remain equipped but temporarily stop providing stats:
+Use `ValidateUse` when the same eligibility rule controls both item use and stat modifiers. Return the reason instead of sending a message inside validation:
 
 ```csharp
-protected override bool CanApplyStatModifiers(MobileEntity wearer)
+public override ItemUseResult ValidateUse(MobileEntity entity)
 {
-    if (!MeetsBaseUseRequirements(wearer))
-        return false;
+    var result = base.ValidateUse(entity);
 
-    return wearer.Alignment == Alignment.Lawful;
+    if (!result.IsAllowed)
+        return result;
+
+    return entity.Alignment == Alignment.Lawful
+        ? ItemUseResult.Allowed
+        : ItemUseResult.Denied("Only lawful characters may use this item.");
 }
 
 protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
@@ -234,6 +238,8 @@ protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
     return modifiers;
 }
 ```
+
+`CanUse` is a side-effect-free boolean wrapper around `ValidateUse`; do not override it. Call `entity.TryUse(item)` at an interactive use site so a denial reason is reported. Combat paths call `entity.TryUseForCombat(item)`, which additionally fumbles a denied item. Override `CanApplyStatModifiers` only when an item may be used but its modifiers have a distinct eligibility rule.
 
 Keep this check free of messages, timers, random rolls, subscriptions, and other side effects because it may run often during refreshes.
 

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -301,6 +301,10 @@ Multiple casters do not automatically multiply the modifier. The status decides 
 
 Adding another source for the same caster or item is a refresh. The old source instance is detached and the new instance becomes the status-owned source.
 
+A status runs at most one spell-expiration timer. When no item source exists, the finite spell source with the latest `End` controls it; shorter sources therefore cannot shorten the benefit. At expiration, all spell sources ending at or before that controlling time are removed together. A zero-duration spell source is indefinite and suppresses expiration.
+
+An item source also suppresses the timer because it makes the status persistent. Spell expiration timestamps continue to elapse while the item remains. Removing the last item source restarts timing from the latest remaining spell expiration, which may expire immediately if that time has already passed. Status implementations should not create additional timers for `SpellSource` expiration.
+
 A debuff uses negative values:
 
 ```csharp

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -23,9 +23,9 @@ When the source is removed, the stored snapshot is removed without recalculating
 | `StatModifierSet.AddMaximumValue(...)` | Changes the maximum-value constraint of an `EntityStat`. |
 | `UpdateStatModifiers()` | Replaces this source's active snapshot after one of its dependencies changes. It does nothing while the source is inactive. |
 | `MobileEntity.UpdateStatModifiers()` | Refreshes every registered item and status source for the wearer. |
-| `IStatModifierSource` | Gives an item or status the shared `AreModifiersActive`, activation, update, and inactivation lifecycle. |
+| `IStatModifierSource` | Provides the shared public `UpdateStatModifiers()` refresh contract. |
 | `CanApplyStatModifiers(MobileEntity wearer)` | Determines whether the item may currently provide its stat modifiers. It uses side-effect-free item validation by default. Override it only when modifier eligibility differs from use eligibility. |
-| `ActivateModifiers(...)` / `InactivateModifiers(...)` | Register or remove a source's snapshot. Equipment and status lifecycles call these operations. |
+| `ActivateModifiers(...)` / `InactivateModifiers(...)` | Protected or internal framework operations that register and remove snapshots. Normal callers should not invoke them. |
 
 The system resolves the wearer from the item's `Parent`. Items do not need to store their own wearer reference.
 

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -1,4 +1,4 @@
-# Bonus Refactor API: Equipment Stat Modifiers
+# Equipment Stat Modifiers
 
 This guide explains how to give equipped and wielded items continuous stat bonuses using the source-aware stat modifier API.
 
@@ -336,24 +336,3 @@ The system cannot detect arbitrary custom dependencies. A custom item property m
 ### Recalculating during removal
 
 Do not compute what should be subtracted during unequip. The collection already retains and removes the exact registered snapshot.
-
-## Testing Checklist
-
-For an item with stat modifiers, verify:
-
-- equipping or wielding applies the expected values once;
-- calling `UpdateStatModifiers` replaces rather than stacks the snapshot;
-- quality and custom property changes replace the active values;
-- relevant wearer changes refresh the values;
-- set bonuses update after both equipping and removing another piece;
-- unequipping or unwielding restores the original values;
-- lifecycle hooks are not replayed during a refresh;
-- ineligible wearers receive no modifiers.
-
-## Related Source
-
-- `Kesmai.Server.Game.StatModifier`
-- `Kesmai.Server.Game.StatModifierSet`
-- `Kesmai.Server.Game.StatModifierCollection`
-- `Kesmai.Server.Items.ItemEntity`
-- `Kesmai.Server.Game.MobileEntity`

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -23,9 +23,9 @@ When the source is removed, the stored snapshot is removed without recalculating
 | `StatModifierSet.AddMaximumValue(...)` | Changes the maximum-value constraint of an `EntityStat`. |
 | `UpdateStatModifiers()` | Replaces this source's active snapshot after one of its dependencies changes. It does nothing while the source is inactive. |
 | `MobileEntity.UpdateStatModifiers()` | Refreshes every registered item and status source for the wearer. |
-| `IStatModifierSource` | Identifies an item or status that owns a replaceable modifier snapshot. |
+| `IStatModifierSource` | Gives an item or status the shared `AreModifiersActive`, activation, update, and inactivation lifecycle. |
 | `CanApplyStatModifiers(MobileEntity wearer)` | Determines whether the item may currently provide its stat modifiers. It uses side-effect-free item validation by default. Override it only when modifier eligibility differs from use eligibility. |
-| `ActivateBonus(...)` / `InactivateBonus(...)` | Lifecycle operations used by equipment containers. Normal item code should not call these to refresh a bonus. |
+| `ActivateModifiers(...)` / `InactivateModifiers(...)` | Register or remove a source's snapshot. Equipment and status lifecycles call these operations. |
 
 The system resolves the wearer from the item's `Parent`. Items do not need to store their own wearer reference.
 
@@ -113,7 +113,7 @@ protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 }
 ```
 
-There is no need to call `InactivateBonus` and `ActivateBonus` around a quality change.
+There is no need to call `InactivateModifiers` and `ActivateModifiers` around a quality change.
 
 ## Refreshing a Custom Item Property
 
@@ -356,7 +356,7 @@ If `Bonus` changes between activation and inactivation, the wrong value is remov
 
 ### Replaying activation to refresh stats
 
-Do not call `InactivateBonus` followed by `ActivateBonus` when a property changes. That replays unrelated lifecycle behavior. Call `UpdateStatModifiers()`.
+Do not call `InactivateModifiers` followed by `ActivateModifiers` when a property changes. That replays unrelated lifecycle behavior. Call `UpdateStatModifiers()`.
 
 ### Depending on activation-hook setup
 

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -31,7 +31,7 @@ The system resolves the wearer from the item's `Parent`. Items do not need to st
 
 Sources are compared by object identity. Always replace and remove a modifier snapshot with the same item or status instance that registered it.
 
-`EntityStat.None` does not identify a real stat and cannot be added to a snapshot. `Add` and `AddMaximumValue` throw `ArgumentOutOfRangeException` when it is supplied.
+`EntityStat.None`, undefined `EntityStat` values, and undefined `ModifierType` values cannot be added to a snapshot. Construction and addition throw `ArgumentOutOfRangeException` for invalid values. `Modifiers` and `MaximumValueModifiers` are runtime-enforced read-only views; add entries through `Add` and `AddMaximumValue` rather than attempting to mutate those collections.
 
 ## Basic Example
 

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -213,6 +213,8 @@ Paperdoll, ring, and hand transactions refresh equipped sources after the transa
 
 ## Eligibility Checks
 
+See [Item Use Validation](ItemUseValidation.md) for the full public API, interaction examples, and pitfalls. This section focuses on how use eligibility affects continuous equipment stats.
+
 Use `ValidateUse` when the same eligibility rule controls both item use and stat modifiers. Return the reason instead of sending a message inside validation:
 
 ```csharp
@@ -239,7 +241,7 @@ protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 }
 ```
 
-`CanUse` is a side-effect-free boolean wrapper around `ValidateUse`; do not override it. Call `entity.TryUse(item)` at an interactive use site so a denial reason is reported. Combat paths call `entity.TryUseForCombat(item)`, which additionally fumbles a denied item. Override `CanApplyStatModifiers` only when an item may be used but its modifiers have a distinct eligibility rule.
+`CanUse` is a side-effect-free boolean wrapper around `ValidateUse`; do not override it. The default `CanApplyStatModifiers` uses this same validation, so shared profession, level, alignment, unlock, binding, and ownership requirements belong in `ValidateUse`. Override `CanApplyStatModifiers` only when modifier eligibility is intentionally different.
 
 Keep this check free of messages, timers, random rolls, subscriptions, and other side effects because it may run often during refreshes.
 

--- a/Documentation/Kesmai.Server/StatModifiers.md
+++ b/Documentation/Kesmai.Server/StatModifiers.md
@@ -1,18 +1,18 @@
 # Equipment Stat Modifiers
 
-This guide explains how to give equipped and wielded items continuous stat bonuses using the source-aware stat modifier API.
+This guide explains how to give equipment, buffs, and debuffs continuous stat modifiers using the source-aware API.
 
 ## Overview
 
-Each active item supplies a complete snapshot of its stat modifiers. The wearer stores that snapshot under the item that supplied it.
+Each active modifier source—such as an item, buff, or debuff—supplies a complete snapshot of its stat modifiers. The wearer stores that snapshot under the instance that supplied it.
 
-When an item changes, the system:
+When a source changes, the system:
 
-1. removes the exact snapshot previously registered by that item;
+1. removes the exact snapshot previously registered by that source;
 2. calculates a new snapshot;
 3. applies the new values.
 
-When the item is removed, the stored snapshot is removed without recalculating it. This prevents stale bonuses and arithmetic drift when a bonus depends on quality, level, profession, skills, alignment, segment, or other equipment.
+When the source is removed, the stored snapshot is removed without recalculating it. This prevents stale modifiers and arithmetic drift when a value depends on quality, level, profession, skills, alignment, segment, equipment, or status sources.
 
 ## API at a Glance
 
@@ -21,12 +21,15 @@ When the item is removed, the stored snapshot is removed without recalculating i
 | `GetStatModifiers(MobileEntity wearer)` | Returns the item's complete continuous stat snapshot. Override this when creating equipment bonuses. |
 | `StatModifierSet.Add(...)` | Adds an ordinary `EntityStat` modifier to the snapshot. |
 | `StatModifierSet.AddMaximumValue(...)` | Changes the maximum-value constraint of an `EntityStat`. |
-| `UpdateStatModifiers()` | Replaces this item's active snapshot after one of its dependencies changes. It does nothing while the item is inactive. |
-| `MobileEntity.UpdateStatModifiers()` | Refreshes every equipped and wielded item for the wearer. |
+| `UpdateStatModifiers()` | Replaces this source's active snapshot after one of its dependencies changes. It does nothing while the source is inactive. |
+| `MobileEntity.UpdateStatModifiers()` | Refreshes every registered item and status source for the wearer. |
+| `IStatModifierSource` | Identifies an item or status that owns a replaceable modifier snapshot. |
 | `CanApplyStatModifiers(MobileEntity wearer)` | Determines whether the item may currently provide its stat modifiers. It uses side-effect-free item validation by default. Override it only when modifier eligibility differs from use eligibility. |
 | `ActivateBonus(...)` / `InactivateBonus(...)` | Lifecycle operations used by equipment containers. Normal item code should not call these to refresh a bonus. |
 
 The system resolves the wearer from the item's `Parent`. Items do not need to store their own wearer reference.
+
+Sources are compared by object identity. Always replace and remove a modifier snapshot with the same item or status instance that registered it.
 
 ## Basic Example
 
@@ -274,6 +277,40 @@ protected override void OnInactivateBonus(MobileEntity entity)
 }
 ```
 
+## Buffs and Debuffs
+
+A `SpellStatus` supplies one complete snapshot for all of its spell and item sources. This example applies Strength once while at least one spell source remains:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity target)
+{
+    var modifiers = base.GetStatModifiers(target);
+
+    if (Spells.Count > 0)
+        modifiers.Add(EntityStat.Strength, 6);
+
+    return modifiers;
+}
+```
+
+Multiple casters do not automatically multiply the modifier. The status decides whether sources are fixed, additive, or strongest-wins when it builds the snapshot.
+
+A debuff uses negative values:
+
+```csharp
+protected override StatModifierSet GetStatModifiers(MobileEntity target)
+{
+    var modifiers = base.GetStatModifiers(target);
+    modifiers.Add(EntityStat.Strength, -6);
+    modifiers.Add(EntityStat.HealthRegenerationRate, -2);
+    return modifiers;
+}
+```
+
+When a source is added, refreshed, or removed, the status replaces its previous aggregate snapshot. When the status expires, the exact stored snapshot is removed. Do not recalculate an amount to subtract in `OnRemoved`.
+
+Keep messages, sounds, timers, and other lifecycle behavior in `OnAcquire`, `OnRemoved`, `OnSourceAdded`, and `OnSourceRemoved`. Those hooks must not directly mutate stats represented by the snapshot.
+
 ## Dynamic Combat Properties
 
 Not every calculated equipment value belongs in a snapshot. Properties read only when combat occurs can remain ordinary calculated properties, for example:
@@ -332,6 +369,8 @@ Failing to call `base.GetStatModifiers(wearer)` silently drops modifiers declare
 ### Side effects during calculation
 
 `GetStatModifiers` can run because of unrelated equipment or wearer changes. It must be deterministic and safe to call repeatedly. Do not send messages, roll randomness, create timers, subscribe to events, or mutate other items from it.
+
+The same rule applies to `SpellStatus.GetStatModifiers`. Read authoritative status sources and wearer state rather than another source's already-calculated stat value, which would make refresh results order dependent.
 
 ### Returning only the value that changed
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/AlligatorVest.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/AlligatorVest.cs
@@ -42,28 +42,17 @@ public class AlligatorVest : Armor
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+1, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+1, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 1);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 1);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+1, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+1, ModifierType.Constant);
-	}
-		
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)
 	{

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/AlligatorVest.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/AlligatorVest.cs
@@ -43,9 +43,9 @@ public class AlligatorVest : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 1);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 1);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/AlligatorVest.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/AlligatorVest.cs
@@ -43,14 +43,14 @@ public class AlligatorVest : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 1);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 1);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 1);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 1);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/ChainmailArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/ChainmailArmor.cs
@@ -42,27 +42,18 @@ public class ChainmailArmor : Armor
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+1, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 1);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+1, ModifierType.Constant);
-	}
+
 
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/ChainmailArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/ChainmailArmor.cs
@@ -43,9 +43,9 @@ public class ChainmailArmor : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 1);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/ChainmailArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/ChainmailArmor.cs
@@ -43,14 +43,14 @@ public class ChainmailArmor : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 1);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 1);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/DragonScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/DragonScaleArmor.cs
@@ -51,29 +51,19 @@ public class DragonScaleArmor : Armor, ITreasure
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+3, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+3, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+3, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 3);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 3);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 3);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+3, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+3, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+3, ModifierType.Constant);
-	}
+
 		
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/DragonScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/DragonScaleArmor.cs
@@ -52,15 +52,15 @@ public class DragonScaleArmor : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 3);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 3);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 3);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 3);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 3);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 3);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/DragonScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/DragonScaleArmor.cs
@@ -52,9 +52,9 @@ public class DragonScaleArmor : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 3);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 3);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/DrakeScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/DrakeScaleArmor.cs
@@ -51,29 +51,19 @@ public class DrakeScaleArmor : Armor, ITreasure
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+4, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+4, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+4, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 4);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 4);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 4);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+4, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+4, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+4, ModifierType.Constant);
-	}
+
 		
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/DrakeScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/DrakeScaleArmor.cs
@@ -52,15 +52,15 @@ public class DrakeScaleArmor : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 4);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 4);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 4);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 4);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 4);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 4);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/DrakeScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/DrakeScaleArmor.cs
@@ -52,9 +52,9 @@ public class DrakeScaleArmor : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 4);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 4);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/IceDragonScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/IceDragonScaleArmor.cs
@@ -56,9 +56,9 @@ public class IceDragonScaleArmor : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 5);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 5);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/IceDragonScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/IceDragonScaleArmor.cs
@@ -56,15 +56,15 @@ public class IceDragonScaleArmor : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 5);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 5);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 5);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 5);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 5);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 5);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/IceDragonScaleArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/IceDragonScaleArmor.cs
@@ -55,30 +55,18 @@ public class IceDragonScaleArmor : Armor, ITreasure
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+5, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+5, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+5, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 5);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 5);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 5);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+5, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+5, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+5, ModifierType.Constant);
-	}
-		
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)
 	{

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
@@ -38,9 +38,9 @@ public class LeatherArmor : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 1);
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
@@ -38,13 +38,13 @@ public class LeatherArmor : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 1);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 1);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LeatherArmor.cs
@@ -37,25 +37,17 @@ public class LeatherArmor : Armor
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+1, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 1);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+1, ModifierType.Constant);
-	}
+
 		
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
@@ -48,29 +48,19 @@ public class LizardScales : Armor
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+2, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 2);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+2, ModifierType.Constant);
-	}
+
 
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
@@ -49,15 +49,15 @@ public class LizardScales : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 2);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 2);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 2);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/LizardScales.cs
@@ -49,9 +49,9 @@ public class LizardScales : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 2);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/PlatemailArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/PlatemailArmor.cs
@@ -46,9 +46,9 @@ public class PlatemailArmor : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 2);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/PlatemailArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/PlatemailArmor.cs
@@ -45,29 +45,19 @@ public class PlatemailArmor : Armor
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+1, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 1);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+1, ModifierType.Constant);
-	}
+
 
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/PlatemailArmor.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/PlatemailArmor.cs
@@ -46,15 +46,15 @@ public class PlatemailArmor : Armor
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 1);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 2);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 1);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
@@ -49,9 +49,9 @@ public class SalamanderScales : Armor, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 2);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
@@ -49,15 +49,15 @@ public class SalamanderScales : Armor, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 2);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 2);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 2);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/SalamanderScales.cs
@@ -48,29 +48,19 @@ public class SalamanderScales : Armor, ITreasure
 	{
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+2, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 2);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+2, ModifierType.Constant);
-	}
+
 	
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/TrollVest.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/TrollVest.cs
@@ -45,29 +45,19 @@ public class TrollVest : Armor, ITreasure
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Add(+2, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
+		bonuses.Add(EntityStat.ProjectileDamageMitigation, 2);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+2, ModifierType.Constant);
-		entity.Stats[EntityStat.ProjectileDamageMitigation].Remove(+2, ModifierType.Constant);
-	}
+
 
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/TrollVest.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/TrollVest.cs
@@ -46,9 +46,9 @@ public class TrollVest : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 2);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/TrollVest.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/TrollVest.cs
@@ -46,15 +46,15 @@ public class TrollVest : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 2);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 2);
-		bonuses.Add(EntityStat.ProjectileDamageMitigation, 2);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 2);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 2);
+		modifiers.Add(EntityStat.ProjectileDamageMitigation, 2);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/WyvernScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/WyvernScales.cs
@@ -43,14 +43,14 @@ public class WyvernScales : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.MeleeDamageMitigation, 1);
-		bonuses.Add(EntityStat.RangedDamageMitigation, 1);
+		modifiers.Add(EntityStat.MeleeDamageMitigation, 1);
+		modifiers.Add(EntityStat.RangedDamageMitigation, 1);
 
-		return bonuses;
+		return modifiers;
 	}
 
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/WyvernScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/WyvernScales.cs
@@ -42,27 +42,18 @@ public class WyvernScales : Armor, ITreasure
 	{
 	}
 	
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		entity.Stats[EntityStat.MeleeDamageMitigation].Add(+1, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Add(+1, ModifierType.Constant);
+		bonuses.Add(EntityStat.MeleeDamageMitigation, 1);
+		bonuses.Add(EntityStat.RangedDamageMitigation, 1);
+
+		return bonuses;
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-        
-		entity.Stats[EntityStat.MeleeDamageMitigation].Remove(+1, ModifierType.Constant);
-		entity.Stats[EntityStat.RangedDamageMitigation].Remove(+1, ModifierType.Constant);
-	}
+
 
 	/// <inheritdoc />
 	public override void GetDescription(List<LocalizationEntry> entries)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Armors/WyvernScales.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Armors/WyvernScales.cs
@@ -43,9 +43,9 @@ public class WyvernScales : Armor, ITreasure
 	}
 	
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.MeleeDamageMitigation, 1);
 		modifiers.Add(EntityStat.RangedDamageMitigation, 1);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
@@ -70,19 +70,19 @@ public class PowerBracelet : Bracelet, ITreasure
 	}
 		
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		if (CanApplyPassiveBonuses(wearer))
+		if (CanApplyStatModifiers(wearer))
 		{
 			var magicDamageDealtIncrease = GetMagicDamageDealtIncrease();
 
 			if (magicDamageDealtIncrease > 0)
-				bonuses.Add(EntityStat.MagicDamageDealtIncrease, magicDamageDealtIncrease);
+				modifiers.Add(EntityStat.MagicDamageDealtIncrease, magicDamageDealtIncrease);
 		}
 
-		return bonuses;
+		return modifiers;
 	}
 	
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
@@ -69,36 +69,20 @@ public class PowerBracelet : Bracelet, ITreasure
 		return bonus;
 	}
 		
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		if (CanUse(entity))
+		if (CanApplyPassiveBonuses(wearer))
 		{
 			var magicDamageDealtIncrease = GetMagicDamageDealtIncrease();
 
 			if (magicDamageDealtIncrease > 0)
-				entity.Stats[EntityStat.MagicDamageDealtIncrease].Add(+magicDamageDealtIncrease, ModifierType.Constant);
+				bonuses.Add(EntityStat.MagicDamageDealtIncrease, magicDamageDealtIncrease);
 		}
-	}
-		
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
 
-		if (CanUse(entity))
-		{
-			var magicDamageDealtIncrease = GetMagicDamageDealtIncrease();
-
-			if (magicDamageDealtIncrease > 0)
-				entity.Stats[EntityStat.MagicDamageDealtIncrease].Remove(+magicDamageDealtIncrease, ModifierType.Constant);
-		}
+		return bonuses;
 	}
 	
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
@@ -41,12 +41,17 @@ public class PowerBracelet : Bracelet, ITreasure
 		entries.Add(new LocalizationEntry(6200000, 6200377)); /* [You are looking at] [a golden bracelet embued with sapphires.] */
 	}
 
-	public override bool CanUse(MobileEntity entity)
+	public override ItemUseResult ValidateUse(MobileEntity entity)
 	{
+		var result = base.ValidateUse(entity);
+
+		if (!result.IsAllowed)
+			return result;
+
 		if (entity is PlayerEntity player)
-			return player.Profession.RestrictSpellcast; /* Thief, Thaum, Wizard. */
+			return player.Profession.RestrictSpellcast ? ItemUseResult.Allowed : ItemUseResult.Denied(); /* Thief, Thaum, Wizard. */
 			
-		return false;
+		return ItemUseResult.Denied();
 	}
 		
 	private int GetMagicDamageDealtIncrease()

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/PowerBracelet.cs
@@ -70,9 +70,9 @@ public class PowerBracelet : Bracelet, ITreasure
 	}
 		
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		if (CanApplyStatModifiers(wearer))
 		{

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Shield/ShieldBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Shield/ShieldBracelet.cs
@@ -52,13 +52,13 @@ public class ShieldBracelet : Bracelet, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.Barrier, Shield);
+		modifiers.Add(EntityStat.Barrier, Shield);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	/// <summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Shield/ShieldBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Shield/ShieldBracelet.cs
@@ -52,9 +52,9 @@ public class ShieldBracelet : Bracelet, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.Barrier, Shield);
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Shield/ShieldBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Shield/ShieldBracelet.cs
@@ -51,6 +51,16 @@ public class ShieldBracelet : Bracelet, ITreasure
 			entries.Add(new LocalizationEntry(6250127)); /* The bracelet contains a medium spell of Shield. */
 	}
 
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	{
+		var bonuses = base.CreatePassiveBonuses(wearer);
+
+		bonuses.Add(EntityStat.Barrier, Shield);
+
+		return bonuses;
+	}
+
 	/// <summary>
 	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
 	/// </summary>
@@ -72,8 +82,6 @@ public class ShieldBracelet : Bracelet, ITreasure
 		{
 			status.AddSource(new ItemSource(this));
 		}
-		
-		entity.Stats[EntityStat.Barrier].Add(+Shield, ModifierType.Constant);
 	}
 
 	/// <summary>
@@ -85,8 +93,6 @@ public class ShieldBracelet : Bracelet, ITreasure
 
 		if (entity.GetStatus(typeof(ShieldStatus), out var status))
 			status.RemoveSource(this);
-		
-		entity.Stats[EntityStat.Barrier].Remove(+Shield, ModifierType.Constant);
 	}
 	
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Strength/StrengthBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Strength/StrengthBracelet.cs
@@ -51,6 +51,16 @@ public class StrengthBracelet : Bracelet, ITreasure
 			entries.Add(new LocalizationEntry(6250058)); /* The bracelet contains a medium spell of Strength. */
 	}
 
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	{
+		var bonuses = base.CreatePassiveBonuses(wearer);
+
+		bonuses.Add(EntityStat.Strength, StrengthBonus);
+
+		return bonuses;
+	}
+
 	/// <summary>
 	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
 	/// </summary>
@@ -72,8 +82,6 @@ public class StrengthBracelet : Bracelet, ITreasure
 		{
 			status.AddSource(new ItemSource(this));
 		}
-			
-		entity.Stats[EntityStat.Strength].Add(+StrengthBonus, ModifierType.Constant);
 	}
 
 	/// <summary>
@@ -83,8 +91,6 @@ public class StrengthBracelet : Bracelet, ITreasure
 	{
 		base.OnInactivateBonus(entity);
 
-		entity.Stats[EntityStat.Strength].Remove(+StrengthBonus, ModifierType.Constant);
-			
 		if (entity.GetStatus(typeof(StrengthSpellStatus), out var status))
 			status.RemoveSource(this);
 	}

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Strength/StrengthBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Strength/StrengthBracelet.cs
@@ -52,13 +52,13 @@ public class StrengthBracelet : Bracelet, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.Strength, StrengthBonus);
+		modifiers.Add(EntityStat.Strength, StrengthBonus);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	/// <summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Strength/StrengthBracelet.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Bracelets/Strength/StrengthBracelet.cs
@@ -52,9 +52,9 @@ public class StrengthBracelet : Bracelet, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.Strength, StrengthBonus);
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
@@ -17,9 +17,6 @@ public abstract class Equipment : ItemEntity
 
 	[CommandProperty(AccessLevel.GameMaster)]
 	public virtual int ProtectionFromDaze => 0;
-
-	[CommandProperty(AccessLevel.GameMaster)]
-	public virtual int ProtectionFromConcussion => 0;
 		
 	[CommandProperty(AccessLevel.GameMaster)]
 	public virtual int ProtectionFromFire => 0;

--- a/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
@@ -17,6 +17,9 @@ public abstract class Equipment : ItemEntity
 
 	[CommandProperty(AccessLevel.GameMaster)]
 	public virtual int ProtectionFromDaze => 0;
+
+	[CommandProperty(AccessLevel.GameMaster)]
+	public virtual int ProtectionFromConcussion => 0;
 		
 	[CommandProperty(AccessLevel.GameMaster)]
 	public virtual int ProtectionFromFire => 0;
@@ -105,62 +108,33 @@ public abstract class Equipment : ItemEntity
 		}
 	}
 
-	/// <summary>
-	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnActivateBonus(MobileEntity entity)
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
 	{
-		base.OnActivateBonus(entity);
+		var bonuses = base.CreatePassiveBonuses(wearer);
 
-		if (CanUse(entity))
+		if (CanApplyPassiveBonuses(wearer))
 		{
 			if (ProtectionFromFire > 0)
-				entity.Stats[EntityStat.FireProtection].Add(+ProtectionFromFire, ModifierType.Constant);
+				bonuses.Add(EntityStat.FireProtection, ProtectionFromFire);
 				
 			if (ProtectionFromIce > 0)
-				entity.Stats[EntityStat.IceProtection].Add(+ProtectionFromIce, ModifierType.Constant);
+				bonuses.Add(EntityStat.IceProtection, ProtectionFromIce);
 				
 			if (ProtectionFromDaze > 0)
-				entity.Stats[EntityStat.DazeProtection].Add(+ProtectionFromDaze, ModifierType.Constant);
+				bonuses.Add(EntityStat.DazeProtection, ProtectionFromDaze);
 
 			if (HealthRegeneration > 0)
-				entity.Stats[EntityStat.HealthRegenerationRate].Add(+HealthRegeneration, ModifierType.Constant);
+				bonuses.Add(EntityStat.HealthRegenerationRate, HealthRegeneration);
 
 			if (StaminaRegeneration > 0)
-				entity.Stats[EntityStat.StaminaRegenerationRate].Add(+StaminaRegeneration, ModifierType.Constant);
+				bonuses.Add(EntityStat.StaminaRegenerationRate, StaminaRegeneration);
 
 			if (ManaRegeneration > 0)
-				entity.Stats[EntityStat.ManaRegenerationRate].Add(+ManaRegeneration, ModifierType.Constant);
+				bonuses.Add(EntityStat.ManaRegenerationRate, ManaRegeneration);
 		}
-	}
-		
-	/// <summary>
-	/// Overridable. Called when effects from this item should be removed from <see cref="MobileEntity"/>.
-	/// </summary>
-	protected override void OnInactivateBonus(MobileEntity entity)
-	{
-		base.OnInactivateBonus(entity);
-		
-		if (CanUse(entity))
-		{
-			if (ProtectionFromFire > 0)
-				entity.Stats[EntityStat.FireProtection].Remove(+ProtectionFromFire, ModifierType.Constant);
-				
-			if (ProtectionFromIce > 0)
-				entity.Stats[EntityStat.IceProtection].Remove(+ProtectionFromIce, ModifierType.Constant);
-				
-			if (ProtectionFromDaze > 0)
-				entity.Stats[EntityStat.DazeProtection].Remove(+ProtectionFromDaze, ModifierType.Constant);
 
-			if (HealthRegeneration > 0)
-				entity.Stats[EntityStat.HealthRegenerationRate].Remove(+HealthRegeneration, ModifierType.Constant);
-
-			if (StaminaRegeneration > 0)
-				entity.Stats[EntityStat.StaminaRegenerationRate].Remove(+StaminaRegeneration, ModifierType.Constant);
-				
-			if (ManaRegeneration > 0)
-				entity.Stats[EntityStat.ManaRegenerationRate].Remove(+ManaRegeneration, ModifierType.Constant);
-		}
+		return bonuses;
 	}
 	
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
@@ -106,9 +106,9 @@ public abstract class Equipment : ItemEntity
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		if (CanApplyStatModifiers(wearer))
 		{

--- a/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Equipment.cs
@@ -109,32 +109,32 @@ public abstract class Equipment : ItemEntity
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		if (CanApplyPassiveBonuses(wearer))
+		if (CanApplyStatModifiers(wearer))
 		{
 			if (ProtectionFromFire > 0)
-				bonuses.Add(EntityStat.FireProtection, ProtectionFromFire);
+				modifiers.Add(EntityStat.FireProtection, ProtectionFromFire);
 				
 			if (ProtectionFromIce > 0)
-				bonuses.Add(EntityStat.IceProtection, ProtectionFromIce);
+				modifiers.Add(EntityStat.IceProtection, ProtectionFromIce);
 				
 			if (ProtectionFromDaze > 0)
-				bonuses.Add(EntityStat.DazeProtection, ProtectionFromDaze);
+				modifiers.Add(EntityStat.DazeProtection, ProtectionFromDaze);
 
 			if (HealthRegeneration > 0)
-				bonuses.Add(EntityStat.HealthRegenerationRate, HealthRegeneration);
+				modifiers.Add(EntityStat.HealthRegenerationRate, HealthRegeneration);
 
 			if (StaminaRegeneration > 0)
-				bonuses.Add(EntityStat.StaminaRegenerationRate, StaminaRegeneration);
+				modifiers.Add(EntityStat.StaminaRegenerationRate, StaminaRegeneration);
 
 			if (ManaRegeneration > 0)
-				bonuses.Add(EntityStat.ManaRegenerationRate, ManaRegeneration);
+				modifiers.Add(EntityStat.ManaRegenerationRate, ManaRegeneration);
 		}
 
-		return bonuses;
+		return modifiers;
 	}
 	
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/Gauntlets.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Gauntlets/Gauntlets.cs
@@ -144,10 +144,12 @@ public abstract class Gauntlets : Equipment, IWeapon, IArmored
 	/// <summary>
 	/// Overridable. Determines whether the specified instance can use this item.
 	/// </summary>
-	public override bool CanUse(MobileEntity entity)
+	public override ItemUseResult ValidateUse(MobileEntity entity)
 	{
-		if (!base.CanUse(entity))
-			return false;
+		var result = base.ValidateUse(entity);
+
+		if (!result.IsAllowed)
+			return result;
 
 		/* We prevent the weapon from being beneficial if alignment values do not match. */
 		var flags = Flags;
@@ -156,9 +158,9 @@ public abstract class Gauntlets : Equipment, IWeapon, IArmored
 		if ((flags.HasFlag(WeaponFlags.Lawful) && alignment != Alignment.Lawful) ||
 		    (flags.HasFlag(WeaponFlags.Neutral) && alignment != Alignment.Neutral) ||
 		    (flags.HasFlag(WeaponFlags.Chaotic) && alignment != Alignment.Chaotic && alignment != Alignment.Evil))
-			return false;
+			return ItemUseResult.Denied();
 			
-		return true;
+		return ItemUseResult.Allowed;
 	}
 	
 	/// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/CrashingWavesRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/CrashingWavesRing.cs
@@ -119,7 +119,7 @@ public class WaterWalkingStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, "Water Walking"); /* The spell of [Water Walking] has worn off. */

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Shield/ShieldRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Shield/ShieldRing.cs
@@ -55,6 +55,16 @@ public class ShieldRing : Ring, ITreasure
 			entries.Add(new LocalizationEntry(6250128)); /* The ring contains a medium spell of Shield. */
 	}
 
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	{
+		var bonuses = base.CreatePassiveBonuses(wearer);
+
+		bonuses.Add(EntityStat.Barrier, Shield);
+
+		return bonuses;
+	}
+
 	/// <summary>
 	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
 	/// </summary>
@@ -76,8 +86,6 @@ public class ShieldRing : Ring, ITreasure
 		{
 			status.AddSource(new ItemSource(this));
 		}
-
-		entity.Stats[EntityStat.Barrier].Add(+Shield, ModifierType.Constant);
 	}
 
 	/// <summary>
@@ -89,8 +97,6 @@ public class ShieldRing : Ring, ITreasure
 
 		if (entity.GetStatus(typeof(ShieldStatus), out var status))
 			status.RemoveSource(this);
-		
-		entity.Stats[EntityStat.Barrier].Remove(+Shield, ModifierType.Constant);
 	}
 	
 	/// <summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Shield/ShieldRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Shield/ShieldRing.cs
@@ -56,13 +56,13 @@ public class ShieldRing : Ring, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.Barrier, Shield);
+		modifiers.Add(EntityStat.Barrier, Shield);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	/// <summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Shield/ShieldRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Shield/ShieldRing.cs
@@ -56,9 +56,9 @@ public class ShieldRing : Ring, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.Barrier, Shield);
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/StrengthRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/StrengthRing.cs
@@ -53,6 +53,16 @@ public class StrengthRing : Ring, ITreasure
 			entries.Add(new LocalizationEntry(6250034)); /* The ring contains a medium spell of Strength. */
 	}
 
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	{
+		var bonuses = base.CreatePassiveBonuses(wearer);
+
+		bonuses.Add(EntityStat.Strength, StrengthBonus);
+
+		return bonuses;
+	}
+
 	/// <summary>
 	/// Overridable. Called when effects from this item should be applied to <see cref="MobileEntity"/>.
 	/// </summary>
@@ -74,8 +84,6 @@ public class StrengthRing : Ring, ITreasure
 		{
 			status.AddSource(new ItemSource(this));
 		}
-
-		entity.Stats[EntityStat.Strength].Add(+StrengthBonus, ModifierType.Constant);
 	}
 	
 	/// <summary>
@@ -84,8 +92,6 @@ public class StrengthRing : Ring, ITreasure
 	protected override void OnInactivateBonus(MobileEntity entity)
 	{
 		base.OnInactivateBonus(entity);
-
-		entity.Stats[EntityStat.Strength].Remove(+StrengthBonus, ModifierType.Constant);
 
 		if (entity.GetStatus(typeof(StrengthSpellStatus), out var status))
 			status.RemoveSource(this);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/StrengthRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/StrengthRing.cs
@@ -54,13 +54,13 @@ public class StrengthRing : Ring, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.Strength, StrengthBonus);
+		modifiers.Add(EntityStat.Strength, StrengthBonus);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	/// <summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/StrengthRing.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Rings/Strength/StrengthRing.cs
@@ -54,9 +54,9 @@ public class StrengthRing : Ring, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.Strength, StrengthBonus);
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/SwiftShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/SwiftShield.cs
@@ -56,13 +56,13 @@ public class SwiftShield : Shield, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
 	{
-		var bonuses = base.CreatePassiveBonuses(wearer);
+		var modifiers = base.ApplyStatModifiers(wearer);
 
-		bonuses.Add(EntityStat.Barrier, Shield);
+		modifiers.Add(EntityStat.Barrier, Shield);
 
-		return bonuses;
+		return modifiers;
 	}
 
 	public override void OnWield(MobileEntity entity)

--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/SwiftShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/SwiftShield.cs
@@ -55,6 +55,16 @@ public class SwiftShield : Shield, ITreasure
 	{
 	}
 
+	/// <inheritdoc />
+	protected override PassiveBonusSet CreatePassiveBonuses(MobileEntity wearer)
+	{
+		var bonuses = base.CreatePassiveBonuses(wearer);
+
+		bonuses.Add(EntityStat.Barrier, Shield);
+
+		return bonuses;
+	}
+
 	public override void OnWield(MobileEntity entity)
 	{
 		base.OnWield(entity);
@@ -73,8 +83,6 @@ public class SwiftShield : Shield, ITreasure
 		{
 			status.AddSource(new ItemSource(this));
 		}
-		
-		entity.Stats[EntityStat.Barrier].Add(+Shield, ModifierType.Constant);
 	}
 
 	public override void OnUnwield(MobileEntity entity)
@@ -83,7 +91,5 @@ public class SwiftShield : Shield, ITreasure
 
 		if (entity.GetStatus(typeof(ShieldStatus), out var status))
 			status.RemoveSource(this);
-		
-		entity.Stats[EntityStat.Barrier].Remove(+Shield, ModifierType.Constant);
 	}
 }

--- a/Source/Kesmai.Server/Game/Items/Equipment/Shields/SwiftShield.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Shields/SwiftShield.cs
@@ -56,9 +56,9 @@ public class SwiftShield : Shield, ITreasure
 	}
 
 	/// <inheritdoc />
-	protected override StatModifierSet ApplyStatModifiers(MobileEntity wearer)
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
 	{
-		var modifiers = base.ApplyStatModifiers(wearer);
+		var modifiers = base.GetStatModifiers(wearer);
 
 		modifiers.Add(EntityStat.Barrier, Shield);
 

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/UnholyScepter.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Maces/UnholyScepter.cs
@@ -56,27 +56,18 @@ public class UnholyScepter : Mace
     }
 
     /// <inheritdoc />
-    public override bool CanUse(MobileEntity entity)
+    public override ItemUseResult ValidateUse(MobileEntity entity)
     {
-        var isUsable = true;
-            
-        if (entity is PlayerEntity player)
-        {
-            if (player.Profession == Profession.Wizard || player.Profession == Profession.Thaumaturge)
-            {
-                isUsable = true;
-            }
-            else
-            {
-                isUsable = false;
-            }
-        }
-        else
-        {
-            isUsable = false;   
-        }
-            
-        return isUsable;        
+        var result = base.ValidateUse(entity);
+
+        if (!result.IsAllowed)
+            return result;
+
+        if (entity is PlayerEntity player &&
+            (player.Profession == Profession.Wizard || player.Profession == Profession.Thaumaturge))
+            return ItemUseResult.Allowed;
+
+        return ItemUseResult.Denied();
     }
 
     /// <inheritdoc />

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
@@ -215,32 +215,10 @@ public abstract class Weapon : ItemEntity, IWeapon, IArmored, IWieldable
 
 	public virtual void OnWield(MobileEntity entity)
 	{
-		if (CanUse(entity))
-		{
-			if (HealthRegeneration > 0)
-				entity.Stats[EntityStat.HealthRegenerationRate].Add(+HealthRegeneration, ModifierType.Constant);
-
-			if (StaminaRegeneration > 0)
-				entity.Stats[EntityStat.StaminaRegenerationRate].Add(+StaminaRegeneration, ModifierType.Constant);
-
-			if (ManaRegeneration > 0)
-				entity.Stats[EntityStat.ManaRegenerationRate].Add(+ManaRegeneration, ModifierType.Constant);
-		}
 	}
 
 	public virtual void OnUnwield(MobileEntity entity)
 	{
-		if (CanUse(entity))
-		{
-			if (HealthRegeneration > 0)
-				entity.Stats[EntityStat.HealthRegenerationRate].Remove(+HealthRegeneration, ModifierType.Constant);
-
-			if (StaminaRegeneration > 0)
-				entity.Stats[EntityStat.StaminaRegenerationRate].Remove(+StaminaRegeneration, ModifierType.Constant);
-
-			if (ManaRegeneration > 0)
-				entity.Stats[EntityStat.ManaRegenerationRate].Remove(+ManaRegeneration, ModifierType.Constant);
-		}
 	}
 
 	/// <inheritdoc />
@@ -328,7 +306,13 @@ public abstract class Weapon : ItemEntity, IWeapon, IArmored, IWieldable
 	/// </summary>
 	public override bool CanUse(MobileEntity entity)
 	{
-		if (!base.CanUse(entity))
+		return CanApplyPassiveBonuses(entity);
+	}
+
+	/// <inheritdoc />
+	protected override bool CanApplyPassiveBonuses(MobileEntity entity)
+	{
+		if (!MeetsBaseUseRequirements(entity))
 			return false;
 
 		/* I thought I recalled information about being unable to swing two handed weapons with left hand. */

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
@@ -222,6 +222,26 @@ public abstract class Weapon : ItemEntity, IWeapon, IArmored, IWieldable
 	}
 
 	/// <inheritdoc />
+	protected override StatModifierSet GetStatModifiers(MobileEntity wearer)
+	{
+		var modifiers = base.GetStatModifiers(wearer);
+
+		if (CanApplyStatModifiers(wearer))
+		{
+			if (HealthRegeneration > 0)
+				modifiers.Add(EntityStat.HealthRegenerationRate, HealthRegeneration);
+
+			if (StaminaRegeneration > 0)
+				modifiers.Add(EntityStat.StaminaRegenerationRate, StaminaRegeneration);
+
+			if (ManaRegeneration > 0)
+				modifiers.Add(EntityStat.ManaRegenerationRate, ManaRegeneration);
+		}
+
+		return modifiers;
+	}
+
+	/// <inheritdoc />
 	public override bool BreaksHide(MobileEntity entity)
 	{
 		return Flags.HasFlag(WeaponFlags.TwoHanded);

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
@@ -324,16 +324,12 @@ public abstract class Weapon : ItemEntity, IWeapon, IArmored, IWieldable
 	/// <summary>
 	/// Overridable. Determines whether the specified instance can use this item.
 	/// </summary>
-	public override bool CanUse(MobileEntity entity)
+	public override ItemUseResult ValidateUse(MobileEntity entity)
 	{
-		return CanApplyStatModifiers(entity);
-	}
+		var result = base.ValidateUse(entity);
 
-	/// <inheritdoc />
-	protected override bool CanApplyStatModifiers(MobileEntity entity)
-	{
-		if (!MeetsBaseUseRequirements(entity))
-			return false;
+		if (!result.IsAllowed)
+			return result;
 
 		/* I thought I recalled information about being unable to swing two handed weapons with left hand. */
 /*			if (entity.LeftHand != null && flags.HasFlag(WeaponFlags.TwoHanded))
@@ -346,9 +342,9 @@ public abstract class Weapon : ItemEntity, IWeapon, IArmored, IWieldable
 		if ((flags.HasFlag(WeaponFlags.Lawful) && alignment != Alignment.Lawful) ||
 		    (flags.HasFlag(WeaponFlags.Neutral) && alignment != Alignment.Neutral) ||
 		    (flags.HasFlag(WeaponFlags.Chaotic) && alignment != Alignment.Chaotic && alignment != Alignment.Evil))
-			return false;
+			return ItemUseResult.Denied();
 
-		return true;
+		return ItemUseResult.Allowed;
 	}
 
 	/// <summary>

--- a/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
+++ b/Source/Kesmai.Server/Game/Items/Equipment/Weapons/Weapon.cs
@@ -306,11 +306,11 @@ public abstract class Weapon : ItemEntity, IWeapon, IArmored, IWieldable
 	/// </summary>
 	public override bool CanUse(MobileEntity entity)
 	{
-		return CanApplyPassiveBonuses(entity);
+		return CanApplyStatModifiers(entity);
 	}
 
 	/// <inheritdoc />
-	protected override bool CanApplyPassiveBonuses(MobileEntity entity)
+	protected override bool CanApplyStatModifiers(MobileEntity entity)
 	{
 		if (!MeetsBaseUseRequirements(entity))
 			return false;

--- a/Source/Kesmai.Server/Spells/Status/AdventurerStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/AdventurerStatus.cs
@@ -26,12 +26,12 @@ public class AdventurerStatus : SpellStatus
 	{
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		Refresh();
 	}
 		
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		if (_internalTimer != null && _internalTimer.Running)
 			_internalTimer.Stop();

--- a/Source/Kesmai.Server/Spells/Status/BlindFearProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BlindFearProtectionStatus.cs
@@ -24,7 +24,7 @@ public class BlindFearProtectionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 541); /* The spell of [Protection from Blind and Fear] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/BlindFearProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BlindFearProtectionStatus.cs
@@ -12,20 +12,12 @@ public class BlindFearProtectionStatus : SpellStatus
 	{
 	}
 
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-
-		_entity.Stats[EntityStat.BlindProtection].Add(+1, ModifierType.Constant);
-		_entity.Stats[EntityStat.FearProtection].Add(+1, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.BlindProtection].Remove(+1, ModifierType.Constant);
-		_entity.Stats[EntityStat.FearProtection].Remove(+1, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.BlindProtection, 1);
+		modifiers.Add(EntityStat.FearProtection, 1);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)

--- a/Source/Kesmai.Server/Spells/Status/BlindResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BlindResistanceStatus.cs
@@ -12,25 +12,18 @@ public class BlindResistanceStatus : SpellStatus
 	{
 	}
 		
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.BlindResistance].Add(+6, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.BlindResistance].Remove(+6, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.BlindResistance, 6);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 547); /* The spell of [Blind Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/BlindResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BlindResistanceStatus.cs
@@ -23,7 +23,7 @@ public class BlindResistanceStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 547); /* The spell of [Blind Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/BlindStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BlindStatus.cs
@@ -17,7 +17,7 @@ public class BlindStatus : SpellStatus
 		_rounds = rounds;
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 			
@@ -27,7 +27,7 @@ public class BlindStatus : SpellStatus
 			Refresh(_rounds);
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		_entity.Delta(MobileDelta.Visibility);
 

--- a/Source/Kesmai.Server/Spells/Status/BreatheWaterStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BreatheWaterStatus.cs
@@ -16,7 +16,7 @@ public class BreatheWaterStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 504); /* The spell of [Breathe Water] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/BreatheWaterStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/BreatheWaterStatus.cs
@@ -23,14 +23,14 @@ public class BreatheWaterStatus : SpellStatus
 		}
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 			
 		_entity.StopWaterTimer();
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		base.OnRemoved();
 			

--- a/Source/Kesmai.Server/Spells/Status/ClearcastStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/ClearcastStatus.cs
@@ -17,7 +17,7 @@ public class ClearcastStatus : SpellStatus
 		};
 	}
 	
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		Refresh();
 
@@ -28,7 +28,7 @@ public class ClearcastStatus : SpellStatus
 		}
 	}
 		
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		if (_internalTimer != null && _internalTimer.Running)
 			_internalTimer.Stop();

--- a/Source/Kesmai.Server/Spells/Status/DazeStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/DazeStatus.cs
@@ -22,7 +22,7 @@ public class DazeStatus : SpellStatus
 		_delay = delay;
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 
@@ -41,7 +41,7 @@ public class DazeStatus : SpellStatus
 		Announce();
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		// TODO: Should we still do this? Or is there a better mechanism.
 		// What if the player is dazed, but has a round lock from action?

--- a/Source/Kesmai.Server/Spells/Status/DeathResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/DeathResistanceStatus.cs
@@ -23,7 +23,7 @@ public class DeathResistanceStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 548); /* The spell of [Death Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/DeathResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/DeathResistanceStatus.cs
@@ -12,25 +12,18 @@ public class DeathResistanceStatus : SpellStatus
 	{
 	}
 		
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.DeathResistance].Add(+6, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.DeathResistance].Remove(+6, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.DeathResistance, 6);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 548); /* The spell of [Death Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/FearResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/FearResistanceStatus.cs
@@ -12,25 +12,18 @@ public class FearResistanceStatus : SpellStatus
 	{
 	}
 		
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.FearResistance].Add(+6, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.FearResistance].Remove(+6, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.FearResistance, 6);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 549); /* The spell of [Fear Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/FearResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/FearResistanceStatus.cs
@@ -23,7 +23,7 @@ public class FearResistanceStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 549); /* The spell of [Fear Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/FearStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/FearStatus.cs
@@ -17,7 +17,7 @@ public class FearStatus : SpellStatus
 		_rounds = rounds;
 	}
 		
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 
@@ -27,7 +27,7 @@ public class FearStatus : SpellStatus
 		_internalTimer = Timer.DelayCall(TimeSpan.Zero, OnTick);
 	}
 		
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		if (_internalTimer != null && _internalTimer.Running)
 			_internalTimer.Stop();

--- a/Source/Kesmai.Server/Spells/Status/FeatherFallStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/FeatherFallStatus.cs
@@ -16,7 +16,7 @@ public class FeatherFallStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 514); /* The spell of [Feather Fall] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/FireProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/FireProtectionStatus.cs
@@ -12,25 +12,18 @@ public class FireProtectionStatus : SpellStatus
 	{
 	}
 
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.FireProtection].Add(+20, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.FireProtection].Remove(+20, ModifierType.Constant);
-			
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.FireProtection, 20);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 543); /* The spell of [Protection from Fire] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/FireProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/FireProtectionStatus.cs
@@ -23,7 +23,7 @@ public class FireProtectionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 543); /* The spell of [Protection from Fire] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/ForcefieldStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/ForcefieldStatus.cs
@@ -46,7 +46,7 @@ public class ForcefieldStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 611); /* The spell of [Forcefield] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/HideStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/HideStatus.cs
@@ -49,7 +49,7 @@ public class HideStatus : SpellStatus
 		OnInternalTick();
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 
@@ -59,7 +59,7 @@ public class HideStatus : SpellStatus
 		OnInternalTick();
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		base.OnRemoved();
 

--- a/Source/Kesmai.Server/Spells/Status/IceProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/IceProtectionStatus.cs
@@ -23,7 +23,7 @@ public class IceProtectionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 542); /* The spell of [Protection from Ice] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/IceProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/IceProtectionStatus.cs
@@ -12,25 +12,18 @@ public class IceProtectionStatus : SpellStatus
 	{
 	}
 		
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.IceProtection].Add(+20, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.IceProtection].Remove(+20, ModifierType.Constant);
-			
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.IceProtection, 20);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 542); /* The spell of [Protection from Ice] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/LightningResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/LightningResistanceStatus.cs
@@ -12,25 +12,18 @@ public class LightningResistanceStatus : SpellStatus
 	{
 	}
 		
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.LightningResistance].Add(+6, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.LightningResistance].Remove(+6, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.LightningResistance, 6);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 550); /* The spell of [Lightning Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/LightningResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/LightningResistanceStatus.cs
@@ -23,7 +23,7 @@ public class LightningResistanceStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 550); /* The spell of [Lightning Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/NightVisionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/NightVisionStatus.cs
@@ -23,14 +23,14 @@ public class NightVisionStatus : SpellStatus
 		}
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 			
 		_entity.Delta(MobileDelta.Visibility);
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		_entity.Delta(MobileDelta.Visibility);
 			

--- a/Source/Kesmai.Server/Spells/Status/NightVisionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/NightVisionStatus.cs
@@ -16,7 +16,7 @@ public class NightVisionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 536); /* The spell of [Night Vision] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/PerceptionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/PerceptionStatus.cs
@@ -23,7 +23,7 @@ public class PerceptionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 595); /* The spell of [Perception] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/PoisonProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/PoisonProtectionStatus.cs
@@ -23,7 +23,7 @@ public class PoisonProtectionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 584); /* The spell of [Protection from Poison] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/PoisonProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/PoisonProtectionStatus.cs
@@ -12,18 +12,11 @@ public class PoisonProtectionStatus : SpellStatus
 	{
 	}
 
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-
-		_entity.Stats[EntityStat.PoisonProtection].Add(+1, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.PoisonProtection].Remove(+1, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.PoisonProtection, 1);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)

--- a/Source/Kesmai.Server/Spells/Status/PoisonStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/PoisonStatus.cs
@@ -65,7 +65,7 @@ public partial class PoisonStatus : SpellStatus
 			_entity.RemoveStatus(this);
 	}
 		
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		if (_internalTimer != null && _internalTimer.Running)
 			_internalTimer.Stop();

--- a/Source/Kesmai.Server/Spells/Status/RapidfireStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/RapidfireStatus.cs
@@ -19,7 +19,7 @@ public class RapidfireStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 598); /* The spell of [Speed] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/ShadowstepStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/ShadowstepStatus.cs
@@ -16,13 +16,13 @@ public class ShadowstepStatus : SpellStatus
 		_rounds = rounds;
 	}
 		
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		_internalTimer = Timer.DelayCall(_entity.Facet.TimeSpan.FromRounds(_rounds), 
 			OnTick);
 	}
 		
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		if (_internalTimer != null && _internalTimer.Running)
 			_internalTimer.Stop();

--- a/Source/Kesmai.Server/Spells/Status/ShieldStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/ShieldStatus.cs
@@ -21,7 +21,7 @@ public class ShieldStatus : SpellStatus
 	{
 		var modifiers = base.GetStatModifiers(target);
 
-		if (_spellSources.Count > 0)
+		if (Spells.Count > 0)
 			modifiers.Add(EntityStat.Barrier, 3);
 
 		return modifiers;
@@ -29,7 +29,7 @@ public class ShieldStatus : SpellStatus
 
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 552); /* The spell of [Shield] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/ShieldStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/ShieldStatus.cs
@@ -17,20 +17,20 @@ public class ShieldStatus : SpellStatus
 	{
 	}
 
-	protected override void OnSourceAdded(SpellStatusSource source)
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnSourceAdded(source);
+		var modifiers = base.GetStatModifiers(target);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 1)
-			_entity.Stats[EntityStat.Barrier].Add(+3, ModifierType.Constant);
+		if (_spellSources.Count > 0)
+			modifiers.Add(EntityStat.Barrier, 3);
+
+		return modifiers;
 	}
 
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
-			_entity.Stats[EntityStat.Barrier].Remove(+3, ModifierType.Constant);
-			
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 552); /* The spell of [Shield] has worn off. */
 		}

--- a/Source/Kesmai.Server/Spells/Status/SpeedStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/SpeedStatus.cs
@@ -16,7 +16,7 @@ public class SpeedStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && !_spellSources.Any())
+		if (source is SpellSource && !Spells.Any())
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 573); /* The spell of [Speed] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/StalkerInTheShadowsStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StalkerInTheShadowsStatus.cs
@@ -12,7 +12,7 @@ public class StalkerInTheShadowsStatus : SpellStatus
 	{
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		base.OnRemoved();
 			

--- a/Source/Kesmai.Server/Spells/Status/StrengthSpellStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StrengthSpellStatus.cs
@@ -18,7 +18,7 @@ public class StrengthSpellStatus : SpellStatus
 	{
 		var modifiers = base.GetStatModifiers(target);
 
-		if (_spellSources.Count > 0)
+		if (Spells.Count > 0)
 			modifiers.Add(EntityStat.Strength, 6);
 
 		return modifiers;
@@ -26,7 +26,7 @@ public class StrengthSpellStatus : SpellStatus
 
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 553); /* The spell of [Strength] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/StrengthSpellStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StrengthSpellStatus.cs
@@ -14,20 +14,20 @@ public class StrengthSpellStatus : SpellStatus
 	{
 	}
 
-	protected override void OnSourceAdded(SpellStatusSource source)
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnSourceAdded(source);
+		var modifiers = base.GetStatModifiers(target);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 1)
-			_entity.Stats[EntityStat.Strength].Add(+6, ModifierType.Constant);
+		if (_spellSources.Count > 0)
+			modifiers.Add(EntityStat.Strength, 6);
+
+		return modifiers;
 	}
 
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
-			_entity.Stats[EntityStat.Strength].Remove(+6, ModifierType.Constant);
-				
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 553); /* The spell of [Strength] has worn off. */
 		}

--- a/Source/Kesmai.Server/Spells/Status/StunDeathProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StunDeathProtectionStatus.cs
@@ -24,7 +24,7 @@ public class StunDeathProtectionStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 545); /* The spell of [Protection from Stun and Death] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/StunDeathProtectionStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StunDeathProtectionStatus.cs
@@ -12,27 +12,19 @@ public class StunDeathProtectionStatus : SpellStatus
 	{
 	}
 
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.StunProtection].Add(+1, ModifierType.Constant);
-		_entity.Stats[EntityStat.DeathProtection].Add(+1, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.StunProtection].Remove(+1, ModifierType.Constant);
-		_entity.Stats[EntityStat.DeathProtection].Remove(+1, ModifierType.Constant);
-			
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.StunProtection, 1);
+		modifiers.Add(EntityStat.DeathProtection, 1);
+		return modifiers;
 	}
 
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 545); /* The spell of [Protection from Stun and Death] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/StunResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StunResistanceStatus.cs
@@ -23,7 +23,7 @@ public class StunResistanceStatus : SpellStatus
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource && _spellSources.Count is 0)
+		if (source is SpellSource && Spells.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 551); /* The spell of [Stun Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/StunResistanceStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StunResistanceStatus.cs
@@ -12,25 +12,18 @@ public class StunResistanceStatus : SpellStatus
 	{
 	}
 		
-	public override void OnAcquire()
+	protected override StatModifierSet GetStatModifiers(MobileEntity target)
 	{
-		base.OnAcquire();
-			
-		_entity.Stats[EntityStat.StunResistance].Add(+6, ModifierType.Constant);
-	}
-
-	public override void OnRemoved()
-	{
-		_entity.Stats[EntityStat.StunResistance].Remove(+6, ModifierType.Constant);
-
-		base.OnRemoved();
+		var modifiers = base.GetStatModifiers(target);
+		modifiers.Add(EntityStat.StunResistance, 6);
+		return modifiers;
 	}
 		
 	protected override void OnSourceRemoved(SpellStatusSource source)
 	{
 		base.OnSourceRemoved(source);
 
-		if (source is SpellSource spellSource && _spellSources.Count is 0)
+		if (source is SpellSource && _spellSources.Count is 0)
 		{
 			if (_entity.Client != null)
 				_entity.SendLocalizedMessage(Color.Magenta, 6300270, 551); /* The spell of [Stun Resistance] has worn off. */

--- a/Source/Kesmai.Server/Spells/Status/StunStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/StunStatus.cs
@@ -22,7 +22,7 @@ public class StunStatus : SpellStatus
 		_delay = delay;
 	}
 
-	public override void OnAcquire()
+	protected override void OnAcquire()
 	{
 		base.OnAcquire();
 
@@ -41,7 +41,7 @@ public class StunStatus : SpellStatus
 		Announce();
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		// TODO: Should we still do this? Or is there a better mechanism.
 		// What if the player is stunned, but has a round lock from action?

--- a/Source/Kesmai.Server/Spells/Status/VigorStatus.cs
+++ b/Source/Kesmai.Server/Spells/Status/VigorStatus.cs
@@ -42,7 +42,7 @@ public class VigorStatus : SpellStatus
 		});
 	}
 
-	public override void OnRemoved()
+	protected override void OnRemoved()
 	{
 		if (_decayTimer != null)
 			_decayTimer.Stop();


### PR DESCRIPTION
## Summary

- Replace direct equipment bonus mutation with source-aware stat modifier snapshots.
- Add unified modifier lifecycle and side-effect-free item-use validation.
- Document the equipment stat modifier API and migration guidance.

## Why

Modifiers can be replaced and removed using the exact values registered by each source, preventing recalculation drift and keeping equipment and status behavior consistent.

## Validation

- Rebased on `master`.
- Working tree is clean and the branch matches its remote.
- Builds and tests were not run per repository instructions.